### PR TITLE
fix: allow JS expressions in assertion names

### DIFF
--- a/src/webview/components/RequestPane/Assertions/index.tsx
+++ b/src/webview/components/RequestPane/Assertions/index.tsx
@@ -8,7 +8,6 @@ import SingleLineEditor from 'components/SingleLineEditor';
 import AssertionOperator from './AssertionOperator';
 import EditableTable from 'components/EditableTable';
 import StyledWrapper from './StyledWrapper';
-import { variableNameRegex } from 'utils/common/regex';
 
 interface unaryOperatorsProps {
   item?: React.ReactNode;
@@ -86,15 +85,6 @@ const Assertions = ({
       updateReorderedItem
     }));
   }, [dispatch, collection.uid, item.uid]);
-
-  const getRowError = useCallback((row: any, index: any, key: any) => {
-    if (key !== 'name') return null;
-    if (!row.name || row.name.trim() === '') return null;
-    if (!variableNameRegex.test(row.name)) {
-      return 'Expression contains invalid characters. Must only contain alphanumeric characters, "-", "_", "."';
-    }
-    return null;
-  }, []);
 
   const columns = [
     {
@@ -191,7 +181,6 @@ const Assertions = ({
         rows={assertions || []}
         onChange={handleAssertionsChange}
         defaultRow={defaultRow}
-        getRowError={getRowError}
         reorderable={true}
         onReorder={handleAssertionDrag}
         testId="assertions-table"

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -280,13 +280,6 @@ const validateRequestNames = (item: any): string | null => {
   const request = item.draft?.request || item.request;
   if (!request) return null;
 
-  // Validate assertions
-  const assertions = request.assertions || [];
-  for (const assertion of assertions) {
-    if (assertion.name && assertion.name.trim() !== '' && !variableNameRegex.test(assertion.name)) {
-      return `Invalid assertion name "${assertion.name}". Must only contain alphanumeric characters, "-", "_", "."`;
-    }
-  }
 
   // Validate request vars
   const reqVars = request.vars?.req || [];


### PR DESCRIPTION
Assertion names were being validated against variableNameRegex (/^[\w-.]*$/), causing any expression with parentheses, brackets, or other JS syntax (e.g. res.body.numberBig.toString()) to show as an error in the assertions table and block saving.

Assertion names are full JS expressions evaluated by the assertion runtime, not variable names. Remove the regex check from the inline row validation and from the save-time validator, matching the main Bruno app which has no such restriction.