### PR TITLE
Add full OAuth2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ npm-debug.log*
 
 # TypeScript
 *.tsbuildinfo
+
+# Test
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,8 @@
         "@rsbuild/plugin-sass": "^1.1.0",
         "@rsbuild/plugin-styled-components": "^1.6.0",
         "@types/adm-zip": "^0.5.7",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.6",
         "@types/fs-extra": "^11.0.4",
         "@types/lodash": "^4.17.0",
         "@types/node": "^20.0.0",
@@ -110,16 +112,21 @@
         "@types/vscode": "^1.80.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
+        "@vitest/coverage-v8": "^4.1.2",
         "@vscode/test-electron": "^2.5.2",
         "autoprefixer": "^10.4.20",
+        "cors": "^2.8.6",
         "esbuild": "^0.20.0",
         "eslint": "^8.57.0",
+        "express": "^5.2.1",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.1",
         "ts-migrate": "^0.1.35",
-        "typescript": "^5.4.0"
+        "tsx": "^4.21.0",
+        "typescript": "^5.4.0",
+        "vitest": "^4.1.2"
       },
       "engines": {
         "vscode": "^1.80.0"
@@ -562,12 +569,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2011,9 +2018,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2021,6 +2028,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -2382,6 +2399,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
@@ -2399,6 +2433,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
@@ -2414,6 +2465,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -3477,6 +3545,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -4655,6 +4733,287 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rsbuild/core": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.2.tgz",
@@ -5000,6 +5359,13 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@swagger-api/apidom-ast": {
       "version": "1.2.2",
@@ -5811,6 +6177,38 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chai/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@types/codemirror": {
       "version": "0.0.90",
       "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.90.tgz",
@@ -5820,11 +6218,63 @@
         "@types/tern": "*"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -5857,6 +6307,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
@@ -5919,6 +6376,13 @@
         "types-ramda": "^0.30.1"
       }
     },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
@@ -5949,6 +6413,27 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/styled-components": {
@@ -6370,6 +6855,160 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
@@ -6411,6 +7050,20 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/acorn": {
@@ -6742,6 +7395,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -7040,6 +7712,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7318,6 +8032,16 @@
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
@@ -8050,6 +8774,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-hrtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
@@ -8075,6 +8823,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/copy-descriptor": {
@@ -8138,6 +8896,24 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -8606,6 +9382,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -8630,8 +9416,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -8855,6 +9641,13 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -8899,6 +9692,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/encoding-sniffer": {
@@ -8994,6 +9797,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -9317,6 +10127,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9325,6 +10145,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-stream": {
@@ -9475,6 +10305,70 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend-shallow": {
@@ -9818,6 +10712,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -10034,6 +10950,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -10089,6 +11015,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/from": {
@@ -10283,6 +11219,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-value": {
@@ -10812,6 +11761,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -10850,6 +11806,27 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -11120,6 +12097,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-accessor-descriptor": {
@@ -11468,6 +12455,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -11566,6 +12560,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jackspeak": {
@@ -12362,6 +13424,267 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -12730,6 +14053,28 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/make-cancellable-promise": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.3.2.tgz",
@@ -12888,11 +14233,34 @@
       "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "license": "MIT"
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-refs": {
       "version": "1.3.0",
@@ -13240,6 +14608,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -13595,6 +14973,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohm-js": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.6.0.tgz",
@@ -13602,6 +14991,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.1"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -14001,6 +15403,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -14088,6 +15500,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -14122,6 +15545,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -14386,9 +15816,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -14752,6 +16182,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -14975,6 +16419,49 @@
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -15783,6 +17270,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -15970,6 +17467,57 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -16485,6 +18033,33 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
@@ -16498,6 +18073,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -16547,6 +18142,13 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -16702,6 +18304,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -17094,6 +18703,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -17141,6 +18757,23 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -18010,6 +19643,23 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -18038,6 +19688,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tippy.js": {
@@ -18149,6 +19809,16 @@
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/toposort": {
       "version": "2.0.2",
@@ -18994,6 +20664,459 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
@@ -19064,6 +21187,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -19283,6 +21421,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unraw": {
@@ -19695,6 +21843,202 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -19822,6 +22166,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "Thunder Client"
   ],
   "activationEvents": [
-    "*"
+    "workspaceContains:**/bruno.json",
+    "workspaceContains:**/opencollection.yaml",
+    "workspaceContains:**/opencollection.yml"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -60,7 +62,8 @@
         {
           "id": "bruno.logsView",
           "name": "Logs",
-          "type": "webview"
+          "type": "webview",
+          "icon": "$(output)"
         }
       ],
       "bruno": [
@@ -68,7 +71,8 @@
           "type": "webview",
           "id": "bruno.sidebarView",
           "name": "Collections",
-          "contextualTitle": "Bruno Collections"
+          "contextualTitle": "Bruno Collections",
+          "icon": "$(folder-library)"
         }
       ],
       "explorer": [
@@ -397,6 +401,10 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "package": "npx @vscode/vsce package --no-dependencies",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:server": "npx tsx tests/e2e/server/index.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
@@ -411,6 +419,8 @@
     "@rsbuild/plugin-sass": "^1.1.0",
     "@rsbuild/plugin-styled-components": "^1.6.0",
     "@types/adm-zip": "^0.5.7",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.6",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.0",
     "@types/node": "^20.0.0",
@@ -421,16 +431,21 @@
     "@types/vscode": "^1.80.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "@vitest/coverage-v8": "^4.1.2",
     "@vscode/test-electron": "^2.5.2",
     "autoprefixer": "^10.4.20",
+    "cors": "^2.8.6",
     "esbuild": "^0.20.0",
     "eslint": "^8.57.0",
+    "express": "^5.2.1",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.1",
     "ts-migrate": "^0.1.35",
-    "typescript": "^5.4.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.2"
   },
   "dependencies": {
     "@faker-js/faker": "^9.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,4 +10,10 @@ export default defineConfig({
   use: {
     trace: 'on-first-retry',
   },
+  webServer: {
+    command: 'npx tsx tests/e2e/server/index.ts',
+    url: 'http://127.0.0.1:8081/ping',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000
+  }
 });

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,0 +1,80 @@
+/**
+ * Mock for the 'vscode' module used in unit tests.
+ * Stubs out VS Code APIs that extension code imports.
+ */
+import { vi } from 'vitest';
+
+export const Uri = {
+  parse: (value: string) => ({
+    scheme: 'https',
+    authority: '',
+    path: value,
+    query: '',
+    fragment: '',
+    fsPath: value,
+    with: () => Uri.parse(value),
+    toString: () => value
+  }),
+  file: (path: string) => ({
+    scheme: 'file',
+    authority: '',
+    path,
+    query: '',
+    fragment: '',
+    fsPath: path,
+    with: () => Uri.file(path),
+    toString: () => `file://${path}`
+  })
+};
+
+export const env = {
+  openExternal: vi.fn().mockResolvedValue(true),
+  uriScheme: 'vscode'
+};
+
+export const window = {
+  registerUriHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  showInformationMessage: vi.fn().mockResolvedValue(undefined),
+  showErrorMessage: vi.fn().mockResolvedValue(undefined),
+  showWarningMessage: vi.fn().mockResolvedValue(undefined),
+  createOutputChannel: vi.fn().mockReturnValue({
+    appendLine: vi.fn(),
+    append: vi.fn(),
+    clear: vi.fn(),
+    show: vi.fn(),
+    hide: vi.fn(),
+    dispose: vi.fn()
+  })
+};
+
+export const workspace = {
+  getConfiguration: vi.fn().mockReturnValue({
+    get: vi.fn(),
+    update: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockReturnValue(false),
+    inspect: vi.fn()
+  }),
+  workspaceFolders: [] as any[]
+};
+
+export const commands = {
+  registerCommand: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  executeCommand: vi.fn().mockResolvedValue(undefined)
+};
+
+export const ExtensionContext = {};
+
+export enum ConfigurationTarget {
+  Global = 1,
+  Workspace = 2,
+  WorkspaceFolder = 3
+}
+
+export default {
+  Uri,
+  env,
+  window,
+  workspace,
+  commands,
+  ConfigurationTarget
+};

--- a/src/bruno-types/app/collection-ext.ts
+++ b/src/bruno-types/app/collection-ext.ts
@@ -12,6 +12,16 @@ export interface RequestSent {
   [key: string]: unknown;
 }
 
+export interface OAuth2CredentialEntry {
+  collectionUid: UID;
+  folderUid?: UID | null;
+  itemUid?: UID | null;
+  url: string;
+  credentialsId: string;
+  credentials: Record<string, unknown>;
+  debugInfo?: { data: unknown[] };
+}
+
 export interface TimelineEntry {
   type: 'request' | 'response' | 'error';
   eventType?: string;
@@ -122,7 +132,7 @@ export interface AppCollection extends Omit<Collection, 'items'> {
   runnerResult?: RunnerResult;
   runnerTags?: string[];
   runnerTagsEnabled?: boolean;
-  oauth2Credentials?: Record<string, unknown>;
+  oauth2Credentials?: OAuth2CredentialEntry[];
   runnerConfig?: Record<string, unknown>;
   globalEnvironmentVariables?: Record<string, string>;
   promptVariables?: Record<string, string> | null;

--- a/src/bruno-types/app/index.ts
+++ b/src/bruno-types/app/index.ts
@@ -41,7 +41,8 @@ export type {
   OAuthState,
   CollectionDraft,
   EnvironmentsDraft,
-  SecurityConfig
+  SecurityConfig,
+  OAuth2CredentialEntry
 } from './collection-ext';
 
 export type {

--- a/src/bruno-types/common/auth.ts
+++ b/src/bruno-types/common/auth.ts
@@ -77,6 +77,7 @@ export interface OAuth2 {
   refreshTokenUrl?: string | null;
   autoRefreshToken?: boolean | null;
   autoFetchToken?: boolean | null;
+  tokenSource?: 'access_token' | 'id_token' | null;
   additionalParameters?: OAuthAdditionalParameters | null;
 }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -36,6 +36,7 @@ import { LogsViewProvider } from './views/LogsViewProvider';
 import logsStore from './store/logs';
 import { registerTreeCommands, registerMainCommands } from './commands';
 import { registerDirtyStateHandlers, registerSaveHandler } from './editors/dirty-state-manager';
+import { createOAuth2UriHandler } from './ipc/network/authorize-user-in-system-browser';
 
 let extensionActivated = false;
 
@@ -102,6 +103,9 @@ export function activate(context: vscode.ExtensionContext): void {
   cookiesStore.initializeCookies();
   setupMessageBroadcaster();
   registerIpcHandlers();
+
+  // Register OAuth2 URI handler for authorization code callbacks
+  context.subscriptions.push(vscode.window.registerUriHandler(createOAuth2UriHandler()));
 
   const brunoEditorProvider = new BrunoEditorProvider(context);
 

--- a/src/extension/ipc/network/authorize-user-in-system-browser.ts
+++ b/src/extension/ipc/network/authorize-user-in-system-browser.ts
@@ -1,57 +1,364 @@
 /**
- * OAuth2 authorization using system browser
- * Opens the authorization URL in the user's default browser
+ * OAuth2 authorization using system browser.
+ * Opens the authorization URL in the user's default browser and listens
+ * for the callback via VS Code's URI handler.
  *
- * In VS Code, we use vscode.env.openExternal instead of Electron's shell
+ * Supports both authorization code flow (code in query params)
+ * and implicit flow (token in URL fragment).
+ *
+ * For implicit flow, since URI handlers don't receive fragments,
+ * we use a local HTTP server to capture the redirect.
  */
 
 import * as vscode from 'vscode';
+import * as http from 'http';
+import type { OAuthAdditionalParameter } from '@bruno-types/common/auth';
 
-interface AuthorizationOptions {
-  authorizationUrl: string;
-  clientId: string;
-  redirectUri: string;
-  scope?: string;
-  state?: string;
-  codeChallenge?: string;
-  codeChallengeMethod?: string;
+const AUTHORIZATION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// --- Module-level state for browser auth tracking ---
+
+let pendingAuthResolve: ((value: AuthorizationResult) => void) | null = null;
+let pendingAuthReject: ((reason: Error) => void) | null = null;
+let authTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+let localServer: http.Server | null = null;
+
+export function isAuthorizationInProgress(): boolean {
+  return pendingAuthResolve !== null;
 }
 
-const authorizeUserInSystemBrowser = async (options: AuthorizationOptions): Promise<void> => {
-  const {
-    authorizationUrl,
-    clientId,
-    redirectUri,
-    scope,
-    state,
-    codeChallenge,
-    codeChallengeMethod
-  } = options;
+export function cancelAuthorization(): void {
+  cleanup();
+  if (pendingAuthReject) {
+    pendingAuthReject(new Error('Authorization was cancelled by user'));
+    pendingAuthResolve = null;
+    pendingAuthReject = null;
+  }
+}
+
+function cleanup(): void {
+  if (authTimeoutHandle) {
+    clearTimeout(authTimeoutHandle);
+    authTimeoutHandle = null;
+  }
+  if (localServer) {
+    localServer.close();
+    localServer = null;
+  }
+}
+
+// --- URI handler for authorization code callback ---
+
+export function createOAuth2UriHandler(): vscode.UriHandler {
+  return {
+    handleUri(uri: vscode.Uri): void {
+      if (!pendingAuthResolve) return;
+
+      const params = new URLSearchParams(uri.query);
+      const error = params.get('error');
+      if (error) {
+        const desc = params.get('error_description') || error;
+        cleanup();
+        pendingAuthReject?.(new Error(`OAuth2 authorization error: ${desc}`));
+        pendingAuthResolve = null;
+        pendingAuthReject = null;
+        return;
+      }
+
+      const code = params.get('code');
+      if (code) {
+        cleanup();
+        pendingAuthResolve({ authorizationCode: code });
+        pendingAuthResolve = null;
+        pendingAuthReject = null;
+        return;
+      }
+
+      // For implicit flow via URI handler (unlikely since fragments aren't forwarded)
+      const accessToken = params.get('access_token');
+      if (accessToken) {
+        cleanup();
+        pendingAuthResolve({
+          implicitTokens: {
+            access_token: accessToken,
+            token_type: params.get('token_type') || 'Bearer',
+            expires_in: params.get('expires_in') || undefined,
+            scope: params.get('scope') || undefined,
+            state: params.get('state') || undefined
+          }
+        });
+        pendingAuthResolve = null;
+        pendingAuthReject = null;
+      }
+    }
+  };
+}
+
+// --- Types ---
+
+export interface AuthorizationResult {
+  authorizationCode?: string;
+  implicitTokens?: {
+    access_token: string;
+    token_type: string;
+    expires_in?: string;
+    scope?: string;
+    state?: string;
+  };
+}
+
+interface AuthorizationCodeOptions {
+  authorizationUrl: string;
+  callbackUrl: string;
+  clientId: string;
+  scope?: string;
+  state?: string;
+  pkce?: boolean;
+  codeChallenge?: string;
+  additionalParameters?: OAuthAdditionalParameter[];
+}
+
+interface ImplicitFlowOptions {
+  authorizationUrl: string;
+  callbackUrl: string;
+  clientId: string;
+  scope?: string;
+  state?: string;
+  additionalParameters?: OAuthAdditionalParameter[];
+}
+
+// --- Authorization code flow ---
+
+export async function getOAuth2AuthorizationCode(options: AuthorizationCodeOptions): Promise<AuthorizationResult> {
+  if (isAuthorizationInProgress()) {
+    throw new Error('An OAuth2 authorization request is already in progress');
+  }
+
+  const { authorizationUrl, callbackUrl, clientId, scope, state, pkce, codeChallenge, additionalParameters } = options;
 
   const url = new URL(authorizationUrl);
-  url.searchParams.set('client_id', clientId);
-  url.searchParams.set('redirect_uri', redirectUri);
-  url.searchParams.set('response_type', 'code');
+  url.searchParams.append('response_type', 'code');
+  url.searchParams.append('client_id', clientId);
 
+  if (callbackUrl) {
+    url.searchParams.append('redirect_uri', callbackUrl);
+  }
   if (scope) {
-    url.searchParams.set('scope', scope);
+    url.searchParams.append('scope', scope);
   }
   if (state) {
-    url.searchParams.set('state', state);
+    url.searchParams.append('state', state);
   }
-  if (codeChallenge) {
-    url.searchParams.set('code_challenge', codeChallenge);
-  }
-  if (codeChallengeMethod) {
-    url.searchParams.set('code_challenge_method', codeChallengeMethod);
+  if (pkce && codeChallenge) {
+    url.searchParams.append('code_challenge', codeChallenge);
+    url.searchParams.append('code_challenge_method', 'S256');
   }
 
-  const opened = await vscode.env.openExternal(vscode.Uri.parse(url.toString()));
-
-  if (!opened) {
-    throw new Error('Failed to open authorization URL in system browser');
+  // Apply additional authorization parameters (queryparams only for auth URL)
+  if (additionalParameters?.length) {
+    additionalParameters.forEach((param) => {
+      if (param.enabled && param.name && param.sendIn === 'queryparams') {
+        url.searchParams.append(param.name, param.value || '');
+      }
+    });
   }
-};
 
-export default authorizeUserInSystemBrowser;
-export { authorizeUserInSystemBrowser, AuthorizationOptions };
+  return openBrowserAndWaitForCallback(url.toString());
+}
+
+// --- Implicit flow ---
+
+export async function getOAuth2ImplicitToken(options: ImplicitFlowOptions): Promise<AuthorizationResult> {
+  if (isAuthorizationInProgress()) {
+    throw new Error('An OAuth2 authorization request is already in progress');
+  }
+
+  const { authorizationUrl, callbackUrl, clientId, scope, state, additionalParameters } = options;
+
+  const url = new URL(authorizationUrl);
+  url.searchParams.append('response_type', 'token');
+  url.searchParams.append('client_id', clientId);
+
+  if (callbackUrl) {
+    url.searchParams.append('redirect_uri', callbackUrl);
+  }
+  if (scope) {
+    url.searchParams.append('scope', scope);
+  }
+  if (state) {
+    url.searchParams.append('state', state);
+  }
+
+  if (additionalParameters?.length) {
+    additionalParameters.forEach((param) => {
+      if (param.enabled && param.name && param.sendIn === 'queryparams') {
+        url.searchParams.append(param.name, param.value || '');
+      }
+    });
+  }
+
+  // Implicit flow tokens arrive in the URL fragment (#access_token=...).
+  // VS Code URI handlers don't receive fragments, so we use a local HTTP server
+  // that serves a page which extracts the fragment and sends it back.
+  return openBrowserWithLocalServer(url.toString());
+}
+
+// --- Browser + URI handler (for authorization code) ---
+
+async function openBrowserAndWaitForCallback(authorizeUrl: string): Promise<AuthorizationResult> {
+  return new Promise<AuthorizationResult>((resolve, reject) => {
+    pendingAuthResolve = resolve;
+    pendingAuthReject = reject;
+
+    authTimeoutHandle = setTimeout(() => {
+      cleanup();
+      pendingAuthResolve = null;
+      pendingAuthReject = null;
+      reject(new Error('OAuth2 authorization timed out after 5 minutes'));
+    }, AUTHORIZATION_TIMEOUT_MS);
+
+    vscode.env.openExternal(vscode.Uri.parse(authorizeUrl)).then((opened) => {
+      if (!opened) {
+        cleanup();
+        pendingAuthResolve = null;
+        pendingAuthReject = null;
+        reject(new Error('Failed to open authorization URL in system browser'));
+      }
+    });
+  });
+}
+
+// --- Local HTTP server (for implicit flow fragment capture) ---
+
+const CALLBACK_HTML = `
+<!DOCTYPE html>
+<html>
+<body>
+<p>Processing OAuth2 callback... You can close this tab.</p>
+<script>
+  // Extract token from URL fragment and send to local server
+  const hash = window.location.hash.substring(1);
+  if (hash) {
+    fetch('/callback?' + hash, { method: 'POST' })
+      .then(() => window.close())
+      .catch(() => document.body.innerHTML = '<p>Authorization complete. You can close this tab.</p>');
+  } else {
+    // Fallback: check query params (some providers use query for implicit too)
+    const params = window.location.search;
+    if (params) {
+      fetch('/callback' + params, { method: 'POST' })
+        .then(() => window.close())
+        .catch(() => document.body.innerHTML = '<p>Authorization complete. You can close this tab.</p>');
+    } else {
+      document.body.innerHTML = '<p>No authorization data received. You can close this tab.</p>';
+    }
+  }
+</script>
+</body>
+</html>
+`;
+
+async function openBrowserWithLocalServer(authorizeUrl: string): Promise<AuthorizationResult> {
+  return new Promise<AuthorizationResult>((resolve, reject) => {
+    pendingAuthResolve = resolve;
+    pendingAuthReject = reject;
+
+    authTimeoutHandle = setTimeout(() => {
+      cleanup();
+      pendingAuthResolve = null;
+      pendingAuthReject = null;
+      reject(new Error('OAuth2 authorization timed out after 5 minutes'));
+    }, AUTHORIZATION_TIMEOUT_MS);
+
+    // Start local server on a random available port
+    const server = http.createServer((req, res) => {
+      if (req.url?.startsWith('/callback')) {
+        const callbackUrl = new URL(req.url, `http://localhost`);
+        const params = callbackUrl.searchParams;
+
+        const error = params.get('error');
+        if (error) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body><p>Authorization failed. You can close this tab.</p></body></html>');
+          cleanup();
+          pendingAuthReject?.(new Error(`OAuth2 error: ${params.get('error_description') || error}`));
+          pendingAuthResolve = null;
+          pendingAuthReject = null;
+          return;
+        }
+
+        const accessToken = params.get('access_token');
+        if (accessToken) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body><p>Authorization complete. You can close this tab.</p></body></html>');
+          cleanup();
+          pendingAuthResolve?.({
+            implicitTokens: {
+              access_token: accessToken,
+              token_type: params.get('token_type') || 'Bearer',
+              expires_in: params.get('expires_in') || undefined,
+              scope: params.get('scope') || undefined,
+              state: params.get('state') || undefined
+            }
+          });
+          pendingAuthResolve = null;
+          pendingAuthReject = null;
+          return;
+        }
+
+        // Authorization code fallback
+        const code = params.get('code');
+        if (code) {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body><p>Authorization complete. You can close this tab.</p></body></html>');
+          cleanup();
+          pendingAuthResolve?.({ authorizationCode: code });
+          pendingAuthResolve = null;
+          pendingAuthReject = null;
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body><p>No authorization data. You can close this tab.</p></body></html>');
+      } else {
+        // Serve the callback page that extracts the fragment
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(CALLBACK_HTML);
+      }
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        cleanup();
+        pendingAuthResolve = null;
+        pendingAuthReject = null;
+        reject(new Error('Failed to start local OAuth2 callback server'));
+        return;
+      }
+
+      localServer = server;
+      const localCallbackUrl = `http://127.0.0.1:${addr.port}/`;
+
+      // Replace the callback URL in the authorization URL
+      const url = new URL(authorizeUrl);
+      url.searchParams.set('redirect_uri', localCallbackUrl);
+
+      vscode.env.openExternal(vscode.Uri.parse(url.toString())).then((opened) => {
+        if (!opened) {
+          cleanup();
+          pendingAuthResolve = null;
+          pendingAuthReject = null;
+          reject(new Error('Failed to open authorization URL in system browser'));
+        }
+      });
+    });
+
+    server.on('error', (err) => {
+      cleanup();
+      pendingAuthResolve = null;
+      pendingAuthReject = null;
+      reject(new Error(`OAuth2 callback server error: ${err.message}`));
+    });
+  });
+}

--- a/src/extension/ipc/network/authorize-user-in-system-browser.ts
+++ b/src/extension/ipc/network/authorize-user-in-system-browser.ts
@@ -127,8 +127,6 @@ interface ImplicitFlowOptions {
   additionalParameters?: OAuthAdditionalParameter[];
 }
 
-// --- Authorization code flow ---
-
 export async function getOAuth2AuthorizationCode(options: AuthorizationCodeOptions): Promise<AuthorizationResult> {
   if (isAuthorizationInProgress()) {
     throw new Error('An OAuth2 authorization request is already in progress');
@@ -166,8 +164,6 @@ export async function getOAuth2AuthorizationCode(options: AuthorizationCodeOptio
   return openBrowserAndWaitForCallback(url.toString());
 }
 
-// --- Implicit flow ---
-
 export async function getOAuth2ImplicitToken(options: ImplicitFlowOptions): Promise<AuthorizationResult> {
   if (isAuthorizationInProgress()) {
     throw new Error('An OAuth2 authorization request is already in progress');
@@ -197,13 +193,8 @@ export async function getOAuth2ImplicitToken(options: ImplicitFlowOptions): Prom
     });
   }
 
-  // Implicit flow tokens arrive in the URL fragment (#access_token=...).
-  // VS Code URI handlers don't receive fragments, so we use a local HTTP server
-  // that serves a page which extracts the fragment and sends it back.
-  return openBrowserWithLocalServer(url.toString());
+  return openBrowserAndWaitForCallback(url.toString());
 }
-
-// --- Browser + URI handler (for authorization code) ---
 
 async function openBrowserAndWaitForCallback(authorizeUrl: string): Promise<AuthorizationResult> {
   return new Promise<AuthorizationResult>((resolve, reject) => {
@@ -224,141 +215,6 @@ async function openBrowserAndWaitForCallback(authorizeUrl: string): Promise<Auth
         pendingAuthReject = null;
         reject(new Error('Failed to open authorization URL in system browser'));
       }
-    });
-  });
-}
-
-// --- Local HTTP server (for implicit flow fragment capture) ---
-
-const CALLBACK_HTML = `
-<!DOCTYPE html>
-<html>
-<body>
-<p>Processing OAuth2 callback... You can close this tab.</p>
-<script>
-  // Extract token from URL fragment and send to local server
-  const hash = window.location.hash.substring(1);
-  if (hash) {
-    fetch('/callback?' + hash, { method: 'POST' })
-      .then(() => window.close())
-      .catch(() => document.body.innerHTML = '<p>Authorization complete. You can close this tab.</p>');
-  } else {
-    // Fallback: check query params (some providers use query for implicit too)
-    const params = window.location.search;
-    if (params) {
-      fetch('/callback' + params, { method: 'POST' })
-        .then(() => window.close())
-        .catch(() => document.body.innerHTML = '<p>Authorization complete. You can close this tab.</p>');
-    } else {
-      document.body.innerHTML = '<p>No authorization data received. You can close this tab.</p>';
-    }
-  }
-</script>
-</body>
-</html>
-`;
-
-async function openBrowserWithLocalServer(authorizeUrl: string): Promise<AuthorizationResult> {
-  return new Promise<AuthorizationResult>((resolve, reject) => {
-    pendingAuthResolve = resolve;
-    pendingAuthReject = reject;
-
-    authTimeoutHandle = setTimeout(() => {
-      cleanup();
-      pendingAuthResolve = null;
-      pendingAuthReject = null;
-      reject(new Error('OAuth2 authorization timed out after 5 minutes'));
-    }, AUTHORIZATION_TIMEOUT_MS);
-
-    // Start local server on a random available port
-    const server = http.createServer((req, res) => {
-      if (req.url?.startsWith('/callback')) {
-        const callbackUrl = new URL(req.url, `http://localhost`);
-        const params = callbackUrl.searchParams;
-
-        const error = params.get('error');
-        if (error) {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end('<html><body><p>Authorization failed. You can close this tab.</p></body></html>');
-          cleanup();
-          pendingAuthReject?.(new Error(`OAuth2 error: ${params.get('error_description') || error}`));
-          pendingAuthResolve = null;
-          pendingAuthReject = null;
-          return;
-        }
-
-        const accessToken = params.get('access_token');
-        if (accessToken) {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end('<html><body><p>Authorization complete. You can close this tab.</p></body></html>');
-          cleanup();
-          pendingAuthResolve?.({
-            implicitTokens: {
-              access_token: accessToken,
-              token_type: params.get('token_type') || 'Bearer',
-              expires_in: params.get('expires_in') || undefined,
-              scope: params.get('scope') || undefined,
-              state: params.get('state') || undefined
-            }
-          });
-          pendingAuthResolve = null;
-          pendingAuthReject = null;
-          return;
-        }
-
-        // Authorization code fallback
-        const code = params.get('code');
-        if (code) {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end('<html><body><p>Authorization complete. You can close this tab.</p></body></html>');
-          cleanup();
-          pendingAuthResolve?.({ authorizationCode: code });
-          pendingAuthResolve = null;
-          pendingAuthReject = null;
-          return;
-        }
-
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end('<html><body><p>No authorization data. You can close this tab.</p></body></html>');
-      } else {
-        // Serve the callback page that extracts the fragment
-        res.writeHead(200, { 'Content-Type': 'text/html' });
-        res.end(CALLBACK_HTML);
-      }
-    });
-
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        cleanup();
-        pendingAuthResolve = null;
-        pendingAuthReject = null;
-        reject(new Error('Failed to start local OAuth2 callback server'));
-        return;
-      }
-
-      localServer = server;
-      const localCallbackUrl = `http://127.0.0.1:${addr.port}/`;
-
-      // Replace the callback URL in the authorization URL
-      const url = new URL(authorizeUrl);
-      url.searchParams.set('redirect_uri', localCallbackUrl);
-
-      vscode.env.openExternal(vscode.Uri.parse(url.toString())).then((opened) => {
-        if (!opened) {
-          cleanup();
-          pendingAuthResolve = null;
-          pendingAuthReject = null;
-          reject(new Error('Failed to open authorization URL in system browser'));
-        }
-      });
-    });
-
-    server.on('error', (err) => {
-      cleanup();
-      pendingAuthResolve = null;
-      pendingAuthReject = null;
-      reject(new Error(`OAuth2 callback server error: ${err.message}`));
     });
   });
 }

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -13,6 +13,7 @@ import { getProcessEnvVars } from '../../store/process-env';
 import { getCertsAndProxyConfig } from './cert-utils';
 import { getEnvVars, getTreePathFromCollectionToItem, mergeVars, mergeHeaders, mergeScripts, mergeAuth, flattenItems, findItemInCollection, findItemInCollectionByPathname, Item } from '../../utils/collection';
 import path from 'path';
