### PR TITLE
fix: scope folder runner to the selected folder's requests

### DIFF
--- a/src/extension/commands/main-commands.ts
+++ b/src/extension/commands/main-commands.ts
@@ -92,7 +92,7 @@ export function registerMainCommands(
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('bruno.runCollection', async (uri: vscode.Uri) => {
+    vscode.commands.registerCommand('bruno.runCollection', async (uri: vscode.Uri, folderUid?: string) => {
       if (!uri) {
         vscode.window.showWarningMessage('No folder selected');
         return;
@@ -116,7 +116,7 @@ export function registerMainCommands(
         return;
       }
 
-      await openRunnerPanel(context, collectionRoot, targetPath);
+      await openRunnerPanel(context, collectionRoot, targetPath, folderUid);
     })
   );
 

--- a/src/extension/panels/runner-panel.ts
+++ b/src/extension/panels/runner-panel.ts
@@ -32,19 +32,22 @@ function handleIpcSend(channel: string, args: unknown[]): void {
 export async function openRunnerPanel(
   context: vscode.ExtensionContext,
   collectionRoot: string,
-  _targetPath: string
+  _targetPath: string,
+  folderUid?: string
 ): Promise<void> {
-  const existingPanel = activeRunnerPanels.get(collectionRoot);
+  const panelKey = folderUid ? `${collectionRoot}::${folderUid}` : collectionRoot;
+  const existingPanel = activeRunnerPanels.get(panelKey);
   if (existingPanel) {
     existingPanel.reveal();
     return;
   }
 
   const collectionName = getCollectionName(collectionRoot);
+  const panelTitle = folderUid ? `Folder Runner: ${collectionName}` : `Runner: ${collectionName}`;
 
   const panel = vscode.window.createWebviewPanel(
     'bruno.runnerPanel',
-    `Runner: ${collectionName}`,
+    panelTitle,
     vscode.ViewColumn.One,
     {
       enableScripts: true,
@@ -54,10 +57,10 @@ export async function openRunnerPanel(
   );
 
   panel.iconPath = vscode.Uri.joinPath(context.extensionUri, 'media', 'bruno-icon.png');
-  activeRunnerPanels.set(collectionRoot, panel);
+  activeRunnerPanels.set(panelKey, panel);
 
   panel.onDidDispose(() => {
-    activeRunnerPanels.delete(collectionRoot);
+    activeRunnerPanels.delete(panelKey);
     stateManager.removeWebview(panel.webview);
   });
 
@@ -116,7 +119,8 @@ export async function openRunnerPanel(
         stateManager.sendTo(panel.webview, 'main:set-view', {
           viewType: 'collection-runner',
           collectionUid,
-          collectionPath: collectionRoot
+          collectionPath: collectionRoot,
+          folderUid
         });
       }, 500);
     } catch (error) {

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -317,9 +317,9 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
 
       case 'sidebar:open-collection-runner':
         if (args[0] && typeof args[0] === 'object') {
-          const { collectionPath } = args[0] as { collectionPath?: string };
+          const { collectionPath, folderUid } = args[0] as { collectionPath?: string; folderUid?: string };
           if (collectionPath) {
-            await vscode.commands.executeCommand('bruno.runCollection', vscode.Uri.file(collectionPath));
+            await vscode.commands.executeCommand('bruno.runCollection', vscode.Uri.file(collectionPath), folderUid);
           }
         }
         break;

--- a/src/webview/components/RunnerResults/RunConfigurationPanel/index.tsx
+++ b/src/webview/components/RunnerResults/RunConfigurationPanel/index.tsx
@@ -5,7 +5,7 @@ import { IconGripVertical, IconCheck, IconAdjustmentsAlt } from '@tabler/icons';
 import { useDispatch } from 'react-redux';
 import { updateRunnerConfiguration } from 'providers/ReduxStore/slices/collections/actions';
 import StyledWrapper from './StyledWrapper';
-import { isItemARequest } from 'utils/collections';
+import { isItemARequest, findItemInCollection } from 'utils/collections';
 import path from 'utils/common/path';
 import { cloneDeep, get } from 'lodash';
 import Button from 'ui/Button/index';
@@ -178,6 +178,7 @@ const RequestItem = ({
 
 const RunConfigurationPanel = ({
   collection,
+  folderUid,
   selectedItems,
   setSelectedItems
 }: any) => {
@@ -186,7 +187,7 @@ const RunConfigurationPanel = ({
   const [originalRequests, setOriginalRequests] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const flattenRequests = useCallback((collection: any) => {
+  const flattenRequests = useCallback((collection: any, rootItems: any[]) => {
     const result: any = [];
 
     const processItems = (items: any) => {
@@ -209,7 +210,7 @@ const RunConfigurationPanel = ({
       });
     };
 
-    processItems(collection.items);
+    processItems(rootItems);
     return result;
   }, []);
 
@@ -218,7 +219,9 @@ const RunConfigurationPanel = ({
 
     try {
       const structureCopy = cloneDeep(collection);
-      const requests = flattenRequests(structureCopy);
+      const folder = folderUid ? findItemInCollection(structureCopy, folderUid) : null;
+      const rootItems = folder ? (folder as any).items || [] : structureCopy.items;
+      const requests = flattenRequests(structureCopy, rootItems);
 
       const savedConfiguration = get(collection, 'runnerConfiguration', null);
       if (savedConfiguration?.requestItemsOrder?.length > 0) {
@@ -248,7 +251,7 @@ const RunConfigurationPanel = ({
     } finally {
       setIsLoading(false);
     }
-  }, [collection, flattenRequests]);
+  }, [collection, folderUid, flattenRequests]);
 
   const moveItem = useCallback((draggedItemUid: any, hoverIndex: any) => {
     setFlattenedRequests((prevRequests) => {

--- a/src/webview/components/RunnerResults/index.tsx
+++ b/src/webview/components/RunnerResults/index.tsx
@@ -93,7 +93,8 @@ const FilterButton = ({
 );
 
 export default function RunnerResults({
-  collection
+  collection,
+  folderUid
 }: any) {
   const dispatch = useDispatch();
   const [selectedItem, setSelectedItem] = useState<any>(null);
@@ -112,7 +113,10 @@ export default function RunnerResults({
 
   const areTagsAdded = tags.include.length > 0 || tags.exclude.length > 0;
 
-  const requestItemsForCollectionRun = getRequestItemsForCollectionRun({ recursive: true, tags, items: collection.items });
+  const folder = folderUid ? findItemInCollection(collection, folderUid) : null;
+  const runScopeItems = folder ? (folder as any).items || [] : collection.items;
+
+  const requestItemsForCollectionRun = getRequestItemsForCollectionRun({ recursive: true, tags, items: runScopeItems });
   const totalRequestItemsCountForCollectionRun = requestItemsForCollectionRun.length;
   const shouldDisableCollectionRun = totalRequestItemsCountForCollectionRun <= 0;
 
@@ -210,10 +214,10 @@ export default function RunnerResults({
   const runCollection = () => {
     if (configureMode && selectedRequestItems.length > 0) {
       dispatch(updateRunnerConfiguration(collection.uid, selectedRequestItems, selectedRequestItems, delay));
-      dispatch(runCollectionFolder(collection.uid, null, true, Number(delay), tagsEnabled && tags, selectedRequestItems));
+      dispatch(runCollectionFolder(collection.uid, folderUid || null, true, Number(delay), tagsEnabled && tags, selectedRequestItems));
     } else {
       dispatch(updateRunnerConfiguration(collection.uid, [], [], delay));
-      dispatch(runCollectionFolder(collection.uid, null, true, Number(delay), tagsEnabled && tags, undefined));
+      dispatch(runCollectionFolder(collection.uid, folderUid || null, true, Number(delay), tagsEnabled && tags, undefined));
     }
   };
 
@@ -260,7 +264,8 @@ export default function RunnerResults({
     }
   }, [tagsEnabled]);
 
-  const totalRequestsInCollection = getTotalRequestCountInCollection(collectionCopy);
+  const folderCopy = folderUid ? findItemInCollection(collectionCopy, folderUid) : null;
+  const totalRequestsInCollection = getTotalRequestCountInCollection(folderCopy || collectionCopy);
   const filterCounts: Record<string, number> = {
     all: items.length,
     passed: items.filter(allTestsPassed).length,
@@ -339,6 +344,7 @@ export default function RunnerResults({
             <div className="run-config-panel w-1/2 border-l">
               <RunConfigurationPanel
                 collection={collection}
+                folderUid={folderUid}
                 selectedItems={selectedRequestItems}
                 setSelectedItems={setSelectedRequestItems}
               />

--- a/src/webview/views/ViewContainer.tsx
+++ b/src/webview/views/ViewContainer.tsx
@@ -285,7 +285,7 @@ const ViewContainer: React.FC<ViewContainerProps> = ({ viewData }) => {
       return (
         <>
           <CollectionToolBar collection={collection} />
-          <RunnerResults collection={collection} />
+          <RunnerResults collection={collection} folderUid={folderUid} />
         </>
       );
 


### PR DESCRIPTION
Clicking Run on a folder previously opened the collection runner showing every request in the collection. The folderUid was sent in the IPC payload but dropped in the SidebarViewProvider handler.

Plumb folderUid end-to-end: IPC handler -> bruno.runCollection command -> openRunnerPanel -> main:set-view -> RunnerResults / RunConfigurationPanel. The folder's items (recursively flattened) now drive both the configurable request list and the dispatched run.

Folder and collection runners can coexist — the panel registry keys on collectionRoot plus optional folderUid so opening both works.