### PR TITLE
fix: sync tags to draft so they persist on save

### DIFF
--- a/src/bruno-types/app/draft.ts
+++ b/src/bruno-types/app/draft.ts
@@ -52,6 +52,7 @@ export interface ItemDraft {
   request?: Request | DraftRequest | null;
   settings?: ItemSettings;
   examples?: Example[];
+  tags?: string[];
   root?: FolderRoot | null;
 }
 

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1461,6 +1461,12 @@ export const collectionsSlice = createSlice({
           if (!item.tags.includes(tag)) {
             item.tags.push(tag);
           }
+          if (item.draft) {
+            if (!item.draft.tags) item.draft.tags = [];
+            if (!item.draft.tags.includes(tag)) {
+              item.draft.tags.push(tag);
+            }
+          }
         }
       }
     },
@@ -1470,8 +1476,13 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (collection) {
         const item = findItemInCollection(collection, itemUid);
-        if (item && item.tags) {
-          item.tags = item.tags.filter(t => t !== tag);
+        if (item) {
+          if (item.tags) {
+            item.tags = item.tags.filter(t => t !== tag);
+          }
+          if (item.draft?.tags) {
+            item.draft.tags = item.draft.tags.filter(t => t !== tag);
+          }
         }
       }
     },

--- a/src/webview/providers/ReduxStore/slices/collections/request-tags.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/request-tags.spec.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, vi } from 'vitest';
+
+// Mock vscode
+vi.mock('vscode', () => ({}));
+
+// Import the slice after mocking
+const { default: collectionsReducer, addRequestTag, deleteRequestTag } = await import('./index');
+
+// Helper to create a minimal collection state matching CollectionsState
+function makeState(item: any): any {
+  return {
+    collections: [{
+      uid: 'col-1',
+      name: 'Test',
+      pathname: '/test',
+      items: [item],
+      environments: [],
+      brunoConfig: {}
+    }],
+    collectionSortOrder: 'default',
+    activeConnections: {}
+  };
+}
+
+describe('addRequestTag', () => {
+  test('adds tag to item.tags', () => {
+    const item = { uid: 'req-1', name: 'Test', type: 'http-request', tags: [], request: { url: '' } };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, addRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'smoke'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toContain('smoke');
+  });
+
+  test('adds tag to item.draft.tags when draft exists', () => {
+    const item = {
+      uid: 'req-1',
+      name: 'Test',
+      type: 'http-request',
+      tags: ['existing'],
+      request: { url: '' },
+      draft: {
+        uid: 'req-1',
+        name: 'Test',
+        type: 'http-request',
+        tags: ['existing'],
+        request: { url: 'http://edited.com' }
+      }
+    };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, addRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'regression'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toContain('regression');
+    expect(updatedItem.draft.tags).toContain('regression');
+  });
+
+  test('initializes draft.tags if draft exists but tags is undefined', () => {
+    const item = {
+      uid: 'req-1',
+      name: 'Test',
+      type: 'http-request',
+      tags: [],
+      request: { url: '' },
+      draft: {
+        uid: 'req-1',
+        name: 'Test',
+        type: 'http-request',
+        request: { url: 'http://edited.com' }
+        // no tags field
+      }
+    };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, addRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'api'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toContain('api');
+    expect(updatedItem.draft.tags).toContain('api');
+  });
+
+  test('does not add duplicate tags', () => {
+    const item = {
+      uid: 'req-1',
+      name: 'Test',
+      type: 'http-request',
+      tags: ['smoke'],
+      request: { url: '' },
+      draft: { uid: 'req-1', tags: ['smoke'], request: { url: '' } }
+    };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, addRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'smoke'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toEqual(['smoke']);
+    expect(updatedItem.draft.tags).toEqual(['smoke']);
+  });
+});
+
+describe('deleteRequestTag', () => {
+  test('removes tag from item.tags', () => {
+    const item = { uid: 'req-1', name: 'Test', type: 'http-request', tags: ['smoke', 'api'], request: { url: '' } };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, deleteRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'smoke'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toEqual(['api']);
+  });
+
+  test('removes tag from both item.tags and item.draft.tags', () => {
+    const item = {
+      uid: 'req-1',
+      name: 'Test',
+      type: 'http-request',
+      tags: ['smoke', 'api'],
+      request: { url: '' },
+      draft: { uid: 'req-1', tags: ['smoke', 'api'], request: { url: 'http://edited.com' } }
+    };
+    const state = makeState(item);
+
+    const result = collectionsReducer(state, deleteRequestTag({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      tag: 'smoke'
+    }));
+
+    const updatedItem = result.collections[0].items[0];
+    expect(updatedItem.tags).toEqual(['api']);
+    expect(updatedItem.draft.tags).toEqual(['api']);
+  });
+});


### PR DESCRIPTION
addRequestTag and deleteRequestTag only modified item.tags but not item.draft.tags. When a draft existed (user edited any field), the save flow read from item.draft which had stale tags — silently dropping any tags added after the draft was created.

Now both reducers update item.tags and item.draft.tags in sync. Added tags field to ItemDraft type definition.

Includes 6 unit tests covering add/delete with and without drafts, draft.tags initialization, and duplicate prevention.