+import { registerOAuth2Handlers, applyOAuth2ToRequest } from './oauth2-handlers';
 import { runPreRequestScript, runPostResponseVars, runPostResponseScript, runTests, runAssertions } from '../../utils/script-runner';
 import { v4 as uuidv4 } from 'uuid';
 import { cloneDeep, get, filter, forOwn } from 'lodash';
@@ -263,6 +264,13 @@ const executeRequest = async (
     const hasVariables = interpolatedRequest.url?.startsWith('{{');
     if (!hasVariables && interpolatedRequest.url && !protocolRegex.test(interpolatedRequest.url)) {
       interpolatedRequest.url = `http://${interpolatedRequest.url}`;
+    }
+
+    // Apply OAuth2 token to request (auto-fetch/refresh if needed)
+    const authMode = (interpolatedRequest as any)?.auth?.mode;
+    if (authMode === 'oauth2' || (interpolatedRequest as any)?.oauth2) {
+      addTimelineEvent('Applying OAuth2 token');
+      await applyOAuth2ToRequest(interpolatedRequest as unknown as Record<string, unknown>, context.collectionUid);
     }
 
     addTimelineEvent('Preparing request');
@@ -1506,17 +1514,8 @@ const registerNetworkIpc = (): void => {
     }
   });
 
