### PR TITLE
feat: add transient in-memory requests with grace-period resurrection

### DIFF
--- a/package.json
+++ b/package.json
@@ -386,6 +386,12 @@
         "key": "ctrl+s",
         "mac": "cmd+s",
         "when": "activeCustomEditorId == 'bruno.requestEditor'"
+      },
+      {
+        "command": "bruno.saveFromEditor",
+        "key": "ctrl+s",
+        "mac": "cmd+s",
+        "when": "activeWebviewPanelId == 'bruno.transientRequest'"
       }
     ]
   },

--- a/src/bruno-types/app/collection-ext.ts
+++ b/src/bruno-types/app/collection-ext.ts
@@ -97,6 +97,7 @@ export interface AppItem extends Item {
   requestStartTime?: number | null;
   requestUid?: UID | null;
   requestSent?: RequestSent | null;
+  isTransient?: boolean;
   /** Only metadata loaded, no full content yet */
   partial?: boolean;
   /** File size in MB (for large files) */

--- a/src/extension/commands/main-commands.ts
+++ b/src/extension/commands/main-commands.ts
@@ -267,7 +267,10 @@ export function registerMainCommands(
   // which conflicts with Bruno's IPC-based save mechanism
   context.subscriptions.push(
     vscode.commands.registerCommand('bruno.saveFromEditor', () => {
-      stateManager.broadcast('main:trigger-save');
+      const activeWebview = stateManager.lastActiveEditorWebview;
+      if (activeWebview) {
+        stateManager.sendTo(activeWebview, 'main:trigger-save');
+      }
     })
   );
 }

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -72,6 +72,13 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
 
     registerDocument(document);
 
+    stateManager.setActiveEditorWebview(webviewPanel.webview);
+    webviewPanel.onDidChangeViewState((e) => {
+      if (e.webviewPanel.active) {
+        stateManager.setActiveEditorWebview(webviewPanel.webview);
+      }
+    });
+
     webviewPanel.onDidDispose(() => {
       stateManager.removeWebview(webviewPanel.webview);
       unregisterDocument(document.uri.fsPath);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -38,6 +38,8 @@ import logsStore from './store/logs';
 import { registerTreeCommands, registerMainCommands } from './commands';
 import { registerDirtyStateHandlers, registerSaveHandler } from './editors/dirty-state-manager';
 import { createOAuth2UriHandler } from './ipc/network/authorize-user-in-system-browser';
+import { openTransientRequestPanel } from './panels/transient-request-panel';
+import { AppItem } from '@bruno-types';
 
 let extensionActivated = false;
 
@@ -163,6 +165,14 @@ export function activate(context: vscode.ExtensionContext): void {
 
   registerTreeCommands(context, workspaceCollectionsProvider);
   registerMainCommands(context, sidebarProvider);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('bruno.openTransientRequest',
+      (itemUid: string, itemName: string, collectionUid: string, collectionPath: string, item?: AppItem) => {
+        openTransientRequestPanel(context, itemUid, itemName, collectionUid, collectionPath, item);
+      }
+    )
+  );
 
   registerSaveHandler(context);
 

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -1,0 +1,294 @@
+/**
+ * Opens a WebviewPanel for a transient (in-memory) request.
+ *
+ * Unlike regular requests that open via the custom editor provider (requires a file on disk),
+ * transient requests use a standalone WebviewPanel. The panel loads the same React app
+ * and sends main:set-view to render the request from Redux state.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WebviewHelper } from '../webview/helper';
+import { showSaveRequestPicker } from '../utils/folder-picker';
+import { stateManager } from '../webview/state-manager';
+import {
+  setCurrentWebview,
+  clearCurrentWebview,
+  handleInvoke,
+  hasHandler
+} from '../ipc/handlers';
+import { openCollection, setMessageSender as setCollectionsMessageSender } from '../app/collections';
+import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
+import collectionWatcher from '../app/collection-watcher';
+import { AppItem } from '@bruno-types';
+
+interface IpcMessage {
+  type: 'invoke' | 'send';
+  channel: string;
+  args?: unknown[];
+  requestId?: string;
+}
+
+// Track open transient panels by item uid
+const transientPanels = new Map<string, vscode.WebviewPanel>();
+
+// Store transient item data so we can forward it to new panels
+const transientItems = new Map<string, Record<string, unknown>>();
+
+export function storeTransientItem(itemUid: string, item: Record<string, unknown>): void {
+  transientItems.set(itemUid, item);
+}
+
+export async function openTransientRequestPanel(
+  context: vscode.ExtensionContext,
+  itemUid: string,
+  itemName: string,
+  collectionUid: string,
+  collectionPath: string,
+  item?: AppItem
+): Promise<void> {
+  // If panel already exists for this item, reveal it
+  const existing = transientPanels.get(itemUid);
+  if (existing) {
+    try {
+      existing.reveal(vscode.ViewColumn.One);
+      return;
+    } catch {
+      transientPanels.delete(itemUid);
+    }
+  }
+
+  const panel = vscode.window.createWebviewPanel(
+    'bruno.transientRequest',
+    itemName,
+    vscode.ViewColumn.One,
+    {
+      ...WebviewHelper.getWebviewOptions(context.extensionUri),
+      retainContextWhenHidden: true
+    }
+  );
+
+  panel.iconPath = vscode.Uri.joinPath(context.extensionUri, 'media', 'bruno-icon.png');
+
+  transientPanels.set(itemUid, panel);
+  panel.webview.html = WebviewHelper.getHtmlForWebview(panel.webview, context.extensionUri);
+  stateManager.addWebview(panel.webview);
+
+  panel.onDidDispose(() => {
+    // stateManager.removeWebview(panel.webview);
+    // transientPanels.delete(itemUid);
+    // transientItems.delete(itemU`id);
+    
+    // Close the tab but create a notification system with a timeout, if resurrected, bring back thr item. After the timer expires, remove from everywhere 
+    // // Notify all webviews to clean up the transient item from Redux
+    // stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+    
+    vscode.window.withProgress<boolean>(                                                                                                                                                                             
+    {                                                                                                                                                                                                     
+      location: vscode.ProgressLocation.Notification,
+      title: `"${itemName}" closed — discarding…`,                                                                                                                                                        
+      cancellable: true                                                                                                                                                                                 
+    },                                                                                                                                                                                                    
+    (progress, token) => new Promise<boolean>((resolve) => {                                                                                                                                               
+      const total = 10_000;                  
+      const step = 100;       
+      let elapsed = 0;                                                                                                                                                                                    
+      const interval = setInterval(() => {                                                                                                                                                                
+        elapsed += step;                                                                                                                                                                                  
+        progress.report({ increment: (step / total) * 100 });                                                                                                                                             
+        if (elapsed >= total) { clearInterval(interval); resolve(false); }                                                                                                                                     
+      }, step);               
+      token.onCancellationRequested(() => { clearInterval(interval); resolve(true); });                                                                                                                       
+    })                                                                                                                                                                                                    
+  ).then((wasCancelled) => {
+    if (wasCancelled){
+      vscode.commands.executeCommand(                                                                                                                                                                     
+        'bruno.openTransientRequest',                                                                                                                                                                   
+        itemUid,                             
+        itemName,                                                                                                                                                                                         
+        collectionUid,
+        collectionPath,
+        item
+      );       
+    } else{
+    stateManager.removeWebview(panel.webview);
+    transientPanels.delete(itemUid);
+    transientItems.delete(itemUid);
+    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+    }
+  });
+
+
+  });
+
+  const webviewSender = (channel: string, ...args: unknown[]) => {
+    stateManager.sendTo(panel.webview, channel, ...args);
+  };
+
+  const originalBroadcastSender = (channel: string, ...args: unknown[]) => {
+    stateManager.broadcast(channel, ...args);
+  };
+
+  let collectionLoaded = false;
+
+  const loadCollection = async () => {
+    if (collectionLoaded) return;
+    collectionLoaded = true;
+
+    setCollectionsMessageSender(webviewSender);
+    setWatcherMessageSender(webviewSender);
+
+    try {
+      await openCollection(collectionWatcher, collectionPath);
+
+      setCollectionsMessageSender(originalBroadcastSender);
+      setWatcherMessageSender(originalBroadcastSender);
+
+      setTimeout(() => {
+        // Forward the transient item data to this panel's Redux store
+        const item = transientItems.get(itemUid);
+        if (item) {
+          stateManager.sendTo(panel.webview, 'main:add-transient-request', {
+            collectionUid,
+            item
+          });
+        }
+
+        // Then tell the panel to render this request
+        setTimeout(() => {
+          stateManager.sendTo(panel.webview, 'main:set-view', {
+            viewType: 'request',
+            collectionUid,
+            itemUid
+          });
+        }, 200);
+      }, 500);
+    } catch (error) {
+      console.error('TransientRequestPanel: Error opening collection:', error);
+      setCollectionsMessageSender(originalBroadcastSender);
+      setWatcherMessageSender(originalBroadcastSender);
+    }
+  };
+
+  panel.webview.onDidReceiveMessage(async (message: IpcMessage) => {
+    const { type, channel, args, requestId } = message;
+
+    if (type === 'invoke' && requestId) {
+      setCurrentWebview(panel.webview);
+
+      try {
+        let result: unknown;
+
+        if (hasHandler(channel)) {
+          result = await handleInvoke(channel, args || []);
+        } else {
+          result = null;
+        }
+
+        panel.webview.postMessage({
+          type: 'response',
+          requestId,
+          result
+        });
+
+        if (channel === 'renderer:ready') {
+          clearCurrentWebview();
+          await loadCollection();
+          return;
+        }
+      } catch (error) {
+        panel.webview.postMessage({
+          type: 'response',
+          requestId,
+          error: error instanceof Error ? error.message : 'Unknown error'
+        });
+      } finally {
+        clearCurrentWebview();
+      }
+    } else if (type === 'send') {
+      setCurrentWebview(panel.webview);
+      try {
+        if (channel === 'open-external' && typeof args?.[0] === 'string') {
+          vscode.env.openExternal(vscode.Uri.parse(args[0]));
+        }
+        // Handle save transient request — args[0] is the serialized item data
+        if (channel === 'transient:save-request' && args?.[0]) {
+          await saveTransientRequest(panel, itemUid, collectionPath, args[0] as Record<string, unknown>);
+        }
+        if (channel === 'transient:item-updated' && args?.[0]) {                                                    
+          const { itemUid: updatedUid, item } = args[0] as { itemUid: string; item: Record<string, unknown> };      
+          if (updatedUid && item) {                                                                                 
+            transientItems.set(updatedUid, item);                                                                   
+          }                                                                                                         
+        }       
+      } finally {
+        clearCurrentWebview();
+      }
+    }
+  });
+  
+}
+
+export function closeTransientPanel(itemUid: string): void {
+  const panel = transientPanels.get(itemUid);
+  if (panel) {
+    panel.dispose();
+    transientPanels.delete(itemUid);
+  }
+}
+
+/**
+ * Save a transient request to disk.
+ * Shows a folder picker, asks for a name, writes the file, closes the panel,
+ * and opens the saved file in the regular editor.
+ */
+async function saveTransientRequest(
+  panel: vscode.WebviewPanel,
+  itemUid: string,
+  collectionPath: string,
+  itemData: Record<string, unknown>
+): Promise<void> {
+  // Step 1: Pick a folder and enter a name
+  const item = transientItems.get(itemUid);
+  const defaultName = (item?.name as string) || 'Untitled';
+
+  const result = await showSaveRequestPicker(collectionPath, defaultName, {
+    title: `Save request to ${path.basename(collectionPath)}`
+  });
+
+  if (!result) return;
+
+  const { folder, name } = result;
+
+  // Step 2: Determine format and write the file
+  const format = fs.existsSync(path.join(collectionPath, 'opencollection.yml')) ? 'yml' : 'bru';
+  const filename = `${name}.${format}`;
+  const fullPath = path.join(folder, filename);
+
+  if (fs.existsSync(fullPath)) {
+    const overwrite = await vscode.window.showWarningMessage(
+      `"${filename}" already exists in this folder. Overwrite?`,
+      'Overwrite',
+      'Cancel'
+    );
+    if (overwrite !== 'Overwrite') return;
+  }
+
+  try {
+    // Write the file using the stringify worker (same as renderer:new-request)
+    const { stringifyRequestViaWorker } = require('@usebruno/filestore');
+    const content = await stringifyRequestViaWorker({ ...itemData, name, filename }, { format });
+    fs.writeFileSync(fullPath, content, 'utf-8');
+
+    // Close the transient panel
+    panel.dispose();
+
+    // Open the saved file in the regular editor
+    await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(fullPath), 'bruno.requestEditor');
+
+    vscode.window.showInformationMessage(`Request saved as "${name}"`);
+  } catch (err: any) {
+    vscode.window.showErrorMessage(`Failed to save request: ${err.message}`);
+  }
+}

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -83,50 +83,30 @@ export async function openTransientRequestPanel(
   });
 
   panel.onDidDispose(() => {
-    // stateManager.removeWebview(panel.webview);
-    // transientPanels.delete(itemUid);
-    // transientItems.delete(itemU`id);
-    
-    // Close the tab but create a notification system with a timeout, if resurrected, bring back thr item. After the timer expires, remove from everywhere 
-    // // Notify all webviews to clean up the transient item from Redux
-    // stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
-    
-    vscode.window.withProgress<boolean>(                                                                                                                                                                             
-    {                                                                                                                                                                                                     
-      location: vscode.ProgressLocation.Notification,
-      title: `"${itemName}" closed — discarding…`,                                                                                                                                                        
-      cancellable: true                                                                                                                                                                                 
-    },                                                                                                                                                                                                    
-    (progress, token) => new Promise<boolean>((resolve) => {                                                                                                                                               
-      const total = 10_000;                  
-      const step = 100;       
-      let elapsed = 0;                                                                                                                                                                                    
-      const interval = setInterval(() => {                                                                                                                                                                
-        elapsed += step;                                                                                                                                                                                  
-        progress.report({ increment: (step / total) * 100 });                                                                                                                                             
-        if (elapsed >= total) { clearInterval(interval); resolve(false); }                                                                                                                                     
-      }, step);               
-      token.onCancellationRequested(() => { clearInterval(interval); resolve(true); });                                                                                                                       
-    })                                                                                                                                                                                                    
-  ).then((wasCancelled) => {
-    if (wasCancelled){
-      vscode.commands.executeCommand(                                                                                                                                                                     
-        'bruno.openTransientRequest',                                                                                                                                                                   
-        itemUid,                             
-        itemName,                                                                                                                                                                                         
-        collectionUid,
-        collectionPath,
-        item
-      );       
-    } else{
-    stateManager.removeWebview(panel.webview);
-    transientPanels.delete(itemUid);
-    transientItems.delete(itemUid);
-    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
-    }
-  });
+    const GRACE_MS = 10_000;
 
+    const timer = setTimeout(() => {
+      stateManager.removeWebview(panel.webview);
+      transientPanels.delete(itemUid);
+      transientItems.delete(itemUid);
+      stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+    }, GRACE_MS);
 
+    vscode.window.showInformationMessage(
+      `"${itemName}" closed. Click Undo to restore.`,
+      'Undo'
+    ).then((choice) => {
+      if (choice === 'Undo') {
+        clearTimeout(timer);
+        vscode.commands.executeCommand(
+          'bruno.openTransientRequest',
+          itemUid,
+          itemName,
+          collectionUid,
+          collectionPath
+        );
+      }
+    });
   });
 
   const webviewSender = (channel: string, ...args: unknown[]) => {
@@ -152,25 +132,13 @@ export async function openTransientRequestPanel(
       setCollectionsMessageSender(originalBroadcastSender);
       setWatcherMessageSender(originalBroadcastSender);
 
-      setTimeout(() => {
-        // Forward the transient item data to this panel's Redux store
-        const item = transientItems.get(itemUid);
-        if (item) {
-          stateManager.sendTo(panel.webview, 'main:add-transient-request', {
-            collectionUid,
-            item
-          });
-        }
-
-        // Then tell the panel to render this request
-        setTimeout(() => {
-          stateManager.sendTo(panel.webview, 'main:set-view', {
-            viewType: 'request',
-            collectionUid,
-            itemUid
-          });
-        }, 200);
-      }, 500);
+      const item = transientItems.get(itemUid);
+      if (item) {
+        stateManager.sendTo(panel.webview, 'main:add-transient-request', {
+          collectionUid,
+          item
+        });
+      }
     } catch (error) {
       console.error('TransientRequestPanel: Error opening collection:', error);
       setCollectionsMessageSender(originalBroadcastSender);
@@ -223,12 +191,22 @@ export async function openTransientRequestPanel(
         if (channel === 'transient:save-request' && args?.[0]) {
           await saveTransientRequest(panel, itemUid, collectionPath, args[0] as Record<string, unknown>);
         }
-        if (channel === 'transient:item-updated' && args?.[0]) {                                                    
-          const { itemUid: updatedUid, item } = args[0] as { itemUid: string; item: Record<string, unknown> };      
-          if (updatedUid && item) {                                                                                 
-            transientItems.set(updatedUid, item);                                                                   
-          }                                                                                                         
-        }       
+        if (channel === 'transient:item-updated' && args?.[0]) {
+          const { itemUid: updatedUid, item } = args[0] as { itemUid: string; item: Record<string, unknown> };
+          if (updatedUid && item) {
+            transientItems.set(updatedUid, item);
+          }
+        }
+        if (channel === 'transient:item-ready' && args?.[0]) {
+          const { itemUid: readyItemUid, collectionUid: readyCollUid } = args[0] as { itemUid: string; collectionUid: string };
+          if (readyItemUid && readyCollUid) {
+            stateManager.sendTo(panel.webview, 'main:set-view', {
+              viewType: 'request',
+              collectionUid: readyCollUid,
+              itemUid: readyItemUid
+            });
+          }
+        }
       } finally {
         clearCurrentWebview();
       }

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -74,6 +74,13 @@ export async function openTransientRequestPanel(
   transientPanels.set(itemUid, panel);
   panel.webview.html = WebviewHelper.getHtmlForWebview(panel.webview, context.extensionUri);
   stateManager.addWebview(panel.webview);
+  stateManager.setActiveEditorWebview(panel.webview);
+
+  panel.onDidChangeViewState((e) => {
+    if (e.webviewPanel.active) {
+      stateManager.setActiveEditorWebview(panel.webview);
+    }
+  });
 
   panel.onDidDispose(() => {
     // stateManager.removeWebview(panel.webview);

--- a/src/extension/utils/folder-picker.ts
+++ b/src/extension/utils/folder-picker.ts
@@ -1,0 +1,142 @@
+/**
+ * Constrained folder picker with request name input using VS Code's QuickPick.
+ * Only allows selecting folders within a given root path.
+ * The user cannot navigate above the root.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface FolderPickItem extends vscode.QuickPickItem {
+  fsPath: string;
+  action: 'navigate' | 'select';
+}
+
+export interface SaveLocation {
+  folder: string;
+  name: string;
+}
+
+/**
+ * Show a folder picker constrained to a root directory, followed by a name input.
+ * Returns the selected folder path and request name, or undefined if cancelled.
+ */
+export async function showSaveRequestPicker(
+  rootPath: string,
+  defaultName?: string,
+  options?: { title?: string }
+): Promise<SaveLocation | undefined> {
+  const rootName = path.basename(rootPath);
+
+  // Step 1: Pick folder
+  const folder = await showFolderStep(rootPath, rootName, options?.title);
+  if (!folder) return undefined;
+
+  // Step 2: Enter name
+  const name = await showNameStep(defaultName, folder, rootPath);
+  if (!name) return undefined;
+
+  return { folder, name };
+}
+
+async function showFolderStep(rootPath: string, rootName: string, title?: string): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    const quickPick = vscode.window.createQuickPick<FolderPickItem>();
+    let currentPath = rootPath;
+    let resolved = false;
+
+    quickPick.title = title || `Save request to ${rootName}`;
+    quickPick.placeholder = 'Select a folder or navigate into one';
+    quickPick.step = 1;
+    quickPick.totalSteps = 2;
+    quickPick.matchOnDescription = true;
+
+    const getRelativePath = (fullPath: string): string => {
+      const rel = path.relative(rootPath, fullPath);
+      return rel || '/';
+    };
+
+    const loadFolders = () => {
+      const items: FolderPickItem[] = [];
+
+      // "Select this folder" option
+      items.push({
+        label: '$(check) Select this folder',
+        description: getRelativePath(currentPath) === '/' ? `${rootName} (root)` : getRelativePath(currentPath),
+        fsPath: currentPath,
+        action: 'select'
+      });
+
+      // "Go up" option
+      if (currentPath !== rootPath) {
+        items.push({
+          label: '$(arrow-up) ..',
+          description: 'Go to parent folder',
+          fsPath: path.dirname(currentPath),
+          action: 'navigate'
+        });
+      }
+
+      // List subdirectories
+      try {
+        const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+        const folders = entries
+          .filter(e => e.isDirectory() && !e.name.startsWith('.') && e.name !== 'node_modules' && e.name !== 'environments')
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        for (const folder of folders) {
+          items.push({
+            label: `$(folder) ${folder.name}`,
+            fsPath: path.join(currentPath, folder.name),
+            action: 'navigate'
+          });
+        }
+      } catch {
+        // Can't read directory
+      }
+
+      quickPick.items = items;
+    };
+
+    quickPick.onDidAccept(() => {
+      const selected = quickPick.activeItems[0];
+      if (!selected) return;
+
+      if (selected.action === 'select') {
+        resolved = true;
+        quickPick.hide();
+        resolve(selected.fsPath);
+      } else {
+        currentPath = selected.fsPath;
+        if (!currentPath.startsWith(rootPath)) {
+          currentPath = rootPath;
+        }
+        loadFolders();
+      }
+    });
+
+    quickPick.onDidHide(() => {
+      quickPick.dispose();
+      if (!resolved) resolve(undefined);
+    });
+
+    loadFolders();
+    quickPick.show();
+  });
+}
+
+async function showNameStep(defaultName: string | undefined, folder: string, rootPath: string): Promise<string | undefined> {
+  const relFolder = path.relative(rootPath, folder) || path.basename(rootPath);
+
+  return vscode.window.showInputBox({
+    title: `Save request to ${relFolder}`,
+    prompt: 'Enter a name for the request',
+    value: defaultName || 'Untitled',
+    validateInput: (value) => {
+      if (!value?.trim()) return 'Name is required';
+      if (/[<>:"/\\|?*]/.test(value)) return 'Name contains invalid characters';
+      return null;
+    }
+  });
+}

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -7,6 +7,7 @@ import {
   handleInvoke,
   hasHandler
 } from '../ipc/handlers';
+import { storeTransientItem }  from '../panels/transient-request-panel';
 
 interface IpcMessage {
   type: 'invoke' | 'send';
@@ -303,6 +304,30 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
           const { collectionPath } = args[0] as { collectionPath?: string };
           if (collectionPath) {
             await vscode.commands.executeCommand('bruno.openEnvironmentSettings', vscode.Uri.file(collectionPath));
+          }
+        }
+        break;
+
+      case 'sidebar:open-transient-request':
+        if (args[0] && typeof args[0] === 'object') {
+          const { itemUid, itemName, collectionUid, collectionPath: transientCollPath, item: transientItem } = args[0] as {
+            itemUid?: string;
+            itemName?: string;
+            collectionUid?: string;
+            collectionPath?: string;
+            item?: Record<string, unknown>;
+          };
+          if (itemUid && collectionUid && transientCollPath) {
+            if (transientItem) {
+              storeTransientItem(itemUid, transientItem);
+            }
+            await vscode.commands.executeCommand(
+              'bruno.openTransientRequest',
+              itemUid,
+              itemName || 'Untitled',
+              collectionUid,
+              transientCollPath
+            );
           }
         }
         break;

--- a/src/extension/webview/state-manager.ts
+++ b/src/extension/webview/state-manager.ts
@@ -11,6 +11,7 @@ interface IpcResponse {
 
 export class WebviewStateManager {
   private webviews: Set<vscode.Webview> = new Set();
+  private _lastActiveEditorWebview: vscode.Webview | null = null;
 
   addWebview(webview: vscode.Webview): void {
     this.webviews.add(webview);
@@ -18,6 +19,17 @@ export class WebviewStateManager {
 
   removeWebview(webview: vscode.Webview): void {
     this.webviews.delete(webview);
+    if (this._lastActiveEditorWebview === webview) {
+      this._lastActiveEditorWebview = null;
+    }
+  }
+
+  setActiveEditorWebview(webview: vscode.Webview): void {
+    this._lastActiveEditorWebview = webview;
+  }
+
+  get lastActiveEditorWebview(): vscode.Webview | null {
+    return this._lastActiveEditorWebview;
   }
 
   broadcast(channel: string, ...args: unknown[]): void {

--- a/src/webview/components/Sidebar/Collections/Collection/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/index.tsx
@@ -16,7 +16,12 @@ import {
   IconFolder,
   IconSettings,
   IconShare,
-  IconX
+  IconX,
+  IconPlus,
+  IconApi,
+  IconBrandGraphql,
+  IconNetwork,
+  IconPlugConnected
 } from '@tabler/icons';
 import { toggleCollection } from 'providers/ReduxStore/slices/collections';
 import {
@@ -46,6 +51,8 @@ import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import { ipcRenderer } from 'utils/ipc';
+import { addTransientRequest } from 'providers/ReduxStore/slices/collections';
+import transientManager from 'utils/transient-manager';
 
 interface CollectionProps {
   collection: any;
@@ -321,8 +328,60 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
     return items.sort((a, b) => a.seq - b.seq);
   };
 
-  const requestItems = sortItemsBySequence(filter(collection.items, (i: any) => isItemARequest(i)));
+  const requestItems = sortItemsBySequence(filter(collection.items, (i: any) => isItemARequest(i) && !i.isTransient));
   const folderItems = sortByNameThenSequence(filter(collection.items, (i: any) => isItemAFolder(i)));
+
+  const newRequestMenuRef = useRef<any>(null);
+
+  const openTransientRequest = (item: any) => {
+    dispatch(addTransientRequest({ collectionUid: collection.uid, item }));
+    ipcRenderer.send('sidebar:open-transient-request', {
+      itemUid: item.uid,
+      itemName: item.name,
+      collectionUid: collection.uid,
+      collectionPath: collection.pathname,
+      item
+    });
+  };
+
+  const transientRequestMenuItems = [
+    {
+      id: 'new-http',
+      leftSection: IconApi,
+      label: 'HTTP',
+      onClick: () => {
+        ensureCollectionIsMounted();
+        openTransientRequest(transientManager.createHttpRequest(collection));
+      }
+    },
+    {
+      id: 'new-graphql',
+      leftSection: IconBrandGraphql,
+      label: 'GraphQL',
+      onClick: () => {
+        ensureCollectionIsMounted();
+        openTransientRequest(transientManager.createGraphQLRequest(collection));
+      }
+    },
+    {
+      id: 'new-grpc',
+      leftSection: IconNetwork,
+      label: 'gRPC',
+      onClick: () => {
+        ensureCollectionIsMounted();
+        openTransientRequest(transientManager.createGrpcRequest(collection));
+      }
+    },
+    {
+      id: 'new-ws',
+      leftSection: IconPlugConnected,
+      label: 'WebSocket',
+      onClick: () => {
+        ensureCollectionIsMounted();
+        openTransientRequest(transientManager.createWebSocketRequest(collection));
+      }
+    }
+  ];
 
   const menuItems = [
     {
@@ -431,7 +490,19 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
           </div>
           {isLoading ? <IconLoader2 className="animate-spin mx-1" size={18} strokeWidth={1.5} /> : null}
         </div>
-        <div>
+        <div className="flex items-center">
+          <MenuDropdown
+            ref={newRequestMenuRef}
+            items={transientRequestMenuItems}
+            placement="bottom-start"
+            appendTo={dropdownContainerRef?.current || document.body}
+            popperOptions={{ strategy: 'fixed' }}
+            data-testid="collection-new-request"
+          >
+            <ActionIcon className="collection-actions" data-testid="collection-new-request-btn">
+              <IconPlus size={16} strokeWidth={2} />
+            </ActionIcon>
+          </MenuDropdown>
           <div className="pr-2">
             <MenuDropdown
               ref={menuDropdownRef}

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -18,7 +18,9 @@ import {
   runFolderEvent,
   runRequestEvent,
   scriptEnvironmentUpdateEvent,
-  streamDataReceived
+  streamDataReceived,
+  addTransientRequest,
+  removeTransientRequest
 } from 'providers/ReduxStore/slices/collections';
 import {
   collectionAddEnvFileEvent,
@@ -371,6 +373,19 @@ const useIpcEvents = () => {
       dispatch(updateCookies(val as Parameters<typeof updateCookies>[0]));
     });
 
+    const removeAddTransientRequestListener = ipcRenderer.on('main:add-transient-request', (val: any) => {
+      if (val?.collectionUid && val?.item) {
+        dispatch(addTransientRequest({ collectionUid: val.collectionUid, item: val.item }));
+      }
+    });
+
+    const removeTransientRequestClosedListener = ipcRenderer.on('main:transient-request-closed', (val: any) => {
+      if (val?.collectionUid && val?.itemUid) {
+        dispatch(removeTransientRequest({ collectionUid: val.collectionUid, itemUid: val.itemUid }));
+      }
+    });
+
+
     const removeGlobalEnvironmentsUpdatesListener = ipcRenderer.on('main:load-global-environments', (val: unknown) => {
       dispatch(updateGlobalEnvironments(val));
     });
@@ -609,6 +624,8 @@ const useIpcEvents = () => {
       removePreferencesUpdatesListener();
       removeCookieUpdateListener();
       removeSystemProxyEnvUpdatesListener();
+      removeAddTransientRequestListener();
+      removeTransientRequestClosedListener();
       removeGlobalEnvironmentsUpdatesListener();
       removeSnapshotHydrationListener();
       removeSecurityConfigUpdatedListener();

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -374,9 +374,29 @@ const useIpcEvents = () => {
     });
 
     const removeAddTransientRequestListener = ipcRenderer.on('main:add-transient-request', (val: any) => {
-      if (val?.collectionUid && val?.item) {
+      if (!val?.collectionUid || !val?.item) return;
+
+      const MAX_RETRIES = 80;
+      const RETRY_DELAY_MS = 50;
+      let retryCount = 0;
+
+      const tryAdd = () => {
+        retryCount++;
+        if (collectionExists(val.collectionUid)) {
         dispatch(addTransientRequest({ collectionUid: val.collectionUid, item: val.item }));
-      }
+          // Signal the extension host that the item is in Redux
+          ipcRenderer.send('transient:item-ready', {
+            itemUid: val.item.uid,
+            collectionUid: val.collectionUid
+          });
+        } else if (retryCount < MAX_RETRIES) {
+          setTimeout(tryAdd, RETRY_DELAY_MS);
+        } else {
+          console.error('[Bruno] Collection not found for transient request after max retries:', val.collectionUid);
+        }
+      };
+
+      tryAdd();
     });
 
     const removeTransientRequestClosedListener = ipcRenderer.on('main:transient-request-closed', (val: any) => {

--- a/src/webview/providers/ReduxStore/middlewares/autosave/middleware.ts
+++ b/src/webview/providers/ReduxStore/middlewares/autosave/middleware.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { saveRequest, saveCollectionSettings, saveFolderRoot } from '../../slices/collections/actions';
-import { flattenItems, isItemARequest, isItemAFolder } from 'utils/collections';
+import { flattenItems, isItemARequest, isItemAFolder, findItemInCollection, findCollectionByUid } from 'utils/collections';
 
 interface actionsToInterceptProps {
   dispatch?: boolean;
@@ -109,7 +109,7 @@ const saveExistingDrafts = (dispatch: any, getState: any, interval: any) => {
 
     const allItems = flattenItems(collection.items);
     allItems.forEach((item: any) => {
-      if (item.draft) {
+      if (item.draft && !item.isTransient) {
         if (isItemARequest(item)) {
           const key = `request-${item.uid}`;
           scheduleAutoSave(key, () => dispatch(saveRequest(item.uid, collection.uid, true)), interval);
@@ -154,6 +154,10 @@ export const autosaveMiddleware = ({
   let key, save;
 
   if (itemUid) {
+    const collection = findCollectionByUid(getState().collections.collections, collectionUid);
+    const item = collection ? findItemInCollection(collection, itemUid) : null;
+    if ((item as any)?.isTransient) return result;
+
     key = `request-${itemUid}`;
     save = () => dispatch(saveRequest(itemUid, collectionUid, true));
   } else if (folderUid) {

--- a/src/webview/providers/ReduxStore/middlewares/draft/middleware.ts
+++ b/src/webview/providers/ReduxStore/middlewares/draft/middleware.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 import { handleMakeTabParmanent } from './utils';
+import { findCollectionByUid, findItemInCollection } from 'utils/collections';
+import { hasRequestChanges }from 'utils/collections';
 
 interface actionsToInterceptProps {
   dispatch?: boolean;
@@ -85,6 +87,21 @@ const actionsToIntercept = [
   'collections/updateCollectionProtobuf',
   'collections/updateCollectionProxy'
 ];
+const transientSyncTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+const scheduleTransientSync = (item: any) => {
+  if (!item?.uid) return;
+  clearTimeout(transientSyncTimers[item.uid]);
+  transientSyncTimers[item.uid] = setTimeout(() => {
+    try {
+      window.ipcRenderer.send('transient:item-updated', {
+        itemUid: item.uid,
+        item: JSON.parse(JSON.stringify(item))
+      });
+    } catch {}
+    delete transientSyncTimers[item.uid];
+  }, 250);
+};
 
 export const draftDetectMiddleware = ({
   dispatch,
@@ -95,5 +112,17 @@ export const draftDetectMiddleware = ({
     handleMakeTabParmanent(state, action, dispatch);
   }
   const result = next(action);
+
+  if (actionsToIntercept.includes(action.type)) {
+    const { itemUid, collectionUid } = action.payload || {};
+    if (itemUid && collectionUid) {
+      const collection = findCollectionByUid(getState().collections.collections, collectionUid);
+      const item = collection ? findItemInCollection(collection, itemUid) : null;
+      if ((item as any)?.isTransient) {
+        scheduleTransientSync(item);
+      }
+    }
+  }
+
   return result;
 };

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -315,6 +315,15 @@ export const saveRequest = (itemUid: string, collectionUid: string, silent = fal
       return reject(new Error('Not able to locate item'));
     }
 
+    if ((item as any).isTransient) {
+      if (!silent) {
+        const { ipcRenderer } = window;
+        const itemToSave = transformRequestToSaveToFilesystem(item);
+        ipcRenderer.send('transient:save-request', itemToSave);
+      }
+      return resolve(undefined);
+    }
+
     // Validate assertion and variable names before saving
     const validationError = validateRequestNames(item);
     if (validationError) {

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1508,6 +1508,23 @@ export const collectionsSlice = createSlice({
       }
     },
 
+    addTransientRequest: (state, action: PayloadAction<{ collectionUid: string; item: any }>) => {
+      const { collectionUid, item } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (collection) {
+        collection.items = collection.items || [];
+        collection.items.push(item);
+      }
+    },
+
+    removeTransientRequest: (state, action: PayloadAction<{ collectionUid: string; itemUid: string }>) => {
+      const { collectionUid, itemUid } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (collection && collection.items) {
+        collection.items = collection.items.filter((i: any) => i.uid !== itemUid);
+      }
+    },
+
     collectionAddFileEvent: (state, action: PayloadAction<CollectionAddFileEventPayload>) => {
       const { meta, data, partial, loading, size, error } = action.payload;
       const isCollectionRoot = meta.collectionRoot ? true : false;
@@ -2942,6 +2959,8 @@ export const {
   updateCollectionTagsList,
   resetCollectionRunner,
   updateRunnerTagsDetails,
+  addTransientRequest,
+  removeTransientRequest,
   collectionAddFileEvent,
   collectionChangeFileEvent,
   collectionUnlinkFileEvent,

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -480,6 +480,9 @@ export const collectionsSlice = createSlice({
         const item = findItemInCollection(collection, itemUid);
         if (item && isItemARequest(item)) {
           const draft = ensureDraft(item);
+          if (draft.request) {
+            (draft.request as { url: string }).url = url;
+          }
           if (draft.request && 'params' in draft.request) {
             type ParamType = { uid?: string; name: string; value: string; enabled?: boolean; type?: string };
             const httpRequest = draft.request as { url: string; params: ParamType[] };

--- a/src/webview/utils/collections/index.tsx
+++ b/src/webview/utils/collections/index.tsx
@@ -1234,6 +1234,7 @@ const getPathParams = (item: any) => {
 export const getTotalRequestCountInCollection = (collection: any) => {
   let count = 0;
   each(collection.items, (item) => {
+    if (item.isTransient) return;
     if (isItemARequest(item)) {
       count++;
     } else if (isItemAFolder(item)) {
@@ -1543,7 +1544,7 @@ export const getRequestItemsForCollectionRun = ({
   }
 
   const requestTypes = ['http-request', 'graphql-request'];
-  requestItems = requestItems.filter((request: any) => requestTypes.includes(request.type));
+  requestItems = requestItems.filter((request: any) => requestTypes.includes(request.type) && !request.isTransient);
 
   if (tags && tags.include && tags.exclude) {
     const includeTags = tags.include ? tags.include : [];

--- a/src/webview/utils/transient-manager.spec.ts
+++ b/src/webview/utils/transient-manager.spec.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { transientManager, type CollectionInfo } from './transient-manager';
+
+vi.mock('utils/common/index', () => {
+  let counter = 0;
+  return {
+    uuid: () => `mock-uid-${++counter}`,
+    sortByNameThenSequence: vi.fn()
+  };
+});
+
+const bruCollection: CollectionInfo = {
+  uid: 'col-1',
+  pathname: '/Users/test/my-collection',
+  format: 'bru'
+};
+
+const ymlCollection: CollectionInfo = {
+  uid: 'col-2',
+  pathname: '/Users/test/my-yml-collection',
+  format: 'yml'
+};
+
+const noFormatCollection: CollectionInfo = {
+  uid: 'col-3',
+  pathname: '/Users/test/my-default-collection'
+};
+
+const windowsCollection: CollectionInfo = {
+  uid: 'col-4',
+  pathname: 'C:\\Users\\test\\my-collection',
+  format: 'bru'
+};
+
+beforeEach(() => {
+  transientManager.resetCounter(bruCollection.uid);
+  transientManager.resetCounter(ymlCollection.uid);
+  transientManager.resetCounter(noFormatCollection.uid);
+  transientManager.resetCounter(windowsCollection.uid);
+});
+
+// ─── Common fields shared by all request types ──────────────────────────────
+
+describe('common transient item fields', () => {
+  test('every item has isTransient: true, seq: 0, draft: null', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.isTransient).toBe(true);
+    expect(item.seq).toBe(0);
+    expect(item.draft).toBeNull();
+  });
+
+  test('every item gets a unique uid', () => {
+    const a = transientManager.createHttpRequest(bruCollection);
+    const b = transientManager.createHttpRequest(bruCollection);
+    expect(a.uid).not.toBe(b.uid);
+  });
+});
+
+// ─── Auto-incrementing names ────────────────────────────────────────────────
+
+describe('auto-incrementing names', () => {
+  test('first item is named "Untitled 1"', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.name).toBe('Untitled 1');
+  });
+
+  test('sequential items increment the counter', () => {
+    const first = transientManager.createHttpRequest(bruCollection);
+    const second = transientManager.createGraphQLRequest(bruCollection);
+    const third = transientManager.createGrpcRequest(bruCollection);
+    expect(first.name).toBe('Untitled 1');
+    expect(second.name).toBe('Untitled 2');
+    expect(third.name).toBe('Untitled 3');
+  });
+
+  test('different collections have independent counters', () => {
+    const a = transientManager.createHttpRequest(bruCollection);
+    const b = transientManager.createHttpRequest(ymlCollection);
+    expect(a.name).toBe('Untitled 1');
+    expect(b.name).toBe('Untitled 1');
+  });
+
+  test('resetCounter resets the naming sequence', () => {
+    transientManager.createHttpRequest(bruCollection);
+    transientManager.createHttpRequest(bruCollection);
+    transientManager.resetCounter(bruCollection.uid);
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.name).toBe('Untitled 1');
+  });
+});
+
+// ─── File extension and pathname ────────────────────────────────────────────
+
+describe('file extension and pathname', () => {
+  test('bru format produces .bru extension', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.filename).toBe('Untitled 1.bru');
+  });
+
+  test('yml format produces .yml extension', () => {
+    const item = transientManager.createHttpRequest(ymlCollection);
+    expect(item.filename).toBe('Untitled 1.yml');
+  });
+
+  test('missing format defaults to .yml', () => {
+    const item = transientManager.createHttpRequest(noFormatCollection);
+    expect(item.filename).toBe('Untitled 1.yml');
+  });
+
+  test('pathname is under .bruno/transient/ with Unix separators', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.pathname).toBe('/Users/test/my-collection/.bruno/transient/Untitled 1.bru');
+  });
+
+  test('pathname uses backslash separators for Windows paths', () => {
+    const item = transientManager.createHttpRequest(windowsCollection);
+    expect(item.pathname).toBe('C:\\Users\\test\\my-collection\\.bruno\\transient\\Untitled 1.bru');
+  });
+});
+
+// ─── HTTP request ───────────────────────────────────────────────────────────
+
+describe('createHttpRequest', () => {
+  test('type is http-request', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.type).toBe('http-request');
+  });
+
+  test('method defaults to GET', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.request.method).toBe('GET');
+  });
+
+  test('body mode is none', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect((item.request.body as any).mode).toBe('none');
+  });
+
+  test('settings has encodeUrl: true', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.settings).toEqual({ encodeUrl: true });
+  });
+
+  test('has empty url, headers, params, assertions, tests, docs', () => {
+    const item = transientManager.createHttpRequest(bruCollection);
+    expect(item.request.url).toBe('');
+    expect(item.request.headers).toEqual([]);
+    expect(item.request.params).toEqual([]);
+    expect(item.request.assertions).toEqual([]);
+    expect(item.request.tests).toBe('');
+    expect(item.request.docs).toBe('');
+  });
+});
+
+// ─── GraphQL request ────────────────────────────────────────────────────────
+
+describe('createGraphQLRequest', () => {
+  test('type is graphql-request', () => {
+    const item = transientManager.createGraphQLRequest(bruCollection);
+    expect(item.type).toBe('graphql-request');
+  });
+
+  test('method defaults to POST', () => {
+    const item = transientManager.createGraphQLRequest(bruCollection);
+    expect(item.request.method).toBe('POST');
+  });
+
+  test('body mode is graphql with query and variables', () => {
+    const item = transientManager.createGraphQLRequest(bruCollection);
+    const body = item.request.body as any;
+    expect(body.mode).toBe('graphql');
+    expect(body.graphql).toEqual({ query: '', variables: '' });
+  });
+});
+
+// ─── gRPC request ───────────────────────────────────────────────────────────
+
+describe('createGrpcRequest', () => {
+  test('type is grpc-request', () => {
+    const item = transientManager.createGrpcRequest(bruCollection);
+    expect(item.type).toBe('grpc-request');
+  });
+
+  test('body mode is grpc with default message', () => {
+    const item = transientManager.createGrpcRequest(bruCollection);
+    const body = item.request.body as any;
+    expect(body.mode).toBe('grpc');
+    expect(body.grpc).toEqual([{ name: 'message 1', content: '{}' }]);
+  });
+
+  test('method and methodType are empty strings', () => {
+    const item = transientManager.createGrpcRequest(bruCollection);
+    expect(item.request.method).toBe('');
+    expect(item.request.methodType).toBe('');
+  });
+
+  test('settings is empty object', () => {
+    const item = transientManager.createGrpcRequest(bruCollection);
+    expect(item.settings).toEqual({});
+  });
+});
+
+// ─── WebSocket request ──────────────────────────────────────────────────────
+
+describe('createWebSocketRequest', () => {
+  test('type is ws-request', () => {
+    const item = transientManager.createWebSocketRequest(bruCollection);
+    expect(item.type).toBe('ws-request');
+  });
+
+  test('method defaults to GET', () => {
+    const item = transientManager.createWebSocketRequest(bruCollection);
+    expect(item.request.method).toBe('GET');
+  });
+
+  test('body mode is ws with default message', () => {
+    const item = transientManager.createWebSocketRequest(bruCollection);
+    const body = item.request.body as any;
+    expect(body.mode).toBe('ws');
+    expect(body.ws).toEqual([{ name: 'message 1', type: 'json', content: '{}' }]);
+  });
+
+  test('settings has timeout and keepAliveInterval', () => {
+    const item = transientManager.createWebSocketRequest(bruCollection);
+    expect(item.settings).toEqual({ timeout: 0, keepAliveInterval: 0 });
+  });
+});

--- a/src/webview/utils/transient-manager.ts
+++ b/src/webview/utils/transient-manager.ts
@@ -1,0 +1,185 @@
+/**
+ * TransientManager — creates in-memory request items that are not persisted to disk.
+ *
+ * Transient requests live only in Redux state and are excluded from the sidebar.
+ * They can be edited, executed, and later saved to a collection folder.
+ *
+ * Each transient item gets a virtual pathname under:
+ *   {collectionPath}/.bruno/transient/{name}.{bru|yml}
+ * This allows scripts to resolve relative paths against the collection root.
+ */
+
+import { uuid } from 'utils/common/index';
+
+interface TransientItem {
+  uid: string;
+  name: string;
+  type: string;
+  isTransient: true;
+  seq: number;
+  draft: null;
+  filename: string;
+  pathname: string;
+  request: Record<string, unknown>;
+  settings: Record<string, unknown>;
+}
+
+interface CollectionInfo {
+  uid: string;
+  pathname: string;
+  format?: string; // 'bru' or 'yml'
+}
+
+// Track the next number for auto-generated names per collection
+const counters: Record<string, number> = {};
+
+function getNextName(collectionUid: string): string {
+  if (!counters[collectionUid]) {
+    counters[collectionUid] = 0;
+  }
+  counters[collectionUid]++;
+  return `Untitled ${counters[collectionUid]}`;
+}
+
+function getFileExtension(format?: string): string {
+  return format === 'bru' ? 'bru' : 'yml';
+}
+
+function buildTransientPath(collectionPathname: string, filename: string): string {
+  const separator = collectionPathname.includes('\\') ? '\\' : '/';
+  return `${collectionPathname}${separator}.bruno${separator}transient${separator}${filename}`;
+}
+
+function generateItemMeta(collection: CollectionInfo): { name: string; filename: string; pathname: string } {
+  const name = getNextName(collection.uid);
+  const ext = getFileExtension(collection.format);
+  const filename = `${name}.${ext}`;
+  const pathname = buildTransientPath(collection.pathname, filename);
+  return { name, filename, pathname };
+}
+
+function createBaseRequest(): Record<string, unknown> {
+  return {
+    url: '',
+    method: 'GET',
+    headers: [],
+    params: [],
+    body: { mode: 'none', formUrlEncoded: [], multipartForm: [], file: [] },
+    auth: { mode: 'inherit' },
+    vars: { req: [], res: [] },
+    assertions: [],
+    script: { req: '', res: '' },
+    tests: '',
+    docs: ''
+  };
+}
+
+const transientManager = {
+  createHttpRequest(collection: CollectionInfo): TransientItem {
+    const { name, filename, pathname } = generateItemMeta(collection);
+    return {
+      uid: uuid(),
+      name,
+      type: 'http-request',
+      isTransient: true,
+      seq: 0,
+      draft: null,
+      filename,
+      pathname,
+      request: createBaseRequest(),
+      settings: { encodeUrl: true }
+    };
+  },
+
+  createGraphQLRequest(collection: CollectionInfo): TransientItem {
+    const { name, filename, pathname } = generateItemMeta(collection);
+    return {
+      uid: uuid(),
+      name,
+      type: 'graphql-request',
+      isTransient: true,
+      seq: 0,
+      draft: null,
+      filename,
+      pathname,
+      request: {
+        ...createBaseRequest(),
+        method: 'POST',
+        body: {
+          mode: 'graphql',
+          graphql: { query: '', variables: '' }
+        }
+      },
+      settings: { encodeUrl: true }
+    };
+  },
+
+  createGrpcRequest(collection: CollectionInfo): TransientItem {
+    const { name, filename, pathname } = generateItemMeta(collection);
+    return {
+      uid: uuid(),
+      name,
+      type: 'grpc-request',
+      isTransient: true,
+      seq: 0,
+      draft: null,
+      filename,
+      pathname,
+      request: {
+        url: '',
+        method: '',
+        methodType: '',
+        headers: [],
+        body: {
+          mode: 'grpc',
+          grpc: [{ name: 'message 1', content: '{}' }]
+        },
+        auth: { mode: 'inherit' },
+        vars: { req: [], res: [] },
+        script: { req: null, res: null },
+        assertions: [],
+        tests: null,
+        docs: null
+      },
+      settings: {}
+    };
+  },
+
+  createWebSocketRequest(collection: CollectionInfo): TransientItem {
+    const { name, filename, pathname } = generateItemMeta(collection);
+    return {
+      uid: uuid(),
+      name,
+      type: 'ws-request',
+      isTransient: true,
+      seq: 0,
+      draft: null,
+      filename,
+      pathname,
+      request: {
+        url: '',
+        method: 'GET',
+        headers: [],
+        params: [],
+        body: {
+          mode: 'ws',
+          ws: [{ name: 'message 1', type: 'json', content: '{}' }]
+        },
+        auth: { mode: 'inherit' },
+        vars: { req: [], res: [] },
+        script: { req: null, res: null },
+        assertions: [],
+        tests: null,
+        docs: null
+      },
+      settings: { timeout: 0, keepAliveInterval: 0 }
+    };
+  },
+
+  resetCounter(collectionUid: string): void {
+    delete counters[collectionUid];
+  }
+};
+
+export default transientManager;
+export { transientManager, TransientItem, CollectionInfo };


### PR DESCRIPTION
Adds a "+" action on each collection row to create HTTP/GraphQL/gRPC/WS requests that live only in Redux + a standalone WebviewPanel — no file is written until the user explicitly saves.

- transient-manager creates typed items with virtual pathnames under {collection}/.bruno/transient/ so scripts resolve relative paths
- dedicated transient-request-panel with protocol-colored icons that reflect dirty state
- custom folder-picker (QuickPick) constrained to the collection root with a request-name input step
- Cmd+S keybinding + beforeunload guard so dirty transient requests cannot silently disappear
- draft middleware debounces and syncs transient item state to the extension host so the latest edits survive panel disposal
- onDidDispose shows a progress-bar notification; cancelling resurrects the panel with the synced state, otherwise the item is cleaned up
- autosave and saveRequest skip transient items (explicit save only)