-  // OAuth2 token retrieval (stub - deferred per user request)
-  registerHandler('renderer:get-oauth2-token', async (args) => {
-    const [_grantType, _credentials, _context] = args as [string, unknown, RequestContext];
-    throw new Error('OAuth2 not yet implemented - deferred');
-  });
-
-  // Refresh OAuth2 token (stub - deferred per user request)
-  registerHandler('renderer:refresh-oauth2-token', async (args) => {
-    const [_refreshToken, _credentials, _context] = args as [string, unknown, RequestContext];
-    throw new Error('OAuth2 not yet implemented - deferred');
-  });
+  // OAuth2 handlers (fetch, refresh, clear, browser auth state)
+  registerOAuth2Handlers();
 
   registerHandler('renderer:start-http-stream', async (args) => {
     const [request, context] = args as [BrunoRequest, RequestContext];

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -267,10 +267,14 @@ const executeRequest = async (
     }
 
     // Apply OAuth2 token to request (auto-fetch/refresh if needed)
-    const authMode = (interpolatedRequest as any)?.auth?.mode;
-    if (authMode === 'oauth2' || (interpolatedRequest as any)?.oauth2) {
+    const authMode = ((interpolatedRequest as { auth?: { mode?: string } })?.auth)?.mode;
+    if (authMode === 'oauth2' || (interpolatedRequest as { oauth2?: unknown }).oauth2) {
       addTimelineEvent('Applying OAuth2 token');
-      await applyOAuth2ToRequest(interpolatedRequest as unknown as Record<string, unknown>, context.collectionUid);
+      await applyOAuth2ToRequest(interpolatedRequest as unknown as Record<string, unknown>, context.collectionUid, {
+        envVars: context.envVars,
+        runtimeVariables: context.runtimeVariables,
+        processEnvVars: context.processEnvVars
+      });
     }
 
     addTimelineEvent('Preparing request');

--- a/src/extension/ipc/network/oauth2-handlers.ts
+++ b/src/extension/ipc/network/oauth2-handlers.ts
@@ -1,0 +1,234 @@
+import { registerHandler } from '../handlers';
+import {
+  getOAuth2TokenUsingClientCredentials,
+  getOAuth2TokenUsingPasswordCredentials,
+  getOAuth2TokenUsingAuthorizationCode,
+  getOAuth2TokenUsingImplicitGrant,
+  refreshOauth2Token,
+  clearOauth2Credentials,
+  getStoredOauth2Credentials,
+  isTokenExpired,
+  placeOAuth2Token,
+  OAuth2TokenResult
+} from '../../utils/oauth2';
+import { isAuthorizationInProgress, cancelAuthorization } from './authorize-user-in-system-browser';
+import { interpolate } from '@usebruno/common';
+import { cloneDeep } from 'lodash';
+import type { OAuth2 } from '@bruno-types/common/auth';
+
+export function registerOAuth2Handlers(): void {
+  // Fetch credentials (all grant types)
+  registerHandler('renderer:fetch-oauth2-credentials', async (args) => {
+    const [payload] = args as [{ itemUid: string; request: Record<string, unknown>; collection: Record<string, unknown> }];
+    const { request, collection } = payload;
+    const collectionUid = (collection as any)?.uid || (collection as any)?.collectionUid || '';
+
+    // Interpolate OAuth2 config before token fetch (resolves {{variables}})
+    const interpolatedRequest = interpolateOAuth2Config(request);
+    const oauth2Config = (interpolatedRequest as any)?.oauth2 || {};
+    const grantType = oauth2Config.grantType;
+
+    switch (grantType) {
+      case 'client_credentials':
+        return getOAuth2TokenUsingClientCredentials({ request: interpolatedRequest, collectionUid, forceFetch: true });
+      case 'password':
+        return getOAuth2TokenUsingPasswordCredentials({ request: interpolatedRequest, collectionUid, forceFetch: true });
+      case 'authorization_code':
+        return getOAuth2TokenUsingAuthorizationCode({ request: interpolatedRequest, collectionUid, forceFetch: true });
+      case 'implicit':
+        return getOAuth2TokenUsingImplicitGrant({ request: interpolatedRequest, collectionUid, forceFetch: true });
+      default:
+        throw new Error(`Unsupported OAuth2 grant type: ${grantType}`);
+    }
+  });
+
+  // Refresh credentials
+  registerHandler('renderer:refresh-oauth2-credentials', async (args) => {
+    const [payload] = args as [{ itemUid: string; request: Record<string, unknown>; collection: Record<string, unknown> }];
+    const { request, collection } = payload;
+    const collectionUid = (collection as any)?.uid || (collection as any)?.collectionUid || '';
+    return refreshOauth2Token({ requestCopy: request, collectionUid });
+  });
+
+  // Clear cached credentials
+  registerHandler('clear-oauth2-cache', async (args) => {
+    const [collectionUid, url, credentialsId] = args as [string, string, string];
+    clearOauth2Credentials({ collectionUid, url, credentialsId });
+  });
+
+  // Check if browser authorization is in progress
+  registerHandler('renderer:is-oauth2-authorization-request-in-progress', async () => {
+    return isAuthorizationInProgress();
+  });
+
+  // Cancel pending browser authorization
+  registerHandler('renderer:cancel-oauth2-authorization-request', async () => {
+    cancelAuthorization();
+  });
+}
+
+/**
+ * Interpolate OAuth2 config values using the request's variable context.
+ * The main interpolateVars call handles the request URL/headers/body, but
+ * nested auth.oauth2 fields (accessTokenUrl, clientId, etc.) need separate
+ * interpolation before we use them for token fetching.
+ */
+function interpolateOAuth2Config(request: Record<string, unknown>): Record<string, unknown> {
+  const requestCopy = cloneDeep(request);
+  const oauth2 = ((requestCopy.auth as any)?.oauth2 || requestCopy.oauth2) as Record<string, unknown> | undefined;
+  if (!oauth2) return requestCopy;
+
+  // Build the variable context from the request (same sources as interpolateVars)
+  // Flatten vars.req array into a key-value map (request variables defined in the Vars tab)
+  const varsReq = ((requestCopy as any)?.vars?.req || (requestCopy as any)?.auth?.oauth2?.vars?.req || []) as Array<{ name: string; value: string; enabled?: boolean }>;
+  const flattenedRequestVars: Record<string, unknown> = {};
+  for (const v of varsReq) {
+    if (v.enabled !== false && v.name) {
+      flattenedRequestVars[v.name] = v.value;
+    }
+  }
+
+  const vars: Record<string, unknown> = {
+    ...(requestCopy.globalEnvironmentVariables as Record<string, unknown> || {}),
+    ...(requestCopy.collectionVariables as Record<string, unknown> || {}),
+    ...(requestCopy.folderVariables as Record<string, unknown> || {}),
+    ...(requestCopy.requestVariables as Record<string, unknown> || {}),
+    ...flattenedRequestVars,
+    ...(requestCopy.oauth2CredentialVariables as Record<string, unknown> || {}),
+  };
+
+  // Interpolate all string values in the oauth2 config
+  const fieldsToInterpolate = [
+    'accessTokenUrl', 'refreshTokenUrl', 'authorizationUrl', 'callbackUrl',
+    'clientId', 'clientSecret', 'username', 'password', 'scope', 'state'
+  ];
+
+  for (const field of fieldsToInterpolate) {
+    if (typeof oauth2[field] === 'string' && (oauth2[field] as string).includes('{{')) {
+      oauth2[field] = (interpolate as any)(oauth2[field], vars);
+    }
+  }
+
+  // Write back interpolated config
+  if ((requestCopy.auth as any)?.oauth2) {
+    (requestCopy.auth as any).oauth2 = oauth2;
+  }
+  if (requestCopy.oauth2) {
+    requestCopy.oauth2 = oauth2;
+  }
+
+  return requestCopy;
+}
+
+/**
+ * Populate oauth2CredentialVariables on the request after token fetch.
+ * Enables {{$oauth2.credentialsId.access_token}} syntax in scripts and tests.
+ */
+function populateOAuth2CredentialVariables(
+  request: Record<string, unknown>,
+  credentialsId: string,
+  credentials: Record<string, unknown>
+): void {
+  const vars = (request.oauth2CredentialVariables || {}) as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(credentials)) {
+    vars[`$oauth2.${credentialsId}.${key}`] = value;
+  }
+
+  request.oauth2CredentialVariables = vars;
+}
+
+/**
+ * Apply OAuth2 token to an outgoing request.
+ * Called in the execution pipeline after variable interpolation, before prepareRequest.
+ *
+ * Mirrors the configureRequest logic in the main Bruno repo
+ * (packages/bruno-electron/src/ipc/network/index.js lines 170-298).
+ *
+ * 1. Interpolates OAuth2 config values (accessTokenUrl, clientId, etc.)
+ * 2. Checks stored credentials / auto-fetches / auto-refreshes
+ * 3. Places the token on the request (header or query param)
+ * 4. Populates oauth2CredentialVariables for script access
+ */
+export async function applyOAuth2ToRequest(
+  request: Record<string, unknown>,
+  collectionUid: string
+): Promise<void> {
+  const auth = request.auth as { mode?: string; oauth2?: OAuth2 } | undefined;
+  const oauth2Raw = (request.oauth2 as OAuth2 | undefined) || auth?.oauth2;
+  if (!oauth2Raw) return;
+
+  // Fix 1: Interpolate OAuth2 config values before using them
+  const interpolatedRequest = interpolateOAuth2Config(request);
+  const interpolatedAuth = interpolatedRequest.auth as { mode?: string; oauth2?: OAuth2 } | undefined;
+  const oauth2 = (interpolatedRequest.oauth2 as OAuth2 | undefined) || interpolatedAuth?.oauth2;
+  if (!oauth2) return;
+
+  const { grantType, credentialsId = 'default', autoFetchToken } = oauth2;
+  const url = oauth2.accessTokenUrl || '';
+  const effectiveCredentialsId = credentialsId || 'default';
+
+  if (!grantType) return;
+  // For implicit flow, url may be empty (uses authorizationUrl instead)
+  if (!url && grantType !== 'implicit') return;
+
+  let result: OAuth2TokenResult | null = null;
+
+  if (grantType === 'client_credentials' || grantType === 'password') {
+    const stored = getStoredOauth2Credentials({ collectionUid, url, credentialsId: effectiveCredentialsId });
+
+    if (stored && !isTokenExpired(stored)) {
+      placeOAuth2Token(request as any, stored, oauth2);
+      populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
+      return;
+    }
+
+    // Expired or missing — delegate to grant type function (handles auto-refresh/auto-fetch)
+    if (grantType === 'client_credentials') {
+      result = await getOAuth2TokenUsingClientCredentials({ request: interpolatedRequest, collectionUid });
+    } else {
+      result = await getOAuth2TokenUsingPasswordCredentials({ request: interpolatedRequest, collectionUid });
+    }
+  } else if (grantType === 'authorization_code' || grantType === 'implicit') {
+    const storedUrl = grantType === 'implicit' ? (oauth2.authorizationUrl || '') : url;
+    const stored = getStoredOauth2Credentials({ collectionUid, url: storedUrl, credentialsId: effectiveCredentialsId });
+
+    if (stored && !isTokenExpired(stored)) {
+      placeOAuth2Token(request as any, stored, oauth2);
+      populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
+      return;
+    }
+
+    // Fix 3: Auto-fetch for browser flows when autoFetchToken is true
+    if (autoFetchToken) {
+      if (grantType === 'authorization_code') {
+        result = await getOAuth2TokenUsingAuthorizationCode({ request: interpolatedRequest, collectionUid });
+      } else {
+        result = await getOAuth2TokenUsingImplicitGrant({ request: interpolatedRequest, collectionUid });
+      }
+    } else if (stored) {
+      // Return expired token if autoFetchToken is disabled
+      placeOAuth2Token(request as any, stored, oauth2);
+      populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
+      return;
+    } else {
+      return;
+    }
+  }
+
+  // Fix 2: Place token and populate credential variables for script access
+  if (result?.credentials) {
+    placeOAuth2Token(request as any, result.credentials, oauth2);
+    populateOAuth2CredentialVariables(request, effectiveCredentialsId, result.credentials);
+
+    // Store oauth2Credentials on request for UI to read back
+    (request as any).oauth2Credentials = {
+      credentials: result.credentials,
+      url: result.url,
+      collectionUid,
+      credentialsId: effectiveCredentialsId,
+      debugInfo: result.debugInfo,
+      folderUid: (request as any).oauth2Credentials?.folderUid
+    };
+  }
+}

--- a/src/extension/ipc/network/oauth2-handlers.ts
+++ b/src/extension/ipc/network/oauth2-handlers.ts
@@ -16,17 +16,31 @@ import { interpolate } from '@usebruno/common';
 import { cloneDeep } from 'lodash';
 import type { OAuth2 } from '@bruno-types/common/auth';
 
+export interface OAuth2VariableContext {
+  envVars?: Record<string, unknown>;
+  runtimeVariables?: Record<string, unknown>;
+  processEnvVars?: Record<string, string>;
+}
+
+interface FetchOAuth2Payload {
+  itemUid: string;
+  request: Record<string, unknown>;
+  collection: Record<string, unknown>;
+}
+
 export function registerOAuth2Handlers(): void {
   // Fetch credentials (all grant types)
   registerHandler('renderer:fetch-oauth2-credentials', async (args) => {
-    const [payload] = args as [{ itemUid: string; request: Record<string, unknown>; collection: Record<string, unknown> }];
+    const [payload] = args as [FetchOAuth2Payload];
     const { request, collection } = payload;
-    const collectionUid = (collection as any)?.uid || (collection as any)?.collectionUid || '';
+    const collectionUid = (collection as { uid?: string; collectionUid?: string })?.uid
+      || (collection as { uid?: string; collectionUid?: string })?.collectionUid || '';
 
-    // Interpolate OAuth2 config before token fetch (resolves {{variables}})
-    const interpolatedRequest = interpolateOAuth2Config(request);
-    const oauth2Config = (interpolatedRequest as any)?.oauth2 || {};
-    const grantType = oauth2Config.grantType;
+    // Use mergedVariables from the webview if available (manual fetch path)
+    const additionalVars = (request.mergedVariables as Record<string, unknown>) || undefined;
+    const interpolatedRequest = interpolateOAuth2Config(request, additionalVars);
+    const oauth2Config = ((interpolatedRequest.auth as { oauth2?: OAuth2 })?.oauth2 || interpolatedRequest.oauth2) as OAuth2 | undefined;
+    const grantType = oauth2Config?.grantType;
 
     switch (grantType) {
       case 'client_credentials':
@@ -44,10 +58,15 @@ export function registerOAuth2Handlers(): void {
 
   // Refresh credentials
   registerHandler('renderer:refresh-oauth2-credentials', async (args) => {
-    const [payload] = args as [{ itemUid: string; request: Record<string, unknown>; collection: Record<string, unknown> }];
+    const [payload] = args as [FetchOAuth2Payload];
     const { request, collection } = payload;
-    const collectionUid = (collection as any)?.uid || (collection as any)?.collectionUid || '';
-    return refreshOauth2Token({ requestCopy: request, collectionUid });
+    const collectionUid = (collection as { uid?: string; collectionUid?: string })?.uid
+      || (collection as { uid?: string; collectionUid?: string })?.collectionUid || '';
+
+    // Interpolate OAuth2 config before refresh (resolves {{variables}})
+    const additionalVars = (request.mergedVariables as Record<string, unknown>) || undefined;
+    const interpolatedRequest = interpolateOAuth2Config(request, additionalVars);
+    return refreshOauth2Token({ requestCopy: interpolatedRequest, collectionUid });
   });
 
   // Clear cached credentials
@@ -72,17 +91,23 @@ export function registerOAuth2Handlers(): void {
  * The main interpolateVars call handles the request URL/headers/body, but
  * nested auth.oauth2 fields (accessTokenUrl, clientId, etc.) need separate
  * interpolation before we use them for token fetching.
+ *
+ * @param request - The request object with variable properties attached
+ * @param additionalVars - Extra variables to merge in (from execution context or webview's getAllVariables)
  */
-function interpolateOAuth2Config(request: Record<string, unknown>): Record<string, unknown> {
+function interpolateOAuth2Config(
+  request: Record<string, unknown>,
+  additionalVars?: Record<string, unknown>
+): Record<string, unknown> {
   const requestCopy = cloneDeep(request);
-  const oauth2 = ((requestCopy.auth as any)?.oauth2 || requestCopy.oauth2) as Record<string, unknown> | undefined;
+  const oauth2 = ((requestCopy.auth as { oauth2?: Record<string, unknown> })?.oauth2 || requestCopy.oauth2) as Record<string, unknown> | undefined;
   if (!oauth2) return requestCopy;
 
   // Build the variable context from the request (same sources as interpolateVars)
   // Flatten vars.req array into a key-value map (request variables defined in the Vars tab)
-  const varsReq = ((requestCopy as any)?.vars?.req || (requestCopy as any)?.auth?.oauth2?.vars?.req || []) as Array<{ name: string; value: string; enabled?: boolean }>;
+  const varsReqSource = (requestCopy as { vars?: { req?: Array<{ name: string; value: string; enabled?: boolean }> } })?.vars?.req || [];
   const flattenedRequestVars: Record<string, unknown> = {};
-  for (const v of varsReq) {
+  for (const v of varsReqSource) {
     if (v.enabled !== false && v.name) {
       flattenedRequestVars[v.name] = v.value;
     }
@@ -91,10 +116,13 @@ function interpolateOAuth2Config(request: Record<string, unknown>): Record<strin
   const vars: Record<string, unknown> = {
     ...(requestCopy.globalEnvironmentVariables as Record<string, unknown> || {}),
     ...(requestCopy.collectionVariables as Record<string, unknown> || {}),
+    ...(requestCopy.envVars as Record<string, unknown> || {}),
     ...(requestCopy.folderVariables as Record<string, unknown> || {}),
     ...(requestCopy.requestVariables as Record<string, unknown> || {}),
     ...flattenedRequestVars,
     ...(requestCopy.oauth2CredentialVariables as Record<string, unknown> || {}),
+    ...(requestCopy.runtimeVariables as Record<string, unknown> || {}),
+    ...(additionalVars || {}),
   };
 
   // Interpolate all string values in the oauth2 config
@@ -105,17 +133,18 @@ function interpolateOAuth2Config(request: Record<string, unknown>): Record<strin
 
   for (const field of fieldsToInterpolate) {
     if (typeof oauth2[field] === 'string' && (oauth2[field] as string).includes('{{')) {
-      oauth2[field] = (interpolate as any)(oauth2[field], vars);
+      oauth2[field] = (interpolate as (str: string, vars: Record<string, unknown>) => string)(oauth2[field] as string, vars);
     }
   }
 
-  // Write back interpolated config
-  if ((requestCopy.auth as any)?.oauth2) {
-    (requestCopy.auth as any).oauth2 = oauth2;
+  // Write back interpolated config to both locations
+  if ((requestCopy.auth as { oauth2?: Record<string, unknown> })?.oauth2) {
+    (requestCopy.auth as { oauth2: Record<string, unknown> }).oauth2 = oauth2;
   }
-  if (requestCopy.oauth2) {
-    requestCopy.oauth2 = oauth2;
-  }
+  // Always ensure oauth2 is at top level — grant type functions read from request.oauth2.
+  // When auth is inherited (mergeAuth), the config only lives at auth.oauth2;
+  // without this, auto-fetch during request execution silently fails.
+  requestCopy.oauth2 = oauth2;
 
   return requestCopy;
 }
@@ -152,14 +181,26 @@ function populateOAuth2CredentialVariables(
  */
 export async function applyOAuth2ToRequest(
   request: Record<string, unknown>,
-  collectionUid: string
+  collectionUid: string,
+  variableContext?: OAuth2VariableContext
 ): Promise<void> {
   const auth = request.auth as { mode?: string; oauth2?: OAuth2 } | undefined;
   const oauth2Raw = (request.oauth2 as OAuth2 | undefined) || auth?.oauth2;
   if (!oauth2Raw) return;
 
-  // Fix 1: Interpolate OAuth2 config values before using them
-  const interpolatedRequest = interpolateOAuth2Config(request);
+  // Build additional vars from execution context (envVars, runtimeVariables, processEnvVars)
+  const additionalVars: Record<string, unknown> = {};
+  if (variableContext?.envVars) {
+    Object.assign(additionalVars, variableContext.envVars);
+  }
+  if (variableContext?.runtimeVariables) {
+    Object.assign(additionalVars, variableContext.runtimeVariables);
+  }
+  if (variableContext?.processEnvVars) {
+    additionalVars.process = { env: { ...variableContext.processEnvVars } };
+  }
+
+  const interpolatedRequest = interpolateOAuth2Config(request, additionalVars);
   const interpolatedAuth = interpolatedRequest.auth as { mode?: string; oauth2?: OAuth2 } | undefined;
   const oauth2 = (interpolatedRequest.oauth2 as OAuth2 | undefined) || interpolatedAuth?.oauth2;
   if (!oauth2) return;
@@ -178,7 +219,7 @@ export async function applyOAuth2ToRequest(
     const stored = getStoredOauth2Credentials({ collectionUid, url, credentialsId: effectiveCredentialsId });
 
     if (stored && !isTokenExpired(stored)) {
-      placeOAuth2Token(request as any, stored, oauth2);
+      placeOAuth2Token(request as { headers?: Record<string, string>; url?: string }, stored, oauth2);
       populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
       return;
     }
@@ -194,12 +235,12 @@ export async function applyOAuth2ToRequest(
     const stored = getStoredOauth2Credentials({ collectionUid, url: storedUrl, credentialsId: effectiveCredentialsId });
 
     if (stored && !isTokenExpired(stored)) {
-      placeOAuth2Token(request as any, stored, oauth2);
+      placeOAuth2Token(request as { headers?: Record<string, string>; url?: string }, stored, oauth2);
       populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
       return;
     }
 
-    // Fix 3: Auto-fetch for browser flows when autoFetchToken is true
+    // Auto-fetch for browser flows when autoFetchToken is true
     if (autoFetchToken) {
       if (grantType === 'authorization_code') {
         result = await getOAuth2TokenUsingAuthorizationCode({ request: interpolatedRequest, collectionUid });
@@ -208,7 +249,7 @@ export async function applyOAuth2ToRequest(
       }
     } else if (stored) {
       // Return expired token if autoFetchToken is disabled
-      placeOAuth2Token(request as any, stored, oauth2);
+      placeOAuth2Token(request as { headers?: Record<string, string>; url?: string }, stored, oauth2);
       populateOAuth2CredentialVariables(request, effectiveCredentialsId, stored);
       return;
     } else {
@@ -216,19 +257,20 @@ export async function applyOAuth2ToRequest(
     }
   }
 
-  // Fix 2: Place token and populate credential variables for script access
+  // Place token and populate credential variables for script access
   if (result?.credentials) {
-    placeOAuth2Token(request as any, result.credentials, oauth2);
+    placeOAuth2Token(request as { headers?: Record<string, string>; url?: string }, result.credentials, oauth2);
     populateOAuth2CredentialVariables(request, effectiveCredentialsId, result.credentials);
 
     // Store oauth2Credentials on request for UI to read back
-    (request as any).oauth2Credentials = {
+    const existingOauth2Creds = request.oauth2Credentials as { folderUid?: string } | undefined;
+    request.oauth2Credentials = {
       credentials: result.credentials,
       url: result.url,
       collectionUid,
       credentialsId: effectiveCredentialsId,
       debugInfo: result.debugInfo,
-      folderUid: (request as any).oauth2Credentials?.folderUid
+      folderUid: existingOauth2Creds?.folderUid
     };
   }
 }

--- a/src/extension/ipc/network/prepare-request.ts
+++ b/src/extension/ipc/network/prepare-request.ts
@@ -265,7 +265,11 @@ const applyAuth = (request: PreparedRequest, auth: BrunoRequest['auth']): void =
       }
       break;
 
-    // digest, oauth2, awsv4 require additional handling
+    case 'oauth2':
+      // Token is already applied by applyOAuth2ToRequest in the execution pipeline
+      break;
+
+    // digest, awsv4 require additional handling
     default:
       console.warn(`Auth mode ${auth.mode} not yet fully implemented`);
   }

--- a/src/extension/utils/oauth2.spec.ts
+++ b/src/extension/utils/oauth2.spec.ts
@@ -1,0 +1,611 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import axios from 'axios';
+import {
+  isTokenExpired,
+  applyAdditionalParameters,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  placeOAuth2Token,
+  getOAuth2TokenUsingClientCredentials,
+  getOAuth2TokenUsingPasswordCredentials
+} from './oauth2';
+
+/**
+ * Creates a mock axios adapter that intercepts HTTP requests.
+ *
+ * Captures the request config for assertions and returns a controlled response.
+ */
+const createMockAdapter = (responseData: any = { access_token: 'test-token', expires_in: 3600 }) => {
+  let capturedConfig: any = null;
+
+  const adapter = async (config: any) => {
+    capturedConfig = config;
+    return {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/json' },
+      config,
+      data: Buffer.from(JSON.stringify(responseData))
+    };
+  };
+
+  return { adapter, getCapturedConfig: () => capturedConfig };
+};
+
+// ─── Client Credentials Grant ────────────────────────────────────────────────
+//
+// Tests verify how client credentials (clientId/clientSecret) are transmitted.
+// OAuth2 spec (RFC 6749 Section 2.3.1) allows two methods:
+//   1. HTTP Basic Authentication header
+//   2. Request body parameters
+
+describe('OAuth2 Helper - Client Credentials Grant', () => {
+  let originalAdapter: any;
+
+  beforeEach(() => {
+    originalAdapter = axios.defaults.adapter;
+  });
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  describe('when credentialsPlacement is basic_auth_header', () => {
+    test('should send token request with Authorization header when clientSecret is undefined', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingClientCredentials({
+        request: {
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: undefined,
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+      expect((result.credentials as any)?.access_token).toBe('test-token');
+
+      const capturedConfig = getCapturedConfig();
+      expect(capturedConfig).not.toBeNull();
+
+      // Authorization: Basic base64(clientId:) with empty secret
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+
+      // grant_type must be in body
+      expect(capturedConfig.data).toContain('grant_type=client_credentials');
+
+      // client_id should NOT be duplicated in body when using basic_auth_header
+      expect(capturedConfig.data).not.toContain('client_id=');
+    });
+
+    test('should send token request with Authorization header when clientSecret is empty string', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingClientCredentials({
+        request: {
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: '',
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+
+      const capturedConfig = getCapturedConfig();
+      // Empty string treated same as undefined
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+    });
+
+    test('should send token request with Authorization header when clientSecret is present', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingClientCredentials({
+        request: {
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: 'my-secret',
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+
+      const capturedConfig = getCapturedConfig();
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:my-secret').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+
+      // client_secret should NOT be in body when using basic_auth_header
+      expect(capturedConfig.data).not.toContain('client_secret=');
+    });
+  });
+
+  describe('when credentialsPlacement is body', () => {
+    test('should send client_id in body and no Authorization header when clientSecret is empty', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingClientCredentials({
+        request: {
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: '',
+            credentialsPlacement: 'body'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+
+      const capturedConfig = getCapturedConfig();
+      expect(capturedConfig.headers['Authorization']).toBeUndefined();
+      expect(capturedConfig.data).toContain('client_id=my-client-id');
+      // Empty client_secret should be omitted
+      expect(capturedConfig.data).not.toContain('client_secret=');
+    });
+
+    test('should send both client_id and client_secret in body when clientSecret is present', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingClientCredentials({
+        request: {
+          oauth2: {
+            grantType: 'client_credentials',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: 'my-secret',
+            credentialsPlacement: 'body'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+
+      const capturedConfig = getCapturedConfig();
+      expect(capturedConfig.headers['Authorization']).toBeUndefined();
+      expect(capturedConfig.data).toContain('client_id=my-client-id');
+      expect(capturedConfig.data).toContain('client_secret=my-secret');
+    });
+  });
+});
+
+// ─── Password Grant ──────────────────────────────────────────────────────────
+//
+// Password grant includes user credentials (username, password) always in body,
+// plus client credentials placement is configurable.
+
+describe('OAuth2 Helper - Password Grant', () => {
+  let originalAdapter: any;
+
+  beforeEach(() => {
+    originalAdapter = axios.defaults.adapter;
+  });
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+  });
+
+  describe('when credentialsPlacement is basic_auth_header', () => {
+    test('should send token request with Authorization header when clientSecret is undefined', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      const result = await getOAuth2TokenUsingPasswordCredentials({
+        request: {
+          oauth2: {
+            grantType: 'password',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: undefined,
+            username: 'testuser',
+            password: 'testpass',
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      expect(result.credentials).not.toBeNull();
+
+      const capturedConfig = getCapturedConfig();
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+
+      expect(capturedConfig.data).toContain('grant_type=password');
+      expect(capturedConfig.data).toContain('username=testuser');
+      expect(capturedConfig.data).toContain('password=testpass');
+
+      // client_id should NOT be in body when using basic_auth_header
+      expect(capturedConfig.data).not.toContain('client_id=');
+    });
+
+    test('should send token request with Authorization header when clientSecret is empty string', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      await getOAuth2TokenUsingPasswordCredentials({
+        request: {
+          oauth2: {
+            grantType: 'password',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: '',
+            username: 'testuser',
+            password: 'testpass',
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      const capturedConfig = getCapturedConfig();
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+    });
+
+    test('should send token request with Authorization header when clientSecret is present', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      await getOAuth2TokenUsingPasswordCredentials({
+        request: {
+          oauth2: {
+            grantType: 'password',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: 'my-secret',
+            username: 'testuser',
+            password: 'testpass',
+            credentialsPlacement: 'basic_auth_header'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      const capturedConfig = getCapturedConfig();
+      const expectedAuth = `Basic ${Buffer.from('my-client-id:my-secret').toString('base64')}`;
+      expect(capturedConfig.headers['Authorization']).toBe(expectedAuth);
+      expect(capturedConfig.data).not.toContain('client_secret=');
+    });
+  });
+
+  describe('when credentialsPlacement is body', () => {
+    test('should send client_id in body and no Authorization header when clientSecret is empty', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      await getOAuth2TokenUsingPasswordCredentials({
+        request: {
+          oauth2: {
+            grantType: 'password',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: '',
+            username: 'testuser',
+            password: 'testpass',
+            credentialsPlacement: 'body'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      const capturedConfig = getCapturedConfig();
+      expect(capturedConfig.headers['Authorization']).toBeUndefined();
+      expect(capturedConfig.data).toContain('client_id=my-client-id');
+      expect(capturedConfig.data).not.toContain('client_secret=');
+    });
+
+    test('should send both client_id and client_secret in body when clientSecret is present', async () => {
+      const { adapter, getCapturedConfig } = createMockAdapter();
+      axios.defaults.adapter = adapter;
+
+      await getOAuth2TokenUsingPasswordCredentials({
+        request: {
+          oauth2: {
+            grantType: 'password',
+            accessTokenUrl: 'https://auth.example.com/token',
+            clientId: 'my-client-id',
+            clientSecret: 'my-secret',
+            username: 'testuser',
+            password: 'testpass',
+            credentialsPlacement: 'body'
+          }
+        },
+        collectionUid: 'test-collection',
+        forceFetch: true
+      });
+
+      const capturedConfig = getCapturedConfig();
+      expect(capturedConfig.headers['Authorization']).toBeUndefined();
+      expect(capturedConfig.data).toContain('client_id=my-client-id');
+      expect(capturedConfig.data).toContain('client_secret=my-secret');
+    });
+  });
+});
+
+// ─── Token Expiry ────────────────────────────────────────────────────────────
+
+describe('OAuth2 Helper - Token Expiry', () => {
+  test('should return true when access_token is missing', () => {
+    expect(isTokenExpired(null)).toBe(true);
+    expect(isTokenExpired({})).toBe(true);
+    expect(isTokenExpired({ refresh_token: 'abc' })).toBe(true);
+  });
+
+  test('should return false when no expiration info', () => {
+    expect(isTokenExpired({ access_token: 'token' })).toBe(false);
+    expect(isTokenExpired({ access_token: 'token', expires_in: 3600 })).toBe(false);
+    expect(isTokenExpired({ access_token: 'token', created_at: Date.now() })).toBe(false);
+  });
+
+  test('should return true when token is expired', () => {
+    const credentials = {
+      access_token: 'token',
+      expires_in: 3600,
+      created_at: Date.now() - 4000 * 1000 // created 4000 seconds ago, expires after 3600
+    };
+    expect(isTokenExpired(credentials)).toBe(true);
+  });
+
+  test('should return false when token is still valid', () => {
+    const credentials = {
+      access_token: 'token',
+      expires_in: 3600,
+      created_at: Date.now() - 1000 * 1000 // created 1000 seconds ago, expires after 3600
+    };
+    expect(isTokenExpired(credentials)).toBe(false);
+  });
+});
+
+// ─── Additional Parameters ───────────────────────────────────────────────────
+
+describe('OAuth2 Helper - Additional Parameters', () => {
+  test('should apply header parameters', () => {
+    const requestConfig = { url: 'https://auth.example.com/token', headers: {} as Record<string, string> };
+    const data: Record<string, string> = {};
+
+    applyAdditionalParameters(requestConfig, data, [
+      { name: 'X-Custom-Header', value: 'custom-value', sendIn: 'headers', enabled: true }
+    ]);
+
+    expect(requestConfig.headers['X-Custom-Header']).toBe('custom-value');
+  });
+
+  test('should apply query parameters', () => {
+    const requestConfig = { url: 'https://auth.example.com/token', headers: {} as Record<string, string> };
+    const data: Record<string, string> = {};
+
+    applyAdditionalParameters(requestConfig, data, [
+      { name: 'audience', value: 'https://api.example.com', sendIn: 'queryparams', enabled: true }
+    ]);
+
+    expect(requestConfig.url).toContain('audience=');
+    expect(requestConfig.url).toContain('https%3A%2F%2Fapi.example.com');
+  });
+
+  test('should apply body parameters', () => {
+    const requestConfig = { url: 'https://auth.example.com/token', headers: {} as Record<string, string> };
+    const data: Record<string, string> = {};
+
+    applyAdditionalParameters(requestConfig, data, [
+      { name: 'resource', value: 'https://api.example.com', sendIn: 'body', enabled: true }
+    ]);
+
+    expect(data['resource']).toBe('https://api.example.com');
+  });
+
+  test('should skip disabled parameters', () => {
+    const requestConfig = { url: 'https://auth.example.com/token', headers: {} as Record<string, string> };
+    const data: Record<string, string> = {};
+
+    applyAdditionalParameters(requestConfig, data, [
+      { name: 'X-Skip', value: 'skip-me', sendIn: 'headers', enabled: false }
+    ]);
+
+    expect(requestConfig.headers['X-Skip']).toBeUndefined();
+  });
+
+  test('should skip parameters without a name', () => {
+    const requestConfig = { url: 'https://auth.example.com/token', headers: {} as Record<string, string> };
+    const data: Record<string, string> = {};
+
+    applyAdditionalParameters(requestConfig, data, [
+      { name: '', value: 'no-name', sendIn: 'headers', enabled: true }
+    ]);
+
+    expect(Object.keys(requestConfig.headers)).toHaveLength(0);
+  });
+});
+
+// ─── Token Placement ─────────────────────────────────────────────────────────
+
+describe('OAuth2 Helper - Token Placement', () => {
+  test('should place token in Authorization header with Bearer prefix by default', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { access_token: 'my-token' }, { grantType: 'client_credentials' });
+
+    expect(request.headers['Authorization']).toBe('Bearer my-token');
+  });
+
+  test('should place token in Authorization header with custom prefix', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { access_token: 'my-token' }, {
+      grantType: 'client_credentials',
+      tokenPlacement: 'header',
+      tokenHeaderPrefix: 'Token'
+    });
+
+    expect(request.headers['Authorization']).toBe('Token my-token');
+  });
+
+  test('should place token in query params', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { access_token: 'my-token' }, {
+      grantType: 'client_credentials',
+      tokenPlacement: 'queryparams',
+      tokenQueryKey: 'token'
+    });
+
+    expect(request.url).toContain('token=my-token');
+    expect(request.headers['Authorization']).toBeUndefined();
+  });
+
+  test('should use default query key access_token', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { access_token: 'my-token' }, {
+      grantType: 'client_credentials',
+      tokenPlacement: 'queryparams'
+    });
+
+    expect(request.url).toContain('access_token=my-token');
+  });
+
+  test('should use id_token when tokenSource is id_token', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { access_token: 'access', id_token: 'id-tok' }, {
+      grantType: 'client_credentials',
+      tokenSource: 'id_token' as any
+    });
+
+    expect(request.headers['Authorization']).toBe('Bearer id-tok');
+  });
+
+  test('should not modify request when token value is missing', () => {
+    const request: { headers: Record<string, string>; url: string } = { headers: {}, url: 'https://api.example.com/data' };
+    placeOAuth2Token(request, { refresh_token: 'refresh-only' }, { grantType: 'client_credentials' });
+
+    expect(request.headers['Authorization']).toBeUndefined();
+    expect(request.url).toBe('https://api.example.com/data');
+  });
+});
+
+// ─── PKCE ────────────────────────────────────────────────────────────────────
+
+describe('OAuth2 Helper - PKCE', () => {
+  test('should generate a code verifier of expected length', () => {
+    const verifier = generateCodeVerifier();
+    // 22 random bytes → 44 hex characters
+    expect(verifier).toHaveLength(44);
+    expect(verifier).toMatch(/^[0-9a-f]+$/);
+  });
+
+  test('should generate different verifiers each time', () => {
+    const v1 = generateCodeVerifier();
+    const v2 = generateCodeVerifier();
+    expect(v1).not.toBe(v2);
+  });
+
+  test('should generate a valid base64url-encoded code challenge', () => {
+    const verifier = 'test-verifier-string';
+    const challenge = generateCodeChallenge(verifier);
+
+    // Should be base64url encoded (no +, /, or = characters)
+    expect(challenge).not.toContain('+');
+    expect(challenge).not.toContain('/');
+    expect(challenge).not.toContain('=');
+    expect(challenge.length).toBeGreaterThan(0);
+  });
+
+  test('should produce consistent challenge for same verifier', () => {
+    const verifier = 'consistent-verifier';
+    const c1 = generateCodeChallenge(verifier);
+    const c2 = generateCodeChallenge(verifier);
+    expect(c1).toBe(c2);
+  });
+});
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+describe('OAuth2 Helper - Validation', () => {
+  test('client_credentials should return error when accessTokenUrl is missing', async () => {
+    const result = await getOAuth2TokenUsingClientCredentials({
+      request: {
+        oauth2: { grantType: 'client_credentials', clientId: 'id' }
+      },
+      collectionUid: 'test',
+      forceFetch: true
+    });
+
+    expect(result.error).toContain('Access Token URL is required');
+    expect(result.credentials).toBeNull();
+  });
+
+  test('client_credentials should return error when clientId is missing', async () => {
+    const result = await getOAuth2TokenUsingClientCredentials({
+      request: {
+        oauth2: { grantType: 'client_credentials', accessTokenUrl: 'https://auth.example.com/token' }
+      },
+      collectionUid: 'test',
+      forceFetch: true
+    });
+
+    expect(result.error).toContain('Client ID is required');
+    expect(result.credentials).toBeNull();
+  });
+
+  test('password should return error when username is missing', async () => {
+    const result = await getOAuth2TokenUsingPasswordCredentials({
+      request: {
+        oauth2: {
+          grantType: 'password',
+          accessTokenUrl: 'https://auth.example.com/token',
+          clientId: 'id',
+          password: 'pass'
+        }
+      },
+      collectionUid: 'test',
+      forceFetch: true
+    });
+
+    expect(result.error).toContain('Username is required');
+  });
+
+  test('password should return error when password is missing', async () => {
+    const result = await getOAuth2TokenUsingPasswordCredentials({
+      request: {
+        oauth2: {
+          grantType: 'password',
+          accessTokenUrl: 'https://auth.example.com/token',
+          clientId: 'id',
+          username: 'user'
+        }
+      },
+      collectionUid: 'test',
+      forceFetch: true
+    });
+
+    expect(result.error).toContain('Password is required');
+  });
+});

--- a/src/extension/utils/oauth2.ts
+++ b/src/extension/utils/oauth2.ts
@@ -1,0 +1,687 @@
+import axios, { AxiosRequestConfig, ResponseType } from 'axios';
+import crypto from 'crypto';
+import qs from 'qs';
+import Oauth2Store from '../store/oauth2';
+import type { OAuth2, OAuthAdditionalParameter } from '@bruno-types/common/auth';
+import {
+  getOAuth2AuthorizationCode,
+  getOAuth2ImplicitToken,
+  type AuthorizationResult
+} from '../ipc/network/authorize-user-in-system-browser';
+
+const BRUNO_OAUTH2_CALLBACK_URL = 'https://oauth.usebruno.com/callback';
+
+const oauth2Store = new Oauth2Store();
+
+// --- Types ---
+
+export interface OAuth2TokenResult {
+  collectionUid: string;
+  url: string;
+  credentials: Record<string, unknown> | null;
+  credentialsId: string;
+  error?: string;
+  debugInfo?: { data: unknown[] };
+}
+
+interface TokenRequestConfig {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  data: string;
+  responseType: ResponseType;
+}
+
+// --- Store wrappers ---
+
+export const persistOauth2Credentials = ({ collectionUid, url, credentials, credentialsId }: {
+  collectionUid: string;
+  url: string;
+  credentials: Record<string, unknown>;
+  credentialsId: string;
+}): void => {
+  if ((credentials as any)?.error || !(credentials as any)?.access_token) return;
+  const enhancedCredentials = {
+    ...credentials,
+    created_at: Date.now()
+  };
+  oauth2Store.updateCredentialsForCollection({ collectionUid, url, credentials: enhancedCredentials, credentialsId });
+};
+
+export const clearOauth2Credentials = ({ collectionUid, url, credentialsId }: {
+  collectionUid: string;
+  url: string;
+  credentialsId: string;
+}): void => {
+  oauth2Store.clearCredentialsForCollection({ collectionUid, url, credentialsId });
+};
+
+export const getStoredOauth2Credentials = ({ collectionUid, url, credentialsId }: {
+  collectionUid: string;
+  url: string;
+  credentialsId: string;
+}): Record<string, unknown> | null => {
+  try {
+    return oauth2Store.getCredentialsForCollection({ collectionUid, url, credentialsId }) as Record<string, unknown> | null;
+  } catch {
+    return null;
+  }
+};
+
+// --- Token expiry ---
+
+export const isTokenExpired = (credentials: Record<string, unknown> | null): boolean => {
+  if (!credentials?.access_token) {
+    return true;
+  }
+  if (!credentials?.expires_in || !credentials.created_at) {
+    return false;
+  }
+  const expiryTime = (credentials.created_at as number) + (credentials.expires_in as number) * 1000;
+  return Date.now() > expiryTime;
+};
+
+// --- PKCE helpers ---
+
+export const generateCodeVerifier = (): string => {
+  return crypto.randomBytes(22).toString('hex');
+};
+
+export const generateCodeChallenge = (codeVerifier: string): string => {
+  const hash = crypto.createHash('sha256');
+  hash.update(codeVerifier);
+  return hash.digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+};
+
+// --- Additional parameters ---
+
+export const applyAdditionalParameters = (
+  requestConfig: { url: string; headers: Record<string, string> },
+  data: Record<string, string>,
+  params: OAuthAdditionalParameter[] = []
+): void => {
+  params.forEach((param) => {
+    if (!param.enabled || !param.name) return;
+
+    switch (param.sendIn) {
+      case 'headers':
+        requestConfig.headers[param.name] = param.value || '';
+        break;
+      case 'queryparams':
+        try {
+          const url = new URL(requestConfig.url);
+          url.searchParams.append(param.name, param.value || '');
+          requestConfig.url = url.href;
+        } catch {
+          console.error('invalid token/refresh url', requestConfig.url);
+        }
+        break;
+      case 'body':
+        data[param.name] = param.value || '';
+        break;
+    }
+  });
+};
+
+// --- Safe JSON parsing ---
+
+const safeParseJSONBuffer = (data: unknown): Record<string, unknown> | null => {
+  try {
+    const str = Buffer.isBuffer(data) ? data.toString() : data;
+    return typeof str === 'string' ? JSON.parse(str) : str as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+};
+
+// --- Token fetching core ---
+
+const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ credentials: Record<string, unknown> | null; requestDetails: Record<string, unknown> }> => {
+  let requestDetails: Record<string, unknown> = { request: {}, response: {} };
+  let parsedResponseData: Record<string, unknown> | null = null;
+
+  try {
+    const response = await axios(requestConfig as AxiosRequestConfig);
+    parsedResponseData = safeParseJSONBuffer(response.data);
+    requestDetails = {
+      request: {
+        url: requestConfig.url,
+        headers: requestConfig.headers,
+        data: requestConfig.data,
+        method: 'POST'
+      },
+      response: {
+        url: response.config?.url,
+        headers: response.headers,
+        data: parsedResponseData,
+        status: response.status,
+        statusText: response.statusText
+      },
+      requestId: Date.now().toString(),
+      fromCache: false,
+      completed: true
+    };
+  } catch (error: any) {
+    if (error.response) {
+      const errorData = safeParseJSONBuffer(error.response.data);
+      requestDetails = {
+        request: {
+          url: requestConfig.url,
+          headers: requestConfig.headers,
+          data: requestConfig.data,
+          method: 'POST'
+        },
+        response: {
+          url: error.response.config?.url,
+          headers: error.response.headers,
+          data: errorData,
+          status: error.response.status,
+          statusText: error.response.statusText,
+          error: errorData
+        },
+        requestId: Date.now().toString(),
+        fromCache: false,
+        completed: true
+      };
+      parsedResponseData = errorData;
+    } else {
+      requestDetails = {
+        request: {
+          url: requestConfig.url,
+          headers: requestConfig.headers,
+          data: requestConfig.data
+        },
+        response: {
+          status: '-',
+          statusText: error?.code || 'Unknown error',
+          headers: {},
+          data: null
+        },
+        requestId: Date.now().toString(),
+        fromCache: false,
+        completed: true
+      };
+    }
+  }
+
+  return { credentials: parsedResponseData, requestDetails };
+};
+
+// --- Build request config helpers ---
+
+const buildBaseRequestConfig = (url: string): TokenRequestConfig => ({
+  method: 'POST',
+  url,
+  headers: {
+    'content-type': 'application/x-www-form-urlencoded',
+    'Accept': 'application/json'
+  },
+  data: '',
+  responseType: 'arraybuffer'
+});
+
+const applyBasicAuthHeader = (headers: Record<string, string>, clientId: string, clientSecret?: string | null): void => {
+  const secret = clientSecret ?? '';
+  headers['Authorization'] = `Basic ${Buffer.from(`${clientId}:${secret}`).toString('base64')}`;
+};
+
+const applyClientCredentialsToData = (
+  data: Record<string, string>,
+  clientId: string,
+  clientSecret: string | undefined | null,
+  credentialsPlacement: string
+): void => {
+  if (credentialsPlacement !== 'basic_auth_header') {
+    data.client_id = clientId;
+  }
+  if (clientSecret && clientSecret.trim() !== '' && credentialsPlacement !== 'basic_auth_header') {
+    data.client_secret = clientSecret;
+  }
+};
+
+// --- Cached token resolution ---
+
+const resolveStoredCredentials = async ({
+  collectionUid,
+  url,
+  credentialsId,
+  autoRefreshToken,
+  autoFetchToken,
+  requestCopy,
+  forceFetch
+}: {
+  collectionUid: string;
+  url: string;
+  credentialsId: string;
+  autoRefreshToken?: boolean;
+  autoFetchToken?: boolean;
+  requestCopy?: Record<string, unknown>;
+  forceFetch: boolean;
+}): Promise<{ shouldFetch: boolean; result?: OAuth2TokenResult }> => {
+  if (forceFetch) return { shouldFetch: true };
+
+  const storedCredentials = getStoredOauth2Credentials({ collectionUid, url, credentialsId });
+
+  if (storedCredentials) {
+    if (!isTokenExpired(storedCredentials)) {
+      return { shouldFetch: false, result: { collectionUid, url, credentials: storedCredentials, credentialsId } };
+    }
+
+    // Token is expired
+    if (autoRefreshToken && storedCredentials.refresh_token && requestCopy) {
+      try {
+        const refreshed = await refreshOauth2Token({ requestCopy, collectionUid });
+        return { shouldFetch: false, result: { collectionUid, url, credentials: refreshed.credentials, credentialsId } };
+      } catch {
+        clearOauth2Credentials({ collectionUid, url, credentialsId });
+        if (autoFetchToken) return { shouldFetch: true };
+        return { shouldFetch: false, result: { collectionUid, url, credentials: storedCredentials, credentialsId } };
+      }
+    } else if (autoRefreshToken && !storedCredentials.refresh_token) {
+      if (autoFetchToken) {
+        clearOauth2Credentials({ collectionUid, url, credentialsId });
+        return { shouldFetch: true };
+      }
+      return { shouldFetch: false, result: { collectionUid, url, credentials: storedCredentials, credentialsId } };
+    } else if (!autoRefreshToken && autoFetchToken) {
+      clearOauth2Credentials({ collectionUid, url, credentialsId });
+      return { shouldFetch: true };
+    }
+    // No auto-refresh, no auto-fetch: return expired token
+    return { shouldFetch: false, result: { collectionUid, url, credentials: storedCredentials, credentialsId } };
+  }
+
+  // No stored credentials
+  if (autoFetchToken) return { shouldFetch: true };
+  return { shouldFetch: false, result: { collectionUid, url, credentials: null, credentialsId } };
+};
+
+// --- Grant type implementations ---
+
+export const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, forceFetch = false }: {
+  request: Record<string, unknown>;
+  collectionUid: string;
+  forceFetch?: boolean;
+}): Promise<OAuth2TokenResult> => {
+  const oAuth = (request.oauth2 || {}) as OAuth2;
+  const {
+    clientId,
+    clientSecret,
+    scope,
+    credentialsPlacement = 'basic_auth_header',
+    credentialsId = 'default',
+    autoRefreshToken,
+    autoFetchToken,
+    additionalParameters
+  } = oAuth;
+  const url = oAuth.accessTokenUrl;
+
+  if (!url) {
+    return { error: 'Access Token URL is required for OAuth2 client credentials flow', credentials: null, url: url || '', credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!clientId) {
+    return { error: 'Client ID is required for OAuth2 client credentials flow', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  const resolved = await resolveStoredCredentials({
+    collectionUid, url, credentialsId: credentialsId || 'default',
+    autoRefreshToken: autoRefreshToken ?? undefined,
+    autoFetchToken: autoFetchToken ?? undefined,
+    requestCopy: request, forceFetch
+  });
+  if (!resolved.shouldFetch && resolved.result) return resolved.result;
+
+  // Fetch new token
+  const requestConfig = buildBaseRequestConfig(url);
+  if (credentialsPlacement === 'basic_auth_header') {
+    applyBasicAuthHeader(requestConfig.headers, clientId, clientSecret);
+  }
+
+  const data: Record<string, string> = { grant_type: 'client_credentials' };
+  applyClientCredentialsToData(data, clientId, clientSecret, credentialsPlacement || 'basic_auth_header');
+  if (scope && scope.trim() !== '') data.scope = scope;
+
+  if (additionalParameters?.token?.length) {
+    applyAdditionalParameters(requestConfig, data, additionalParameters.token as OAuthAdditionalParameter[]);
+  }
+  requestConfig.data = qs.stringify(data);
+
+  const debugInfo: { data: unknown[] } = { data: [] };
+  const { credentials, requestDetails } = await fetchTokenFromUrl(requestConfig);
+  debugInfo.data.push(requestDetails);
+
+  if (credentials) {
+    persistOauth2Credentials({ collectionUid, url, credentials, credentialsId: credentialsId || 'default' });
+  }
+  return { collectionUid, url, credentials, credentialsId: credentialsId || 'default', debugInfo };
+};
+
+export const getOAuth2TokenUsingPasswordCredentials = async ({ request, collectionUid, forceFetch = false }: {
+  request: Record<string, unknown>;
+  collectionUid: string;
+  forceFetch?: boolean;
+}): Promise<OAuth2TokenResult> => {
+  const oAuth = (request.oauth2 || {}) as OAuth2;
+  const {
+    username,
+    password,
+    clientId,
+    clientSecret,
+    scope,
+    credentialsPlacement = 'basic_auth_header',
+    credentialsId = 'default',
+    autoRefreshToken,
+    autoFetchToken,
+    additionalParameters
+  } = oAuth;
+  const url = oAuth.accessTokenUrl;
+
+  if (!url) {
+    return { error: 'Access Token URL is required for OAuth2 password credentials flow', credentials: null, url: url || '', credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!username) {
+    return { error: 'Username is required for OAuth2 password credentials flow', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!password) {
+    return { error: 'Password is required for OAuth2 password credentials flow', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!clientId) {
+    return { error: 'Client ID is required for OAuth2 password credentials flow', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  const resolved = await resolveStoredCredentials({
+    collectionUid, url, credentialsId: credentialsId || 'default',
+    autoRefreshToken: autoRefreshToken ?? undefined,
+    autoFetchToken: autoFetchToken ?? undefined,
+    requestCopy: request, forceFetch
+  });
+  if (!resolved.shouldFetch && resolved.result) return resolved.result;
+
+  // Fetch new token
+  const requestConfig = buildBaseRequestConfig(url);
+  if (credentialsPlacement === 'basic_auth_header') {
+    applyBasicAuthHeader(requestConfig.headers, clientId, clientSecret);
+  }
+
+  const data: Record<string, string> = {
+    grant_type: 'password',
+    username,
+    password
+  };
+  applyClientCredentialsToData(data, clientId, clientSecret, credentialsPlacement || 'basic_auth_header');
+  if (scope && scope.trim() !== '') data.scope = scope;
+
+  if (additionalParameters?.token?.length) {
+    applyAdditionalParameters(requestConfig, data, additionalParameters.token as OAuthAdditionalParameter[]);
+  }
+  requestConfig.data = qs.stringify(data);
+
+  const debugInfo: { data: unknown[] } = { data: [] };
+  const { credentials, requestDetails } = await fetchTokenFromUrl(requestConfig);
+  debugInfo.data.push(requestDetails);
+
+  if (credentials) {
+    persistOauth2Credentials({ collectionUid, url, credentials, credentialsId: credentialsId || 'default' });
+  }
+  return { collectionUid, url, credentials, credentialsId: credentialsId || 'default', debugInfo };
+};
+
+// --- Authorization code grant ---
+
+export const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, forceFetch = false }: {
+  request: Record<string, unknown>;
+  collectionUid: string;
+  forceFetch?: boolean;
+}): Promise<OAuth2TokenResult> => {
+  const oAuth = (request.oauth2 || {}) as OAuth2;
+  const {
+    clientId,
+    clientSecret,
+    callbackUrl,
+    scope,
+    state,
+    pkce,
+    credentialsPlacement = 'basic_auth_header',
+    authorizationUrl,
+    credentialsId = 'default',
+    autoRefreshToken,
+    autoFetchToken,
+    additionalParameters
+  } = oAuth;
+  const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+  const url = oAuth.accessTokenUrl;
+
+  if (!authorizationUrl) {
+    return { error: 'Authorization URL is required for OAuth2 authorization code flow', credentials: null, url: url || '', credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!url) {
+    return { error: 'Access Token URL is required for OAuth2 authorization code flow', credentials: null, url: authorizationUrl, credentialsId: credentialsId || 'default', collectionUid };
+  }
+  if (!clientId) {
+    return { error: 'Client ID is required for OAuth2 authorization code flow', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  const resolved = await resolveStoredCredentials({
+    collectionUid, url, credentialsId: credentialsId || 'default',
+    autoRefreshToken: autoRefreshToken ?? undefined,
+    autoFetchToken: autoFetchToken ?? undefined,
+    requestCopy: request, forceFetch
+  });
+  if (!resolved.shouldFetch && resolved.result) return resolved.result;
+
+  // Generate PKCE values
+  let codeVerifier: string | undefined;
+  let codeChallenge: string | undefined;
+  if (pkce) {
+    codeVerifier = generateCodeVerifier();
+    codeChallenge = generateCodeChallenge(codeVerifier);
+  }
+
+  // Open browser and wait for authorization code
+  const authResult: AuthorizationResult = await getOAuth2AuthorizationCode({
+    authorizationUrl,
+    callbackUrl: effectiveCallbackUrl,
+    clientId,
+    scope: scope || undefined,
+    state: state || undefined,
+    pkce: pkce || false,
+    codeChallenge,
+    additionalParameters: additionalParameters?.authorization as OAuthAdditionalParameter[] || undefined
+  });
+
+  if (!authResult.authorizationCode) {
+    return { error: 'No authorization code received', credentials: null, url, credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  // Exchange authorization code for token
+  const requestConfig = buildBaseRequestConfig(url);
+  if (credentialsPlacement === 'basic_auth_header') {
+    applyBasicAuthHeader(requestConfig.headers, clientId, clientSecret);
+  }
+
+  const data: Record<string, string> = {
+    grant_type: 'authorization_code',
+    code: authResult.authorizationCode,
+    redirect_uri: effectiveCallbackUrl
+  };
+  applyClientCredentialsToData(data, clientId, clientSecret, credentialsPlacement || 'basic_auth_header');
+  if (pkce && codeVerifier) {
+    data.code_verifier = codeVerifier;
+  }
+
+  if (additionalParameters?.token?.length) {
+    applyAdditionalParameters(requestConfig, data, additionalParameters.token as OAuthAdditionalParameter[]);
+  }
+  requestConfig.data = qs.stringify(data);
+
+  const debugInfo: { data: unknown[] } = { data: [] };
+  const { credentials, requestDetails } = await fetchTokenFromUrl(requestConfig);
+  debugInfo.data.push(requestDetails);
+
+  if (credentials) {
+    persistOauth2Credentials({ collectionUid, url, credentials, credentialsId: credentialsId || 'default' });
+  }
+  return { collectionUid, url, credentials, credentialsId: credentialsId || 'default', debugInfo };
+};
+
+// --- Implicit grant ---
+
+export const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceFetch = false }: {
+  request: Record<string, unknown>;
+  collectionUid: string;
+  forceFetch?: boolean;
+}): Promise<OAuth2TokenResult> => {
+  const oAuth = (request.oauth2 || {}) as OAuth2;
+  const {
+    authorizationUrl,
+    clientId,
+    scope,
+    state,
+    callbackUrl,
+    credentialsId = 'default',
+    autoFetchToken,
+    additionalParameters
+  } = oAuth;
+  const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+
+  if (!authorizationUrl) {
+    return { error: 'Authorization URL is required for OAuth2 implicit flow', credentials: null, url: authorizationUrl || '', credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  // Check stored credentials
+  if (!forceFetch) {
+    const stored = getStoredOauth2Credentials({ collectionUid, url: authorizationUrl, credentialsId: credentialsId || 'default' });
+    if (stored) {
+      if (!isTokenExpired(stored)) {
+        return { collectionUid, url: authorizationUrl, credentials: stored, credentialsId: credentialsId || 'default' };
+      }
+      // Expired — implicit flow has no refresh tokens
+      if (autoFetchToken) {
+        clearOauth2Credentials({ collectionUid, url: authorizationUrl, credentialsId: credentialsId || 'default' });
+      } else {
+        return { collectionUid, url: authorizationUrl, credentials: stored, credentialsId: credentialsId || 'default' };
+      }
+    } else if (!autoFetchToken) {
+      return { collectionUid, url: authorizationUrl, credentials: null, credentialsId: credentialsId || 'default' };
+    }
+  }
+
+  // Open browser for implicit flow
+  const authResult: AuthorizationResult = await getOAuth2ImplicitToken({
+    authorizationUrl,
+    callbackUrl: effectiveCallbackUrl,
+    clientId: clientId || '',
+    scope: scope || undefined,
+    state: state || undefined,
+    additionalParameters: additionalParameters?.authorization as OAuthAdditionalParameter[] || undefined
+  });
+
+  if (!authResult.implicitTokens?.access_token) {
+    return { error: 'No access token received from authorization server', credentials: null, url: authorizationUrl, credentialsId: credentialsId || 'default', collectionUid };
+  }
+
+  const credentials: Record<string, unknown> = {
+    access_token: authResult.implicitTokens.access_token,
+    token_type: authResult.implicitTokens.token_type || 'Bearer',
+    state: authResult.implicitTokens.state || '',
+    ...(authResult.implicitTokens.expires_in ? { expires_in: parseInt(authResult.implicitTokens.expires_in) } : {}),
+    ...(authResult.implicitTokens.scope ? { scope: authResult.implicitTokens.scope } : {}),
+    created_at: Date.now()
+  };
+
+  persistOauth2Credentials({ collectionUid, url: authorizationUrl, credentials, credentialsId: credentialsId || 'default' });
+  return { collectionUid, url: authorizationUrl, credentials, credentialsId: credentialsId || 'default' };
+};
+
+// --- Refresh token ---
+
+export const refreshOauth2Token = async ({ requestCopy, collectionUid }: {
+  requestCopy: Record<string, unknown>;
+  collectionUid: string;
+}): Promise<OAuth2TokenResult> => {
+  const oAuth = (requestCopy.oauth2 || {}) as OAuth2;
+  const { clientId, clientSecret, credentialsId = 'default', credentialsPlacement, additionalParameters } = oAuth;
+  const url = oAuth.refreshTokenUrl || oAuth.accessTokenUrl;
+
+  if (!url) {
+    return { collectionUid, url: '', credentials: null, credentialsId: credentialsId || 'default' };
+  }
+
+  const credentials = getStoredOauth2Credentials({ collectionUid, url, credentialsId: credentialsId || 'default' });
+  if (!credentials?.refresh_token) {
+    clearOauth2Credentials({ collectionUid, url, credentialsId: credentialsId || 'default' });
+    return { collectionUid, url, credentials: null, credentialsId: credentialsId || 'default' };
+  }
+
+  const requestConfig = buildBaseRequestConfig(url);
+  if (credentialsPlacement === 'basic_auth_header' && clientId) {
+    applyBasicAuthHeader(requestConfig.headers, clientId, clientSecret);
+  }
+
+  const data: Record<string, string> = {
+    grant_type: 'refresh_token',
+    refresh_token: credentials.refresh_token as string
+  };
+  if (clientId) {
+    applyClientCredentialsToData(data, clientId, clientSecret, credentialsPlacement || 'basic_auth_header');
+  }
+
+  if (additionalParameters?.refresh?.length) {
+    applyAdditionalParameters(requestConfig, data, additionalParameters.refresh as OAuthAdditionalParameter[]);
+  }
+  requestConfig.data = qs.stringify(data);
+
+  const debugInfo: { data: unknown[] } = { data: [] };
+  const { credentials: newCredentials, requestDetails } = await fetchTokenFromUrl(requestConfig);
+  debugInfo.data.push(requestDetails);
+
+  if (!newCredentials || (newCredentials as any)?.error) {
+    clearOauth2Credentials({ collectionUid, url, credentialsId: credentialsId || 'default' });
+    return { collectionUid, url, credentials: null, credentialsId: credentialsId || 'default', debugInfo };
+  }
+
+  persistOauth2Credentials({ collectionUid, url, credentials: newCredentials, credentialsId: credentialsId || 'default' });
+  return { collectionUid, url, credentials: newCredentials, credentialsId: credentialsId || 'default', debugInfo };
+};
+
+// --- Token placement ---
+
+export const placeOAuth2Token = (
+  request: { headers?: Record<string, string>; url?: string },
+  credentials: Record<string, unknown>,
+  oauth2Config: OAuth2
+): void => {
+  const { tokenPlacement, tokenHeaderPrefix = 'Bearer', tokenQueryKey = 'access_token' } = oauth2Config;
+  const tokenSource = (oauth2Config as any).tokenSource || 'access_token';
+  const tokenValue = tokenSource === 'id_token'
+    ? (credentials.id_token as string)
+    : (credentials.access_token as string);
+
+  if (!tokenValue) return;
+
+  if (tokenPlacement === 'header' || !tokenPlacement) {
+    if (!request.headers) request.headers = {};
+    const prefix = tokenHeaderPrefix || 'Bearer';
+    request.headers['Authorization'] = `${prefix} ${tokenValue}`.trim();
+  } else {
+    // Query parameter placement
+    const key = tokenQueryKey || 'access_token';
+    try {
+      const url = new URL(request.url || '');
+      url.searchParams.append(key, tokenValue);
+      request.url = url.href;
+    } catch {
+      // If URL parsing fails, append manually
+      const separator = request.url?.includes('?') ? '&' : '?';
+      request.url = `${request.url}${separator}${encodeURIComponent(key)}=${encodeURIComponent(tokenValue)}`;
+    }
+  }
+};
+
+export {
+  BRUNO_OAUTH2_CALLBACK_URL,
+  oauth2Store
+};

--- a/src/extension/utils/oauth2.ts
+++ b/src/extension/utils/oauth2.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, ResponseType } from 'axios';
+import axios, { AxiosError, AxiosRequestConfig, ResponseType } from 'axios';
 import crypto from 'crypto';
 import qs from 'qs';
 import Oauth2Store from '../store/oauth2';
@@ -10,11 +10,9 @@ import {
 } from '../ipc/network/authorize-user-in-system-browser';
 
 const BRUNO_OAUTH2_CALLBACK_URL = 'https://oauth.usebruno.com/vscode/callback';
-// const BRUNO_OAUTH2_CALLBACK_URL = 'http://localhost:8081/vscode/callback';
 
 const oauth2Store = new Oauth2Store();
 
-// --- Types ---
 
 export interface OAuth2TokenResult {
   collectionUid: string;
@@ -33,7 +31,6 @@ interface TokenRequestConfig {
   responseType: ResponseType;
 }
 
-// --- Store wrappers ---
 
 export const persistOauth2Credentials = ({ collectionUid, url, credentials, credentialsId }: {
   collectionUid: string;
@@ -41,7 +38,7 @@ export const persistOauth2Credentials = ({ collectionUid, url, credentials, cred
   credentials: Record<string, unknown>;
   credentialsId: string;
 }): void => {
-  if ((credentials as any)?.error || !(credentials as any)?.access_token) return;
+  if (credentials.error || !credentials.access_token) return;
   const enhancedCredentials = {
     ...credentials,
     created_at: Date.now()
@@ -69,7 +66,6 @@ export const getStoredOauth2Credentials = ({ collectionUid, url, credentialsId }
   }
 };
 
-// --- Token expiry ---
 
 export const isTokenExpired = (credentials: Record<string, unknown> | null): boolean => {
   if (!credentials?.access_token) {
@@ -82,7 +78,6 @@ export const isTokenExpired = (credentials: Record<string, unknown> | null): boo
   return Date.now() > expiryTime;
 };
 
-// --- PKCE helpers ---
 
 export const generateCodeVerifier = (): string => {
   return crypto.randomBytes(22).toString('hex');
@@ -97,7 +92,6 @@ export const generateCodeChallenge = (codeVerifier: string): string => {
     .replace(/=/g, '');
 };
 
-// --- Additional parameters ---
 
 export const applyAdditionalParameters = (
   requestConfig: { url: string; headers: Record<string, string> },
@@ -127,7 +121,6 @@ export const applyAdditionalParameters = (
   });
 };
 
-// --- Safe JSON parsing ---
 
 const safeParseJSONBuffer = (data: unknown): Record<string, unknown> | null => {
   try {
@@ -138,7 +131,6 @@ const safeParseJSONBuffer = (data: unknown): Record<string, unknown> | null => {
   }
 };
 
-// --- Token fetching core ---
 
 const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ credentials: Record<string, unknown> | null; requestDetails: Record<string, unknown> }> => {
   let requestDetails: Record<string, unknown> = { request: {}, response: {} };
@@ -165,9 +157,10 @@ const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ c
       fromCache: false,
       completed: true
     };
-  } catch (error: any) {
-    if (error.response) {
-      const errorData = safeParseJSONBuffer(error.response.data);
+  } catch (error: unknown) {
+    const axiosError = error as AxiosError;
+    if (axiosError.response) {
+      const errorData = safeParseJSONBuffer(axiosError.response.data);
       requestDetails = {
         request: {
           url: requestConfig.url,
@@ -176,11 +169,11 @@ const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ c
           method: 'POST'
         },
         response: {
-          url: error.response.config?.url,
-          headers: error.response.headers,
+          url: axiosError.response.config?.url,
+          headers: axiosError.response.headers,
           data: errorData,
-          status: error.response.status,
-          statusText: error.response.statusText,
+          status: axiosError.response.status,
+          statusText: axiosError.response.statusText,
           error: errorData
         },
         requestId: Date.now().toString(),
@@ -197,7 +190,7 @@ const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ c
         },
         response: {
           status: '-',
-          statusText: error?.code || 'Unknown error',
+          statusText: axiosError?.code || 'Unknown error',
           headers: {},
           data: null
         },
@@ -211,7 +204,6 @@ const fetchTokenFromUrl = async (requestConfig: TokenRequestConfig): Promise<{ c
   return { credentials: parsedResponseData, requestDetails };
 };
 
-// --- Build request config helpers ---
 
 const buildBaseRequestConfig = (url: string): TokenRequestConfig => ({
   method: 'POST',
@@ -243,7 +235,6 @@ const applyClientCredentialsToData = (
   }
 };
 
-// --- Cached token resolution ---
 
 const resolveStoredCredentials = async ({
   collectionUid,
@@ -299,8 +290,6 @@ const resolveStoredCredentials = async ({
   if (autoFetchToken) return { shouldFetch: true };
   return { shouldFetch: false, result: { collectionUid, url, credentials: null, credentialsId } };
 };
-
-// --- Grant type implementations ---
 
 export const getOAuth2TokenUsingClientCredentials = async ({ request, collectionUid, forceFetch = false }: {
   request: Record<string, unknown>;
@@ -430,7 +419,6 @@ export const getOAuth2TokenUsingPasswordCredentials = async ({ request, collecti
   return { collectionUid, url, credentials, credentialsId: credentialsId || 'default', debugInfo };
 };
 
-// --- Authorization code grant ---
 
 export const getOAuth2TokenUsingAuthorizationCode = async ({ request, collectionUid, forceFetch = false }: {
   request: Record<string, unknown>;
@@ -529,7 +517,6 @@ export const getOAuth2TokenUsingAuthorizationCode = async ({ request, collection
   return { collectionUid, url, credentials, credentialsId: credentialsId || 'default', debugInfo };
 };
 
-// --- Implicit grant ---
 
 export const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid, forceFetch = false }: {
   request: Record<string, unknown>;
@@ -599,7 +586,6 @@ export const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid,
   return { collectionUid, url: authorizationUrl, credentials, credentialsId: credentialsId || 'default' };
 };
 
-// --- Refresh token ---
 
 export const refreshOauth2Token = async ({ requestCopy, collectionUid }: {
   requestCopy: Record<string, unknown>;
@@ -641,7 +627,7 @@ export const refreshOauth2Token = async ({ requestCopy, collectionUid }: {
   const { credentials: newCredentials, requestDetails } = await fetchTokenFromUrl(requestConfig);
   debugInfo.data.push(requestDetails);
 
-  if (!newCredentials || (newCredentials as any)?.error) {
+  if (!newCredentials || newCredentials.error) {
     clearOauth2Credentials({ collectionUid, url, credentialsId: credentialsId || 'default' });
     return { collectionUid, url, credentials: null, credentialsId: credentialsId || 'default', debugInfo };
   }
@@ -650,7 +636,6 @@ export const refreshOauth2Token = async ({ requestCopy, collectionUid }: {
   return { collectionUid, url, credentials: newCredentials, credentialsId: credentialsId || 'default', debugInfo };
 };
 
-// --- Token placement ---
 
 export const placeOAuth2Token = (
   request: { headers?: Record<string, string>; url?: string },
@@ -658,7 +643,7 @@ export const placeOAuth2Token = (
   oauth2Config: OAuth2
 ): void => {
   const { tokenPlacement, tokenHeaderPrefix = 'Bearer', tokenQueryKey = 'access_token' } = oauth2Config;
-  const tokenSource = (oauth2Config as any).tokenSource || 'access_token';
+  const tokenSource = oauth2Config.tokenSource || 'access_token';
   const tokenValue = tokenSource === 'id_token'
     ? (credentials.id_token as string)
     : (credentials.access_token as string);

--- a/src/extension/utils/oauth2.ts
+++ b/src/extension/utils/oauth2.ts
@@ -9,7 +9,8 @@ import {
   type AuthorizationResult
 } from '../ipc/network/authorize-user-in-system-browser';
 
-const BRUNO_OAUTH2_CALLBACK_URL = 'https://oauth.usebruno.com/callback';
+const BRUNO_OAUTH2_CALLBACK_URL = 'https://oauth.usebruno.com/vscode/callback';
+// const BRUNO_OAUTH2_CALLBACK_URL = 'http://localhost:8081/vscode/callback';
 
 const oauth2Store = new Oauth2Store();
 
@@ -451,7 +452,8 @@ export const getOAuth2TokenUsingAuthorizationCode = async ({ request, collection
     autoFetchToken,
     additionalParameters
   } = oAuth;
-  const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+  // VS Code always uses Bruno's callback URL with source=vscode param
+  const effectiveCallbackUrl = BRUNO_OAUTH2_CALLBACK_URL;
   const url = oAuth.accessTokenUrl;
 
   if (!authorizationUrl) {
@@ -545,7 +547,8 @@ export const getOAuth2TokenUsingImplicitGrant = async ({ request, collectionUid,
     autoFetchToken,
     additionalParameters
   } = oAuth;
-  const effectiveCallbackUrl = callbackUrl && callbackUrl.length ? callbackUrl : BRUNO_OAUTH2_CALLBACK_URL;
+
+  const effectiveCallbackUrl = BRUNO_OAUTH2_CALLBACK_URL;
 
   if (!authorizationUrl) {
     return { error: 'Authorization URL is required for OAuth2 implicit flow', credentials: null, url: authorizationUrl || '', credentialsId: credentialsId || 'default', collectionUid };

--- a/src/webview/components/CollectionSettings/Auth/AuthMode/index.tsx
+++ b/src/webview/components/CollectionSettings/Auth/AuthMode/index.tsx
@@ -58,11 +58,11 @@ const AuthMode = ({
       label: 'NTLM Auth',
       onClick: () => onModeChange('ntlm')
     },
-    // {
-    //   id: 'oauth2',
-    //   label: 'OAuth 2.0',
-    //   onClick: () => onModeChange('oauth2')
-    // },
+    {
+      id: 'oauth2',
+      label: 'OAuth 2.0',
+      onClick: () => onModeChange('oauth2')
+    },
     {
       id: 'apikey',
       label: 'API Key',

--- a/src/webview/components/CollectionSettings/Auth/index.tsx
+++ b/src/webview/components/CollectionSettings/Auth/index.tsx
@@ -44,9 +44,9 @@ const Auth = ({
       case 'ntlm': {
         return <NTLMAuth collection={collection} />;
       }
-      // case 'oauth2': {
-      //   return <OAuth2 collection={collection} />;
-      // }
+      case 'oauth2': {
+        return <OAuth2 collection={collection} />;
+      }
       case 'wsse': {
         return <WsseAuth collection={collection} />;
       }

--- a/src/webview/components/FolderSettings/Auth/index.tsx
+++ b/src/webview/components/FolderSettings/Auth/index.tsx
@@ -178,19 +178,19 @@ const Auth = ({
           />
         );
       }
-      // case 'oauth2': {
-      //   return (
-      //     <>
-      //       <GrantTypeSelector
-      //         request={request}
-      //         updateAuth={updateFolderAuth}
-      //         collection={collection}
-      //         item={folder}
-      //       />
-      //       <GrantTypeComponentMap collection={collection} folder={folder} />
-      //     </>
-      //   );
-      // }
+      case 'oauth2': {
+        return (
+          <>
+            <GrantTypeSelector
+              request={request}
+              updateAuth={updateFolderAuth}
+              collection={collection}
+              item={folder}
+            />
+            <GrantTypeComponentMap collection={collection} folder={folder} />
+          </>
+        );
+      }
       case 'inherit': {
         const source = getEffectiveAuthSource();
         return (

--- a/src/webview/components/FolderSettings/AuthMode/index.tsx
+++ b/src/webview/components/FolderSettings/AuthMode/index.tsx
@@ -56,11 +56,11 @@ const AuthMode = ({
       label: 'NTLM Auth',
       onClick: () => onModeChange('ntlm')
     },
-    // {
-    //   id: 'oauth2',
-    //   label: 'OAuth 2.0',
-    //   onClick: () => onModeChange('oauth2')
-    // },
+    {
+      id: 'oauth2',
+      label: 'OAuth 2.0',
+      onClick: () => onModeChange('oauth2')
+    },
     {
       id: 'wsse',
       label: 'WSSE Auth',

--- a/src/webview/components/RequestPane/Auth/AuthMode/index.tsx
+++ b/src/webview/components/RequestPane/Auth/AuthMode/index.tsx
@@ -56,11 +56,11 @@ const AuthMode = ({
       label: 'NTLM Auth',
       onClick: () => onModeChange('ntlm')
     },
-    // {
-    //   id: 'oauth2',
-    //   label: 'OAuth 2.0',
-    //   onClick: () => onModeChange('oauth2')
-    // },
+    {
+      id: 'oauth2',
+      label: 'OAuth 2.0',
+      onClick: () => onModeChange('oauth2')
+    },
     {
       id: 'wsse',
       label: 'WSSE Auth',
@@ -85,7 +85,7 @@ const AuthMode = ({
 
   return (
     <StyledWrapper>
-      <div className="inline-flex items-center cursor-pointer auth-mode-selector">
+      <div className="inline-flex items-center cursor-pointer auth-mode-selector" data-testid="oauth2-auth-mode-selector">
         <MenuDropdown
           items={menuItems}
           placement="bottom-end"

--- a/src/webview/components/RequestPane/Auth/OAuth2/AdditionalParams/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/AdditionalParams/index.tsx
@@ -252,7 +252,7 @@ const AdditionalParams = ({
                     }}
                     className="mousetrap bg-transparent"
                   >
-                    {sendInOptionsMap[grantType || 'authorization_code'][activeTab].map((optionValue: any) => <option key={optionValue} value={optionValue}>
+                    {(sendInOptionsMap[grantType || 'authorization_code']?.[activeTab] || ['headers', 'queryparams', 'body']).map((optionValue: any) => <option key={optionValue} value={optionValue}>
                       {optionValue}
                     </option>)}
                   </select>

--- a/src/webview/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/AuthorizationCode/index.tsx
@@ -170,40 +170,38 @@ const OAuth2AuthorizationCode = ({
       </div>
       <div className="flex items-center gap-4 w-full" key="input-callbackUrl">
         <label className="block min-w-[140px]">Callback URL</label>
-        <div className="flex flex-col gap-1 w-full">
-          <div className="single-line-editor-wrapper flex-1 flex items-center">
+        <div className="flex flex-col gap-1 flex-1 min-w-0" title="Callback URL is managed by Bruno and cannot be changed in VS Code">
+          <div className="single-line-editor-wrapper flex-1 flex items-center opacity-50">
             <SingleLineEditor
-              value={callbackUrl}
+              value={callbackUrl || 'https://oauth.usebruno.com/vscode/callback'}
               theme={storedTheme}
               onSave={handleSave}
-              onChange={(val: any) => handleChange('callbackUrl', val)}
+              onChange={() => {}}
               onRun={handleRun}
               collection={collection}
               item={item}
-              placeholder={useSystemBrowser ? 'https://oauth.usebruno.com/callback' : undefined}
               isCompact
+              readOnly
             />
           </div>
+          <span className="text-xs text-muted">Managed by Bruno. Redirects via oauth.usebruno.com</span>
         </div>
       </div>
       <div className="flex items-center gap-4 w-full" key="input-use-system-browser">
         <label className="block min-w-[140px]"></label>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 opacity-50" title="VS Code always uses the system browser for OAuth authorization">
           <input
             type="checkbox"
-            checked={Boolean(useSystemBrowser)}
-            onChange={handleUseSystemBrowserToggle}
-            className="cursor-pointer"
+            checked={true}
+            disabled
+            className="cursor-not-allowed"
           />
-          <label
-            className="block cursor-pointer"
-            onClick={(e) => {
-              e.preventDefault();
-              handleUseSystemBrowserToggle({ target: { checked: !useSystemBrowser } });
-            }}
-          >
+          <label className="block cursor-not-allowed">
             Use system browser for OAuth
           </label>
+          <span title="VS Code extensions cannot embed a browser. The system browser is always used for OAuth authorization.">
+            <IconHelp size={14} className="text-gray-400" />
+          </span>
         </div>
       </div>
       {inputsConfig.map((input) => {

--- a/src/webview/components/RequestPane/Auth/OAuth2/ClientCredentials/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/ClientCredentials/index.tsx
@@ -111,7 +111,7 @@ const OAuth2ClientCredentials = ({
         const { showWarning, warningMessage } = isSensitive(value);
 
         return (
-          <div className="flex items-center gap-4 w-full" key={`input-${key}`}>
+          <div className="flex items-center gap-4 w-full" key={`input-${key}`} data-testid={`oauth2-field-${key}`}>
             <label className="block min-w-[140px]">{label}</label>
             <div className="single-line-editor-wrapper flex-1 flex items-center">
               <SingleLineEditor
@@ -130,9 +130,9 @@ const OAuth2ClientCredentials = ({
           </div>
         );
       })}
-      <div className="flex items-center gap-4 w-full" key="input-credentials-placement">
+      <div className="flex items-center gap-4 w-full" key="input-credentials-placement" data-testid="oauth2-field-credentialsPlacement">
         <label className="block min-w-[140px]">Add Credentials to</label>
-        <div className="inline-flex items-center cursor-pointer token-placement-selector">
+        <div className="inline-flex items-center cursor-pointer token-placement-selector" data-testid="oauth2-credentials-placement-selector">
           <Dropdown onCreate={onDropdownCreate} icon={<CredentialsPlacementIcon />} placement="bottom-end">
             <div
               className="dropdown-item"
@@ -163,7 +163,7 @@ const OAuth2ClientCredentials = ({
           Token
         </span>
       </div>
-      <div className="flex items-center gap-4 w-full" key="input-token-name">
+      <div className="flex items-center gap-4 w-full" key="input-token-name" data-testid="oauth2-field-credentialsId">
         <label className="block min-w-[140px]">Token ID</label>
         <div className="single-line-editor-wrapper flex-1">
           <SingleLineEditor
@@ -178,9 +178,9 @@ const OAuth2ClientCredentials = ({
           />
         </div>
       </div>
-      <div className="flex items-center gap-4 w-full" key="input-token-placement">
+      <div className="flex items-center gap-4 w-full" key="input-token-placement" data-testid="oauth2-field-tokenPlacement">
         <label className="block min-w-[140px]">Add token to</label>
-        <div className="inline-flex items-center cursor-pointer token-placement-selector w-fit">
+        <div className="inline-flex items-center cursor-pointer token-placement-selector w-fit" data-testid="oauth2-token-placement-selector">
           <Dropdown onCreate={onDropdownCreate} icon={<TokenPlacementIcon />} placement="bottom-end">
             <div
               className="dropdown-item"
@@ -206,7 +206,7 @@ const OAuth2ClientCredentials = ({
       {
         tokenPlacement === 'header'
           ? (
-              <div className="flex items-center gap-4 w-full" key="input-token-prefix">
+              <div className="flex items-center gap-4 w-full" key="input-token-prefix" data-testid="oauth2-field-tokenHeaderPrefix">
                 <label className="block min-w-[140px]">Header Prefix</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor
@@ -222,7 +222,7 @@ const OAuth2ClientCredentials = ({
               </div>
             )
           : (
-              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key">
+              <div className="flex items-center gap-4 w-full" key="input-token-query-param-key" data-testid="oauth2-field-tokenQueryKey">
                 <label className="block min-w-[140px]">Query Param Key</label>
                 <div className="single-line-editor-wrapper flex-1">
                   <SingleLineEditor
@@ -247,7 +247,7 @@ const OAuth2ClientCredentials = ({
         </span>
       </div>
 
-      <div className="flex items-center gap-4 w-full mb-4">
+      <div className="flex items-center gap-4 w-full mb-4" data-testid="oauth2-field-refreshTokenUrl">
         <label className="block min-w-[140px]">Refresh Token URL</label>
         <div className="single-line-editor-wrapper flex-1">
           <SingleLineEditor

--- a/src/webview/components/RequestPane/Auth/OAuth2/GrantTypeSelector/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/GrantTypeSelector/index.tsx
@@ -86,7 +86,7 @@ const GrantTypeSelector = ({
           Grant Type
         </span>
       </div>
-      <div className="inline-flex items-center cursor-pointer grant-type-mode-selector w-fit">
+      <div className="inline-flex items-center cursor-pointer grant-type-mode-selector w-fit" data-testid="oauth2-grant-type-selector">
         <Dropdown onCreate={onDropdownCreate} icon={<Icon />} placement="bottom-end">
           <div
             className="dropdown-item"

--- a/src/webview/components/RequestPane/Auth/OAuth2/Implicit/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/Implicit/index.tsx
@@ -135,40 +135,38 @@ const OAuth2Implicit = ({
       </div>
       <div className="flex items-center gap-4 w-full" key="input-callbackUrl">
         <label className="block min-w-[140px]">Callback URL</label>
-        <div className="flex flex-col gap-1 w-full">
-          <div className="oauth2-input-wrapper flex-1 flex items-center">
+        <div className="flex flex-col gap-1 flex-1 min-w-0" title="Callback URL is managed by Bruno and cannot be changed in VS Code">
+          <div className="oauth2-input-wrapper flex-1 flex items-center opacity-50">
             <SingleLineEditor
-              value={callbackUrl}
+              value={callbackUrl || 'https://oauth.usebruno.com/vscode/callback'}
               theme={storedTheme}
               onSave={handleSave}
-              onChange={(val: any) => handleChange('callbackUrl', val)}
+              onChange={() => {}}
               onRun={handleRun}
               collection={collection}
               item={item}
-              placeholder={useSystemBrowser ? 'https://oauth.usebruno.com/callback' : undefined}
               isCompact
+              readOnly
             />
           </div>
+          <span className="text-xs text-muted">Managed by Bruno. Redirects via oauth.usebruno.com</span>
         </div>
       </div>
       <div className="flex items-center gap-4 w-full" key="input-use-system-browser">
         <label className="block min-w-[140px]"></label>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 opacity-50" title="VS Code always uses the system browser for OAuth authorization">
           <input
             type="checkbox"
-            checked={Boolean(useSystemBrowser)}
-            onChange={handleUseSystemBrowserToggle}
-            className="cursor-pointer"
+            checked={true}
+            disabled
+            className="cursor-not-allowed"
           />
-          <label
-            className="block cursor-pointer"
-            onClick={(e) => {
-              e.preventDefault();
-              handleUseSystemBrowserToggle({ target: { checked: !useSystemBrowser } });
-            }}
-          >
+          <label className="block cursor-not-allowed">
             Use system browser for OAuth
           </label>
+          <span title="VS Code extensions cannot embed a browser. The system browser is always used for OAuth authorization.">
+            <IconHelp size={14} className="text-gray-400" />
+          </span>
         </div>
       </div>
       {inputsConfig.map((input) => {

--- a/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
@@ -152,6 +152,7 @@ const Oauth2ActionButtons = ({
         onClick={handleFetchOauth2Credentials}
         disabled={fetchingToken || refreshingToken}
         loading={fetchingToken}
+        data-testid="oauth2-get-token-btn"
       >
         Get Access Token
       </Button>
@@ -163,6 +164,7 @@ const Oauth2ActionButtons = ({
               onClick={handleRefreshAccessToken}
               disabled={fetchingToken || refreshingToken}
               loading={refreshingToken}
+              data-testid="oauth2-refresh-token-btn"
             >
               Refresh Token
             </Button>
@@ -176,6 +178,7 @@ const Oauth2ActionButtons = ({
               onClick={handleCancelAuthorization}
               icon={<IconX size={16} />}
               iconPosition="left"
+              data-testid="oauth2-cancel-auth-btn"
             >
               Cancel Authorization
             </Button>
@@ -185,6 +188,7 @@ const Oauth2ActionButtons = ({
         color="secondary"
         variant="ghost"
         onClick={handleClearCache}
+        data-testid="oauth2-clear-cache-btn"
       >
         Clear Cache
       </Button>

--- a/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
@@ -1,19 +1,20 @@
 import { useMemo, useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import toast from 'react-hot-toast';
-import { cloneDeep, find, get } from 'lodash';
-import { IconLoader2, IconX } from '@tabler/icons';
+import { cloneDeep, find } from 'lodash';
+import { IconX } from '@tabler/icons';
 import { interpolate } from '@usebruno/common';
 import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } from 'providers/ReduxStore/slices/collections/actions';
 import { getAllVariables } from 'utils/collections/index';
 import Button from 'ui/Button';
+import type { AppCollection, AppItem, OAuth2CredentialEntry } from '@bruno-types';
 
 interface Oauth2ActionButtonsProps {
-  item: unknown;
-  request: unknown;
-  collection?: unknown;
-  url?: unknown;
-  credentialsId?: string;
+  item: AppItem;
+  request: Record<string, unknown>;
+  collection: AppCollection;
+  url: string;
+  credentialsId: string;
 }
 
 const Oauth2ActionButtons = ({
@@ -22,19 +23,16 @@ const Oauth2ActionButtons = ({
   collection,
   url: accessTokenUrl,
   credentialsId
-}: any) => {
-  const { uid: collectionUid } = collection;
+}: Oauth2ActionButtonsProps) => {
+  const collectionUid = collection.uid;
 
   const dispatch = useDispatch();
-  const preferences = useSelector((state: any) => state.app.preferences);
   const [fetchingToken, toggleFetchingToken] = useState(false);
   const [refreshingToken, toggleRefreshingToken] = useState(false);
   const [fetchingAuthorizationCode, toggleFetchingAuthorizationCode] = useState(false);
 
-  const useSystemBrowser = get(preferences, 'request.oauth2.useSystemBrowser', false);
-
   useEffect(() => {
-    if (useSystemBrowser && fetchingToken) {
+    if (fetchingToken) {
       const getRequestStatus = async () => {
         try {
           const inProgress = await (dispatch(isOauth2AuthorizationRequestInProgress()) as unknown as Promise<boolean>);
@@ -45,45 +43,52 @@ const Oauth2ActionButtons = ({
       };
       getRequestStatus();
     }
-  }, [useSystemBrowser, fetchingToken, dispatch]);
+  }, [fetchingToken, dispatch]);
+
+  const allVariables = useMemo(() => getAllVariables(collection, item), [collection, item]);
 
   const interpolatedAccessTokenUrl = useMemo(() => {
-    const variables = getAllVariables(collection, item);
-    return interpolate(accessTokenUrl, variables);
-  }, [collection, item, accessTokenUrl]);
+    return (interpolate as (str: string, vars: Record<string, unknown>) => string)(accessTokenUrl, allVariables);
+  }, [accessTokenUrl, allVariables]);
 
-  const credentialsData = find(collection?.oauth2Credentials, (creds) => creds?.url == interpolatedAccessTokenUrl && creds?.collectionUid == collectionUid && creds?.credentialsId == credentialsId);
-  const creds = credentialsData?.credentials || {};
+  const credentialsData = find(
+    collection?.oauth2Credentials as OAuth2CredentialEntry[] | undefined,
+    (creds) => creds?.url === interpolatedAccessTokenUrl && creds?.collectionUid === collectionUid && creds?.credentialsId === credentialsId
+  );
+  const creds = (credentialsData?.credentials || {}) as Record<string, unknown>;
 
   const handleFetchOauth2Credentials = async () => {
-    let requestCopy = cloneDeep(request);
-    requestCopy.oauth2 = requestCopy?.auth.oauth2;
+    const requestCopy = cloneDeep(request) as Record<string, unknown>;
+    const auth = requestCopy.auth as { oauth2?: unknown } | undefined;
+    requestCopy.oauth2 = auth?.oauth2;
     requestCopy.headers = {};
+    // Attach all resolved variables so the backend can interpolate OAuth2 config fields
+    requestCopy.mergedVariables = allVariables;
     toggleFetchingToken(true);
     try {
       const result = await (dispatch(fetchOauth2Credentials({
         itemUid: item.uid,
         request: requestCopy,
-        collection,
-        forceGetToken: true
-      })) as unknown as Promise<{ access_token?: string; error?: string }>);
+        collection
+      })) as unknown as Promise<Record<string, unknown>>);
 
       if (!result || !result.access_token) {
-        const errorMessage = result?.error || 'No access token received from authorization server';
+        const errorMessage = (result?.error as string) || 'No access token received from authorization server';
         console.error(errorMessage);
         toast.error(errorMessage);
         return;
       }
 
       toast.success('Token fetched successfully!');
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as { message?: string };
       console.error('could not fetch the token!');
       console.error(error);
       // Don't show error toast for user cancellation
-      if (error?.message && error.message.includes('cancelled by user')) {
+      if (err?.message && err.message.includes('cancelled by user')) {
         return;
       }
-      toast.error(error?.message || 'An error occurred while fetching token!');
+      toast.error(err?.message || 'An error occurred while fetching token!');
     } finally {
       toggleFetchingToken(false);
       toggleFetchingAuthorizationCode(false);
@@ -91,41 +96,44 @@ const Oauth2ActionButtons = ({
   };
 
   const handleRefreshAccessToken = async () => {
-    let requestCopy = cloneDeep(request);
-    requestCopy.oauth2 = requestCopy?.auth.oauth2;
+    const requestCopy = cloneDeep(request) as Record<string, unknown>;
+    const auth = requestCopy.auth as { oauth2?: unknown } | undefined;
+    requestCopy.oauth2 = auth?.oauth2;
     requestCopy.headers = {};
+    // Attach all resolved variables so the backend can interpolate OAuth2 config fields
+    requestCopy.mergedVariables = allVariables;
     toggleRefreshingToken(true);
     try {
       const result = await (dispatch(refreshOauth2Credentials({
         itemUid: item.uid,
         request: requestCopy,
-        collection,
-        forceGetToken: true
-      })) as unknown as Promise<{ access_token?: string; error?: string }>);
+        collection
+      })) as unknown as Promise<Record<string, unknown>>);
 
       toggleRefreshingToken(false);
 
       if (!result || !result.access_token) {
-        const errorMessage = result?.error || 'No access token received from authorization server';
+        const errorMessage = (result?.error as string) || 'No access token received from authorization server';
         console.error(errorMessage);
         toast.error(errorMessage);
         return;
       }
 
       toast.success('Token refreshed successfully!');
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as { message?: string };
       console.error(error);
       toggleRefreshingToken(false);
-      toast.error(error?.message || 'An error occurred while refreshing token!');
+      toast.error(err?.message || 'An error occurred while refreshing token!');
     }
   };
 
-  const handleClearCache = (e: any) => {
-    (dispatch(clearOauth2Cache({ collectionUid: collection?.uid, url: interpolatedAccessTokenUrl, credentialsId })) as unknown as Promise<void>)
+  const handleClearCache = () => {
+    (dispatch(clearOauth2Cache({ collectionUid, url: interpolatedAccessTokenUrl, credentialsId })) as unknown as Promise<void>)
       .then(() => {
         toast.success('Cleared cache successfully');
       })
-      .catch((err: any) => {
+      .catch((err: { message: string }) => {
         toast.error(err.message);
       });
   };
@@ -170,7 +178,7 @@ const Oauth2ActionButtons = ({
             </Button>
           )
         : null}
-      {useSystemBrowser && fetchingAuthorizationCode
+      {fetchingAuthorizationCode
         ? (
             <Button
               size="sm"

--- a/src/webview/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/Oauth2TokenViewer/index.tsx
@@ -58,7 +58,7 @@ const TokenSection = ({
             ? <IconChevronDown size={18} className="text-gray-500" />
             : <IconChevronRight size={18} className="text-gray-500" />}
           <div className="flex flex-row justify-between w-full">
-            <h3 className="font-medium">{title}</h3>
+            <h3 className="font-medium" data-testid="oauth2-token-title">{title}</h3>
             {decodedToken?.exp && <ExpiryTimer expiresIn={decodedToken?.exp} />}
           </div>
         </div>

--- a/src/webview/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/PasswordCredentials/index.tsx
@@ -115,7 +115,7 @@ const OAuth2PasswordCredentials = ({
         const { showWarning, warningMessage } = isSensitive(value);
 
         return (
-          <div className="flex items-center gap-4 w-full" key={`input-${key}`}>
+          <div className="flex items-center gap-4 w-full" key={`input-${key}`} data-testid={`oauth2-field-${key}`}>
             <label className="block min-w-[140px]">{label}</label>
             <div className="single-line-editor-wrapper flex-1 flex items-center">
               <SingleLineEditor
@@ -134,9 +134,9 @@ const OAuth2PasswordCredentials = ({
           </div>
         );
       })}
-      <div className="flex items-center gap-4 w-full" key="input-credentials-placement">
+      <div className="flex items-center gap-4 w-full" key="input-credentials-placement" data-testid="oauth2-field-credentialsPlacement">
         <label className="block min-w-[140px]">Add Credentials to</label>
-        <div className="inline-flex items-center cursor-pointer token-placement-selector">
+        <div className="inline-flex items-center cursor-pointer token-placement-selector" data-testid="oauth2-credentials-placement-selector">
           <Dropdown onCreate={onDropdownCreate} icon={<CredentialsPlacementIcon />} placement="bottom-end">
             <div
               className="dropdown-item"

--- a/src/webview/components/RequestPane/Auth/index.tsx
+++ b/src/webview/components/RequestPane/Auth/index.tsx
@@ -96,9 +96,9 @@ const Auth = ({
       case 'ntlm': {
         return <NTLMAuth collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
       }
-      // case 'oauth2': {
-      //   return <OAuth2 collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
-      // }
+      case 'oauth2': {
+        return <OAuth2 collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
+      }
       case 'wsse': {
         return <WsseAuth collection={collection} item={item} request={request} save={save} updateAuth={updateAuth} />;
       }

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -389,7 +389,9 @@ const useIpcEvents = () => {
         collectionUid: credData.collectionUid || '',
         itemUid: credData.itemUid || null,
         folderUid: credData.folderUid || null,
-        credentialsId: credData.credentialsId || 'credentials'
+        url: credData.url || '',
+        credentialsId: credData.credentialsId || 'credentials',
+        credentials: credData.credentials || {}
       };
       dispatch(collectionAddOauth2CredentialsByUrl(payload));
     });

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -2727,7 +2727,22 @@ export const hydrateCollectionWithUiStateSnapshot = (payload: any) => (dispatch:
   });
 };
 
-export const fetchOauth2Credentials = (payload: any) => async (dispatch: any, getState: any) => {
+interface FetchOauth2CredentialsPayload {
+  request: Record<string, unknown>;
+  collection: AppCollection;
+  itemUid: string;
+  folderUid?: string | null;
+}
+
+interface OAuth2TokenResponse {
+  credentials: Record<string, unknown>;
+  url: string;
+  collectionUid: string;
+  credentialsId: string;
+  debugInfo?: { data: unknown[] };
+}
+
+export const fetchOauth2Credentials = (payload: FetchOauth2CredentialsPayload): ThunkAction<Promise<Record<string, unknown>>> => async (dispatch, getState) => {
   const { request, collection, itemUid, folderUid } = payload;
   const state = getState();
   const { globalEnvironments, activeGlobalEnvironmentUid } = state.globalEnvironments;
@@ -2736,14 +2751,14 @@ export const fetchOauth2Credentials = (payload: any) => async (dispatch: any, ge
   return new Promise((resolve, reject) => {
     window.ipcRenderer
       .invoke('renderer:fetch-oauth2-credentials', { itemUid, request, collection })
-      .then(({ credentials, url, collectionUid, credentialsId, debugInfo }) => {
+      .then(({ credentials, url, collectionUid, credentialsId, debugInfo }: OAuth2TokenResponse) => {
         dispatch(
           collectionAddOauth2CredentialsByUrl({
             credentials,
             url,
             collectionUid,
             credentialsId,
-            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)) as { data: unknown[] } | undefined,
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })
@@ -2754,7 +2769,7 @@ export const fetchOauth2Credentials = (payload: any) => async (dispatch: any, ge
   });
 };
 
-export const refreshOauth2Credentials = (payload: any) => async (dispatch: any, getState: any) => {
+export const refreshOauth2Credentials = (payload: FetchOauth2CredentialsPayload): ThunkAction<Promise<Record<string, unknown>>> => async (dispatch, getState) => {
   const { request, collection, folderUid, itemUid } = payload;
   const state = getState();
   const { globalEnvironments, activeGlobalEnvironmentUid } = state.globalEnvironments;
@@ -2763,14 +2778,14 @@ export const refreshOauth2Credentials = (payload: any) => async (dispatch: any, 
   return new Promise((resolve, reject) => {
     window.ipcRenderer
       .invoke('renderer:refresh-oauth2-credentials', { itemUid, request, collection })
-      .then(({ credentials, url, collectionUid, debugInfo, credentialsId }) => {
+      .then(({ credentials, url, collectionUid, debugInfo, credentialsId }: OAuth2TokenResponse) => {
         dispatch(
           collectionAddOauth2CredentialsByUrl({
             credentials,
             url,
             collectionUid,
             credentialsId,
-            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)),
+            debugInfo: safeParseJSON(safeStringifyJSON(debugInfo)) as { data: unknown[] } | undefined,
             folderUid: folderUid || null,
             itemUid: !folderUid ? itemUid : null
           })
@@ -2781,7 +2796,7 @@ export const refreshOauth2Credentials = (payload: any) => async (dispatch: any, 
   });
 };
 
-export const clearOauth2Cache = (payload: any) => async (dispatch: any, getState: any) => {
+export const clearOauth2Cache = (payload: { collectionUid: string; url: string; credentialsId: string }): ThunkAction<Promise<void>> => async (dispatch) => {
   const { collectionUid, url, credentialsId } = payload;
   return new Promise<void>((resolve, reject) => {
     window.ipcRenderer
@@ -2789,7 +2804,9 @@ export const clearOauth2Cache = (payload: any) => async (dispatch: any, getState
       .then(() => {
         dispatch(
           collectionClearOauth2CredentialsByUrl({
-            collectionUid
+            collectionUid,
+            url,
+            credentialsId
           })
         );
         resolve();

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -2292,21 +2292,29 @@ export const collectionsSlice = createSlice({
     },
 
     collectionAddOauth2CredentialsByUrl: (state, action: PayloadAction<CollectionAddOauth2CredentialsByUrlPayload>) => {
-      const { collectionUid } = action.payload;
+      const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo } = action.payload as any;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection) {
-        if (!collection.oauth2Credentials) {
-          collection.oauth2Credentials = {};
-        }
-        Object.assign(collection.oauth2Credentials, action.payload);
+      if (!collection) return;
+
+      if (!collection.oauth2Credentials || !Array.isArray(collection.oauth2Credentials)) {
+        collection.oauth2Credentials = [] as any;
       }
+
+      // Remove existing credentials for the same combination
+      const filtered = (collection.oauth2Credentials as unknown as any[]).filter(
+        (creds: any) => !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId)
+      );
+
+      // Add the new credential
+      filtered.push({ collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo });
+      collection.oauth2Credentials = filtered as any;
     },
 
     collectionClearOauth2CredentialsByUrl: (state, action: PayloadAction<CollectionClearOauth2CredentialsByUrlPayload>) => {
       const { collectionUid } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection && collection.oauth2Credentials) {
-        collection.oauth2Credentials = {};
+      if (collection) {
+        collection.oauth2Credentials = [] as any;
       }
     },
 

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -22,7 +22,7 @@ import { splitOnFirst, parsePathParams } from 'utils/url';
 import { parseQueryParams } from '@usebruno/common/utils';
 // @ts-expect-error - @usebruno/common/utils may not export buildQueryString in types
 import { buildQueryString as stringifyQueryParams } from '@usebruno/common/utils';
-import type { AppCollection, AppItem, UID, KeyValue, DraftRequestBody, HttpRequestParam, ResponseState, AuthMode } from '@bruno-types';
+import type { AppCollection, AppItem, UID, KeyValue, DraftRequestBody, HttpRequestParam, ResponseState, AuthMode, OAuth2CredentialEntry } from '@bruno-types';
 import type {
   CollectionUidPayload,
   ItemUidPayload,
@@ -2292,30 +2292,33 @@ export const collectionsSlice = createSlice({
     },
 
     collectionAddOauth2CredentialsByUrl: (state, action: PayloadAction<CollectionAddOauth2CredentialsByUrlPayload>) => {
-      const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo } = action.payload as any;
+      const { collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (!collection) return;
 
       if (!collection.oauth2Credentials || !Array.isArray(collection.oauth2Credentials)) {
-        collection.oauth2Credentials = [] as any;
+        collection.oauth2Credentials = [];
       }
 
       // Remove existing credentials for the same combination
-      const filtered = (collection.oauth2Credentials as unknown as any[]).filter(
-        (creds: any) => !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId)
+      const filtered = collection.oauth2Credentials.filter(
+        (creds: OAuth2CredentialEntry) => !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId)
       );
 
       // Add the new credential
-      filtered.push({ collectionUid, folderUid, itemUid, url, credentials, credentialsId, debugInfo });
-      collection.oauth2Credentials = filtered as any;
+      filtered.push({ collectionUid, folderUid: folderUid || null, itemUid: itemUid || null, url, credentials, credentialsId, debugInfo });
+      collection.oauth2Credentials = filtered;
     },
 
     collectionClearOauth2CredentialsByUrl: (state, action: PayloadAction<CollectionClearOauth2CredentialsByUrlPayload>) => {
-      const { collectionUid } = action.payload;
+      const { collectionUid, url, credentialsId } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection) {
-        collection.oauth2Credentials = [] as any;
-      }
+      if (!collection) return;
+      if (!collection.oauth2Credentials || !Array.isArray(collection.oauth2Credentials)) return;
+
+      collection.oauth2Credentials = collection.oauth2Credentials.filter(
+        (creds: OAuth2CredentialEntry) => !(creds.url === url && creds.collectionUid === collectionUid && creds.credentialsId === credentialsId)
+      );
     },
 
     collectionAddEnvFileEvent: (state, action: PayloadAction<CollectionAddEnvFileEventPayload>) => {

--- a/src/webview/providers/ReduxStore/slices/collections/types.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/types.ts
@@ -575,13 +575,15 @@ export interface StreamDataReceivedPayload extends ItemUidPayload {
 export interface CollectionAddOauth2CredentialsByUrlPayload extends CollectionUidPayload {
   itemUid?: UID | null;
   folderUid?: UID | null;
+  url: string;
   credentialsId: string;
-  [key: string]: unknown;
+  credentials: Record<string, unknown>;
+  debugInfo?: { data: unknown[] };
 }
 
 export interface CollectionClearOauth2CredentialsByUrlPayload extends CollectionUidPayload {
-  itemUid?: UID | null;
-  folderUid?: UID | null;
+  url: string;
+  credentialsId: string;
 }
 
 export interface CollectionAddEnvFileEventPayload {

--- a/tests/e2e/fixtures/oauth2-interpolation-collection.json
+++ b/tests/e2e/fixtures/oauth2-interpolation-collection.json
@@ -1,0 +1,85 @@
+{
+  "name": "OAuth2 Interpolation",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "Get Resource With Vars",
+      "filename": "get-resource-with-vars.bru",
+      "seq": 1,
+      "settings": {
+        "encodeUrl": true
+      },
+      "tags": [],
+      "request": {
+        "url": "http://127.0.0.1:8081/api/auth/oauth2/resource",
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": {
+          "mode": "none",
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": []
+        },
+        "script": {},
+        "vars": {
+          "req": [
+            {
+              "uid": "var1",
+              "name": "tokenUrl",
+              "value": "http://127.0.0.1:8081/api/auth/oauth2/client_credentials/token",
+              "enabled": true,
+              "local": false
+            },
+            {
+              "uid": "var2",
+              "name": "myClientId",
+              "value": "test-client",
+              "enabled": true,
+              "local": false
+            },
+            {
+              "uid": "var3",
+              "name": "myClientSecret",
+              "value": "test-secret",
+              "enabled": true,
+              "local": false
+            }
+          ],
+          "res": []
+        },
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "oauth2",
+          "oauth2": {
+            "grantType": "client_credentials",
+            "accessTokenUrl": "{{tokenUrl}}",
+            "clientId": "{{myClientId}}",
+            "clientSecret": "{{myClientSecret}}",
+            "scope": "",
+            "credentialsPlacement": "body",
+            "credentialsId": "credentials",
+            "tokenPlacement": "header",
+            "tokenHeaderPrefix": "Bearer",
+            "tokenQueryKey": "access_token",
+            "autoFetchToken": true,
+            "autoRefreshToken": false
+          }
+        }
+      }
+    }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "OAuth2 Interpolation",
+    "type": "collection",
+    "ignore": [
+      "node_modules",
+      ".git"
+    ]
+  }
+}

--- a/tests/e2e/server/auth/oauth2.ts
+++ b/tests/e2e/server/auth/oauth2.ts
@@ -1,0 +1,387 @@
+/**
+ * OAuth2 test endpoints for all 4 grant types + refresh + protected resource.
+ *
+ * Mirrors the main Bruno repo's test server pattern:
+ *   packages/bruno-tests/src/auth/oauth2/clientCredentials.js
+ *   packages/bruno-tests/src/auth/oauth2/passwordCredentials.js
+ *   packages/bruno-tests/src/auth/oauth2/authorizationCode.js
+ *
+ * Default credentials:
+ *   Client: client_id=test-client, client_secret=test-secret
+ *   User:   username=testuser, password=testpass
+ */
+
+import { Router, Request, Response } from 'express';
+import crypto from 'crypto';
+
+const router = Router();
+
+// --- State ---
+
+interface IssuedToken {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string;
+  clientId: string;
+  scope?: string;
+  username?: string;
+  expiresIn: number;
+  createdAt: number;
+}
+
+const clients = [
+  { clientId: 'test-client', clientSecret: 'test-secret' },
+  { clientId: 'public-client', clientSecret: '' }
+];
+
+const users = [
+  { username: 'testuser', password: 'testpass' }
+];
+
+const tokens: IssuedToken[] = [];
+const authCodes: Array<{
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  scope?: string;
+  codeChallenge?: string;
+}> = [];
+
+// --- Helpers ---
+
+function generateToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+function parseBasicAuth(authHeader?: string): { clientId: string; clientSecret: string } | null {
+  if (!authHeader?.startsWith('Basic ')) return null;
+  try {
+    const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+    const i = decoded.indexOf(':');
+    if (i === -1) return null;
+    return { clientId: decoded.substring(0, i), clientSecret: decoded.substring(i + 1) };
+  } catch {
+    return null;
+  }
+}
+
+function extractClientCredentials(req: Request): { clientId: string | null; clientSecret: string | null } {
+  // Try Authorization header first
+  const basic = parseBasicAuth(req.headers.authorization);
+  if (basic) return basic;
+  // Fall back to body params
+  return {
+    clientId: req.body.client_id || null,
+    clientSecret: req.body.client_secret ?? null
+  };
+}
+
+function validateClient(clientId: string, clientSecret: string | null): boolean {
+  const client = clients.find(c => c.clientId === clientId);
+  if (!client) return false;
+  // If client has a secret, it must match
+  if (client.clientSecret && clientSecret !== client.clientSecret) return false;
+  return true;
+}
+
+function issueTokens(clientId: string, scope?: string, username?: string): {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
+  id_token: string;
+  scope?: string;
+} {
+  const accessToken = generateToken();
+  const refreshToken = generateToken();
+  const idToken = generateToken();
+
+  tokens.push({
+    accessToken,
+    refreshToken,
+    idToken,
+    clientId,
+    scope,
+    username,
+    expiresIn: 3600,
+    createdAt: Date.now()
+  });
+
+  return {
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: refreshToken,
+    id_token: idToken,
+    ...(scope ? { scope } : {})
+  };
+}
+
+function findTokenByAccess(token: string): IssuedToken | undefined {
+  return tokens.find(t => t.accessToken === token);
+}
+
+function findTokenByRefresh(refreshToken: string): IssuedToken | undefined {
+  return tokens.find(t => t.refreshToken === refreshToken);
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  return crypto.createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+// ─── Client Credentials ──────────────────────────────────────────────────────
+
+router.post('/client_credentials/token', (req: Request, res: Response) => {
+  const { clientId, clientSecret } = extractClientCredentials(req);
+  const { grant_type, scope } = req.body;
+
+  if (grant_type !== 'client_credentials') {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Expected grant_type=client_credentials' });
+    return;
+  }
+  if (!clientId || !validateClient(clientId, clientSecret)) {
+    res.status(401).json({ error: 'invalid_client', error_description: 'Invalid client credentials' });
+    return;
+  }
+
+  res.json(issueTokens(clientId, scope));
+});
+
+// ─── Password Credentials ────────────────────────────────────────────────────
+
+router.post('/password_credentials/token', (req: Request, res: Response) => {
+  const { clientId, clientSecret } = extractClientCredentials(req);
+  const { grant_type, username, password, scope } = req.body;
+
+  if (grant_type !== 'password') {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Expected grant_type=password' });
+    return;
+  }
+  if (!clientId || !validateClient(clientId, clientSecret)) {
+    res.status(401).json({ error: 'invalid_client', error_description: 'Invalid client credentials' });
+    return;
+  }
+  if (!username || !password) {
+    res.status(400).json({ error: 'invalid_request', error_description: 'username and password are required' });
+    return;
+  }
+
+  const user = users.find(u => u.username === username && u.password === password);
+  if (!user) {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Invalid username or password' });
+    return;
+  }
+
+  res.json(issueTokens(clientId, scope, username));
+});
+
+// ─── Authorization Code ──────────────────────────────────────────────────────
+
+router.get('/authorization_code/authorize', (req: Request, res: Response) => {
+  const { response_type, client_id, redirect_uri, scope, state, code_challenge } = req.query as Record<string, string>;
+
+  if (response_type !== 'code') {
+    res.status(400).json({ error: 'unsupported_response_type' });
+    return;
+  }
+  if (!client_id || !clients.find(c => c.clientId === client_id)) {
+    res.status(400).json({ error: 'invalid_client' });
+    return;
+  }
+  if (!redirect_uri) {
+    res.status(400).json({ error: 'invalid_request', error_description: 'redirect_uri is required' });
+    return;
+  }
+
+  const code = crypto.randomBytes(16).toString('hex');
+  authCodes.push({ code, clientId: client_id, redirectUri: redirect_uri, scope, codeChallenge: code_challenge });
+
+  // Auto-approve: redirect immediately with code (no user interaction needed for e2e)
+  const redirectUrl = new URL(redirect_uri);
+  redirectUrl.searchParams.set('code', code);
+  if (state) redirectUrl.searchParams.set('state', state);
+
+  res.redirect(302, redirectUrl.toString());
+});
+
+router.post('/authorization_code/token', (req: Request, res: Response) => {
+  const { clientId, clientSecret } = extractClientCredentials(req);
+  const { grant_type, code, redirect_uri, code_verifier } = req.body;
+
+  if (grant_type !== 'authorization_code') {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Expected grant_type=authorization_code' });
+    return;
+  }
+  if (!clientId || !validateClient(clientId, clientSecret)) {
+    res.status(401).json({ error: 'invalid_client', error_description: 'Invalid client credentials' });
+    return;
+  }
+  if (!code) {
+    res.status(400).json({ error: 'invalid_request', error_description: 'code is required' });
+    return;
+  }
+
+  const idx = authCodes.findIndex(a => a.code === code && a.clientId === clientId);
+  if (idx === -1) {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Invalid or expired authorization code' });
+    return;
+  }
+
+  const stored = authCodes[idx];
+  // Single-use: remove the code
+  authCodes.splice(idx, 1);
+
+  if (redirect_uri && stored.redirectUri !== redirect_uri) {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'redirect_uri mismatch' });
+    return;
+  }
+
+  // PKCE validation
+  if (stored.codeChallenge) {
+    if (!code_verifier) {
+      res.status(400).json({ error: 'invalid_request', error_description: 'code_verifier is required for PKCE' });
+      return;
+    }
+    if (generateCodeChallenge(code_verifier) !== stored.codeChallenge) {
+      res.status(400).json({ error: 'invalid_grant', error_description: 'PKCE code_verifier validation failed' });
+      return;
+    }
+  }
+
+  res.json(issueTokens(clientId, stored.scope));
+});
+
+// ─── Implicit ────────────────────────────────────────────────────────────────
+
+router.get('/implicit/authorize', (req: Request, res: Response) => {
+  const { response_type, client_id, redirect_uri, scope, state } = req.query as Record<string, string>;
+
+  if (response_type !== 'token') {
+    res.status(400).json({ error: 'unsupported_response_type' });
+    return;
+  }
+  if (!client_id || !clients.find(c => c.clientId === client_id)) {
+    res.status(400).json({ error: 'invalid_client' });
+    return;
+  }
+  if (!redirect_uri) {
+    res.status(400).json({ error: 'invalid_request', error_description: 'redirect_uri is required' });
+    return;
+  }
+
+  const tokenData = issueTokens(client_id, scope);
+
+  // Redirect with token in fragment
+  const fragment = new URLSearchParams({
+    access_token: tokenData.access_token,
+    token_type: tokenData.token_type,
+    expires_in: String(tokenData.expires_in),
+    ...(scope ? { scope } : {}),
+    ...(state ? { state } : {})
+  });
+
+  res.redirect(302, `${redirect_uri}#${fragment.toString()}`);
+});
+
+// ─── Token Refresh (shared across all flows) ─────────────────────────────────
+
+router.post('/refresh', (req: Request, res: Response) => {
+  const { clientId, clientSecret } = extractClientCredentials(req);
+  const { grant_type, refresh_token } = req.body;
+
+  if (grant_type !== 'refresh_token') {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Expected grant_type=refresh_token' });
+    return;
+  }
+  if (!clientId || !validateClient(clientId, clientSecret)) {
+    res.status(401).json({ error: 'invalid_client' });
+    return;
+  }
+  if (!refresh_token) {
+    res.status(400).json({ error: 'invalid_request', error_description: 'refresh_token is required' });
+    return;
+  }
+
+  const stored = findTokenByRefresh(refresh_token);
+  if (!stored) {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Invalid refresh token' });
+    return;
+  }
+
+  // Invalidate old token
+  const idx = tokens.indexOf(stored);
+  if (idx !== -1) tokens.splice(idx, 1);
+
+  // Issue new tokens
+  res.json(issueTokens(clientId, stored.scope, stored.username));
+});
+
+// ─── Protected Resource (shared) ─────────────────────────────────────────────
+
+router.get('/resource', (req: Request, res: Response) => {
+  // Accept token from Bearer header or query param
+  let token: string | null = null;
+  const auth = req.headers.authorization;
+  if (auth?.startsWith('Bearer ')) {
+    token = auth.slice(7);
+  } else if (auth?.startsWith('Token ')) {
+    token = auth.slice(6);
+  }
+  if (!token) {
+    token = (req.query.access_token || req.query.token || req.query.api_token) as string | null;
+  }
+
+  if (!token) {
+    res.status(401).json({ error: 'unauthorized', message: 'No access token provided' });
+    return;
+  }
+
+  const issued = findTokenByAccess(token);
+  if (!issued) {
+    res.status(401).json({ error: 'invalid_token', message: 'Invalid or expired access token' });
+    return;
+  }
+
+  res.json({
+    resource: { name: issued.username || 'service', email: `${issued.username || 'service'}@test.local` },
+    client_id: issued.clientId,
+    scope: issued.scope || null
+  });
+});
+
+// ─── Userinfo ────────────────────────────────────────────────────────────────
+
+router.get('/userinfo', (req: Request, res: Response) => {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+
+  const issued = findTokenByAccess(auth.slice(7));
+  if (!issued) {
+    res.status(401).json({ error: 'invalid_token' });
+    return;
+  }
+
+  res.json({
+    sub: issued.username || issued.clientId,
+    name: issued.username || 'Service Account',
+    email: issued.username ? `${issued.username}@test.local` : null
+  });
+});
+
+// ─── Reset (for test isolation) ──────────────────────────────────────────────
+
+router.post('/reset', (_req: Request, res: Response) => {
+  tokens.length = 0;
+  authCodes.length = 0;
+  res.json({ message: 'OAuth2 state reset' });
+});
+
+export { router as oauth2Router };

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Unified test server for e2e tests.
+ *
+ * Mirrors the pattern from the main Bruno repo (packages/bruno-tests/src/index.js).
+ * Playwright auto-starts this via the webServer config.
+ *
+ * Endpoints:
+ *   GET  /ping                                    - Health check
+ *   GET  /headers                                 - Echo request headers
+ *   POST /api/echo/json                           - Echo JSON body
+ *   *    /api/auth/oauth2/client_credentials/*     - Client credentials flow
+ *   *    /api/auth/oauth2/password_credentials/*   - Password credentials flow
+ *   *    /api/auth/oauth2/authorization_code/*     - Authorization code flow
+ *   *    /api/auth/oauth2/implicit/*               - Implicit flow
+ *   GET  /api/auth/oauth2/resource                - Protected resource (all flows)
+ *   POST /api/auth/oauth2/refresh                 - Token refresh
+ *   POST /api/auth/oauth2/reset                   - Reset all OAuth2 state
+ */
+
+import express from 'express';
+import cors from 'cors';
+import { oauth2Router } from './auth/oauth2';
+
+const app = express();
+const port = process.env.PORT || 8081;
+
+app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// --- Core endpoints ---
+
+app.get('/ping', (_req, res) => {
+  res.send('pong');
+});
+
+app.get('/headers', (req, res) => {
+  res.json(req.headers);
+});
+
+app.post('/api/echo/json', (req, res) => {
+  res.json(req.body);
+});
+
+// --- Auth ---
+
+app.use('/api/auth/oauth2', oauth2Router);
+
+// --- Start ---
+
+app.listen(port, () => {
+  console.log(`[test-server] Listening on http://127.0.0.1:${port}`);
+});

--- a/tests/e2e/specs/oauth2.spec.ts
+++ b/tests/e2e/specs/oauth2.spec.ts
@@ -1,0 +1,315 @@
+import * as path from 'path';
+import { test, expect } from '../fixtures';
+import type { Frame } from '@playwright/test';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openNewRequestPanel,
+  createRequest,
+  openRequest,
+  sendRequest,
+  importCollection,
+} from '../utils/actions';
+import {
+  fillOAuth2Field,
+  selectDropdownItem,
+  getActiveEditorFrame,
+} from '../utils/oauth2-actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+/**
+ * Common setup: create a collection with a GET request to the protected resource,
+ * open it, switch to Auth tab, select OAuth 2.0, select the given grant type.
+ */
+async function setupOAuth2Request(
+  page: import('@playwright/test').Page,
+  sidebar: Frame,
+  tmpDir: string,
+  collectionName: string,
+  grantType: 'Client Credentials' | 'Password Credentials' | 'Authorization Code' | 'Implicit'
+): Promise<Frame> {
+  await createCollection(page, sidebar, collectionName, tmpDir);
+  const newReqPanel = await openNewRequestPanel(page, sidebar, collectionName);
+  await createRequest(page, newReqPanel, sidebar, collectionName, 'Get Resource', `${TEST_SERVER}/api/auth/oauth2/resource`);
+  const editor = await openRequest(page, sidebar, collectionName, 'Get Resource');
+
+  const authTab = editor.locator('[role="tab"]').filter({ hasText: 'Auth' });
+  await expect(authTab).toBeVisible({ timeout: 10_000 });
+  await authTab.click();
+  await expect(editor.locator('[data-testid="oauth2-auth-mode-selector"]')).toBeVisible({ timeout: 5_000 });
+
+  await selectDropdownItem(editor, '[data-testid="oauth2-auth-mode-selector"]', 'OAuth 2.0');
+  await expect(editor.locator('[data-testid="oauth2-grant-type-selector"]')).toBeVisible({ timeout: 10_000 });
+
+  await selectDropdownItem(editor, '[data-testid="oauth2-grant-type-selector"]', grantType);
+  await expect(editor.locator('[data-testid="oauth2-field-accessTokenUrl"]')).toBeVisible({ timeout: 5_000 });
+
+  return editor;
+}
+
+/**
+ * Fill client credentials fields and fetch token.
+ */
+async function fillClientCredentialsAndFetchToken(
+  page: import('@playwright/test').Page,
+  editor: Frame,
+  opts: {
+    tokenUrl?: string;
+    clientId?: string;
+    clientSecret?: string;
+    scope?: string;
+    credentialsPlacement?: 'Request Body' | 'Basic Auth Header';
+  } = {}
+): Promise<void> {
+  const {
+    tokenUrl = `${TEST_SERVER}/api/auth/oauth2/client_credentials/token`,
+    clientId = 'test-client',
+    clientSecret = 'test-secret',
+    scope,
+    credentialsPlacement = 'Request Body'
+  } = opts;
+
+  await fillOAuth2Field(page, editor, 'accessTokenUrl', tokenUrl);
+  await fillOAuth2Field(page, editor, 'clientId', clientId);
+  await fillOAuth2Field(page, editor, 'clientSecret', clientSecret);
+  if (scope) {
+    await fillOAuth2Field(page, editor, 'scope', scope);
+  }
+
+  await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+  await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', credentialsPlacement);
+
+  const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+  await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+  await getTokenBtn.click();
+
+  await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+  await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+}
+
+test.describe('OAuth2 Authentication', () => {
+
+  test.beforeEach(async () => {
+    await fetch(`${TEST_SERVER}/api/auth/oauth2/reset`, { method: 'POST' });
+  });
+
+  // ─── Client Credentials Grant ────────────────────────────────────────
+
+  test('Client Credentials (body placement): fetch token and send authenticated request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'CC Body', 'Client Credentials');
+
+    await fillClientCredentialsAndFetchToken(page, editor, { credentialsPlacement: 'Request Body' });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  test('Client Credentials (basic auth header): fetch token and send authenticated request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'CC Header', 'Client Credentials');
+
+    await fillClientCredentialsAndFetchToken(page, editor, { credentialsPlacement: 'Basic Auth Header' });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  test('Client Credentials with scope: scope sent in token request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'CC Scope', 'Client Credentials');
+
+    await fillClientCredentialsAndFetchToken(page, editor, { scope: 'admin' });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  // ─── Password Grant ──────────────────────────────────────────────────
+
+  test('Password Credentials (body placement): fetch token and send authenticated request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'PW Body', 'Password Credentials');
+
+    await fillOAuth2Field(page, editor, 'accessTokenUrl', `${TEST_SERVER}/api/auth/oauth2/password_credentials/token`);
+    await fillOAuth2Field(page, editor, 'username', 'testuser');
+    await fillOAuth2Field(page, editor, 'password', 'testpass');
+    await fillOAuth2Field(page, editor, 'clientId', 'test-client');
+    await fillOAuth2Field(page, editor, 'clientSecret', 'test-secret');
+
+    await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+    await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', 'Request Body');
+
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  test('Password Credentials (basic auth header): fetch token and send authenticated request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'PW Header', 'Password Credentials');
+
+    await fillOAuth2Field(page, editor, 'accessTokenUrl', `${TEST_SERVER}/api/auth/oauth2/password_credentials/token`);
+    await fillOAuth2Field(page, editor, 'username', 'testuser');
+    await fillOAuth2Field(page, editor, 'password', 'testpass');
+    await fillOAuth2Field(page, editor, 'clientId', 'test-client');
+    await fillOAuth2Field(page, editor, 'clientSecret', 'test-secret');
+
+    await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+    await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', 'Basic Auth Header');
+
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  // ─── Token Placement ─────────────────────────────────────────────────
+
+  test('Token placement: custom header prefix', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'TP Prefix', 'Client Credentials');
+
+    await fillClientCredentialsAndFetchToken(page, editor);
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  test('Token placement: URL query parameter', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'TP URL', 'Client Credentials');
+
+    await fillOAuth2Field(page, editor, 'accessTokenUrl', `${TEST_SERVER}/api/auth/oauth2/client_credentials/token`);
+    await fillOAuth2Field(page, editor, 'clientId', 'test-client');
+    await fillOAuth2Field(page, editor, 'clientSecret', 'test-secret');
+
+    await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+    await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', 'Request Body');
+
+    // Change token placement to URL
+    await selectDropdownItem(editor, '[data-testid="oauth2-token-placement-selector"]', 'URL');
+    await expect(editor.locator('[data-testid="oauth2-field-tokenQueryKey"]')).toBeVisible({ timeout: 5_000 });
+
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  // ─── Token Lifecycle ─────────────────────────────────────────────────
+
+  test('Clear cache: removes stored token', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'Token Cache', 'Client Credentials');
+
+    await fillClientCredentialsAndFetchToken(page, editor);
+
+    const tokenTitle = editor.locator('[data-testid="oauth2-token-title"]').filter({ hasText: 'Access Token' });
+    await expect(tokenTitle).toBeVisible({ timeout: 5_000 });
+
+    const clearBtn = editor.locator('[data-testid="oauth2-clear-cache-btn"]');
+    await clearBtn.scrollIntoViewIfNeeded();
+    await expect(clearBtn).toBeVisible({ timeout: 5_000 });
+    await clearBtn.click();
+
+    await expect(tokenTitle).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Refresh token: fetches new token', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'Refresh', 'Client Credentials');
+
+    await fillOAuth2Field(page, editor, 'accessTokenUrl', `${TEST_SERVER}/api/auth/oauth2/client_credentials/token`);
+    await fillOAuth2Field(page, editor, 'clientId', 'test-client');
+    await fillOAuth2Field(page, editor, 'clientSecret', 'test-secret');
+    await fillOAuth2Field(page, editor, 'refreshTokenUrl', `${TEST_SERVER}/api/auth/oauth2/refresh`);
+
+    await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+    await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', 'Request Body');
+
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    const refreshBtn = editor.locator('[data-testid="oauth2-refresh-token-btn"]');
+    await expect(refreshBtn).toBeVisible({ timeout: 5_000 });
+    await refreshBtn.click();
+    await expect(refreshBtn).toBeEnabled({ timeout: 15_000 });
+
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 5_000 });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  // ─── Interpolation ─────────────────────────────────────────────────
+
+  test('Interpolation: OAuth2 fields with {{variables}} resolve correctly', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const fixturePath = path.resolve(__dirname, '../fixtures/oauth2-interpolation-collection.json');
+
+    // Import the collection that has {{tokenUrl}}, {{myClientId}}, {{myClientSecret}} in OAuth2 config
+    // with request vars providing the actual values
+    await importCollection(page, sidebar, fixturePath, tmpDir, 'OAuth2 Interpolation');
+
+    // Open the request
+    const editor = await openRequest(page, sidebar, 'OAuth2 Interpolation', 'Get Resource With Vars');
+
+    // Switch to Auth tab — OAuth2 should already be configured from the fixture
+    const authTab = editor.locator('[role="tab"]').filter({ hasText: 'Auth' });
+    await expect(authTab).toBeVisible({ timeout: 10_000 });
+    await authTab.click();
+    await expect(editor.locator('[data-testid="oauth2-get-token-btn"]')).toBeVisible({ timeout: 10_000 });
+
+    // Click "Get Access Token" — this should interpolate {{tokenUrl}} etc. and fetch successfully
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+
+    // Verify token was fetched (interpolation worked)
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    // Send authenticated request — verifies the token is applied to the request
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
+  // ─── Validation ──────────────────────────────────────────────────────
+
+  test('Validation: missing Client ID shows error toast', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const editor = await setupOAuth2Request(page, sidebar, tmpDir, 'Validation', 'Client Credentials');
+
+    await fillOAuth2Field(page, editor, 'accessTokenUrl', `${TEST_SERVER}/api/auth/oauth2/client_credentials/token`);
+
+    await expect(editor.locator('[data-testid="oauth2-credentials-placement-selector"]')).toBeVisible({ timeout: 5_000 });
+    await selectDropdownItem(editor, '[data-testid="oauth2-credentials-placement-selector"]', 'Request Body');
+
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+    await expect(getTokenBtn).toBeEnabled({ timeout: 10_000 });
+
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 401);
+  });
+
+});

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,9 +1,13 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": false,
+    "types": ["node"]
   },
   "include": [
     "**/*.ts"

--- a/tests/e2e/utils/oauth2-actions.ts
+++ b/tests/e2e/utils/oauth2-actions.ts
@@ -1,0 +1,63 @@
+import { Page, Frame, expect } from '@playwright/test';
+
+/**
+ * Type a value into a SingleLineEditor (CodeMirror) field identified by its
+ * data-testid (e.g. "oauth2-field-clientId") or label text as fallback.
+ *
+ * Waits for focus before typing, presses Tab to blur and commit the onChange,
+ * then waits for the focus class to disappear. Includes a 500ms settle time
+ * for CodeMirror→Redux propagation (no DOM signal available for this).
+ */
+export async function fillOAuth2Field(page: Page, editor: Frame, fieldKey: string, value: string) {
+  // Try data-testid first, fall back to label text
+  let row = editor.locator(`[data-testid="oauth2-field-${fieldKey}"]`);
+  if (await row.count() === 0) {
+    row = editor.locator(`label:has-text("${fieldKey}")`).locator('..');
+  }
+
+  const cmEditor = row.locator('.CodeMirror');
+  await expect(cmEditor).toBeVisible({ timeout: 5_000 });
+  await cmEditor.click();
+  await expect(row.locator('.CodeMirror-focused')).toBeVisible({ timeout: 2_000 });
+
+  // Clear existing content: triple-click to select all (works reliably in CodeMirror)
+  await cmEditor.click({ clickCount: 3 });
+  await page.keyboard.press('Backspace');
+
+  // Type new value
+  await page.keyboard.type(value, { delay: 15 });
+
+  // Blur by pressing Tab — triggers CodeMirror onChange
+  await page.keyboard.press('Tab');
+  await expect(row.locator('.CodeMirror-focused')).not.toBeVisible({ timeout: 2_000 });
+
+  // Allow Redux to process the onChange dispatch
+  await page.waitForTimeout(500);
+}
+
+/**
+ * Click a dropdown trigger and select an item by text.
+ * Accepts either a data-testid or CSS selector for the trigger.
+ * Waits for the dropdown item to appear, clicks it, waits for it to disappear.
+ */
+export async function selectDropdownItem(editor: Frame, triggerSelector: string, itemText: string) {
+  await editor.locator(triggerSelector).click();
+  const item = editor.locator('.dropdown-item').filter({ hasText: itemText });
+  await expect(item).toBeVisible({ timeout: 5_000 });
+  await item.click();
+  await expect(item).not.toBeVisible({ timeout: 2_000 });
+}
+
+/**
+ * Re-acquire the editor frame (VS Code may detach/recreate webview frames).
+ * Falls back to the provided frame if no active editor is found.
+ */
+export async function getActiveEditorFrame(page: Page, fallback: Frame): Promise<Frame> {
+  for (const frame of page.frames()) {
+    if (frame === page.mainFrame()) continue;
+    try {
+      if (await frame.locator('#send-request').count() > 0) return frame;
+    } catch { /* skip detached */ }
+  }
+  return fallback;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,9 @@
     },
     },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "playwright.config.ts",
+    "vitest.config.ts"
   ],
   "exclude": [
     "node_modules",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+    exclude: ['tests/e2e/**', 'node_modules', 'dist'],
+    environment: 'node',
+    globals: true
+  },
+  resolve: {
+    alias: {
+      vscode: path.resolve(__dirname, 'src/__mocks__/vscode.ts'),
+      '@bruno-types': path.resolve(__dirname, 'src/bruno-types'),
+      'components': path.resolve(__dirname, 'src/webview/components'),
+      'providers': path.resolve(__dirname, 'src/webview/providers'),
+      'hooks': path.resolve(__dirname, 'src/webview/hooks'),
+      'utils': path.resolve(__dirname, 'src/webview/utils'),
+      'themes': path.resolve(__dirname, 'src/webview/themes'),
+      'assets': path.resolve(__dirname, 'src/webview/assets'),
+      'selectors': path.resolve(__dirname, 'src/webview/selectors'),
+      'ui': path.resolve(__dirname, 'src/webview/ui'),
+      'views': path.resolve(__dirname, 'src/webview/views')
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Complete OAuth2 implementation for the VS Code extension, matching the main Bruno repo's behavior.

- All 4 grant types: Client Credentials, Password, Authorization Code, Implicit
- PKCE support, token refresh, credential caching, additional parameters
- Variable interpolation in OAuth2 fields (`{{vars}}`)
- OAuth2 credential variables for scripts (`$oauth2.*.access_token`)
- Auto-fetch and auto-refresh tokens during request execution
- Unit test framework (vitest) with 33 tests
- E2E test suite with 11 Playwright tests against a local OAuth2 test server
- `data-testid` attributes on all OAuth2 UI components

### Changes

**Backend (extension host):**
- `src/extension/utils/oauth2.ts` — Core OAuth2 helper (token fetch, refresh, PKCE, placement)
- `src/extension/ipc/network/oauth2-handlers.ts` — IPC handlers + request pipeline integration
- `src/extension/ipc/network/authorize-user-in-system-browser.ts` — Browser-based flows with URI handler
- `src/extension/ipc/network/prepare-request.ts` — OAuth2 auth mode handling
- `src/extension/extension.ts` — URI handler registration

**Frontend (webview):**
- Enable OAuth2 in auth mode dropdown and component rendering
- Fix `oauth2Credentials` Redux reducer (array, matching main repo)
- Fix `AdditionalParams` crash on grant type switch
- Add `data-testid` attributes to all OAuth2 UI elements

**Testing:**
- `vitest.config.ts` + `src/__mocks__/vscode.ts` — Unit test framework setup
- `src/extension/utils/oauth2.spec.ts` — 33 unit tests
- `tests/e2e/server/` — Express test server with OAuth2 endpoints
- `tests/e2e/specs/oauth2.spec.ts` — 11 e2e tests
- `tests/e2e/utils/oauth2-actions.ts` — Reusable test helpers
- `tests/e2e/fixtures/oauth2-interpolation-collection.json` — Variable interpolation fixture

## Test plan

- [x] `npm test` — 33 unit tests pass
- [x] `npm run test:e2e` — 11 e2e tests pass
- [x] `npm run build` — extension builds
- [x] `npm run typecheck` — no TS errors
- [ ] Manual test: authorization code flow with a real OAuth2 provider
- [ ] Manual test: implicit flow with a real OAuth2 provider