### PR TITLE
fix: interpolate variables in OAuth2 additional parameters

### DIFF
--- a/src/extension/ipc/network/oauth2-handlers.ts
+++ b/src/extension/ipc/network/oauth2-handlers.ts
@@ -136,6 +136,27 @@ function interpolateOAuth2Config(
       oauth2[field] = (interpolate as (str: string, vars: Record<string, unknown>) => string)(oauth2[field] as string, vars);
     }
   }
+  
+  // Interpolate additional parameters (authorization, token, refresh)
+  const additionalParameters = oauth2.additionalParameters as Record<string, unknown> | undefined;
+  if (additionalParameters){
+    ['authorization', 'token', 'refresh'].forEach((key) => {
+      const params = additionalParameters[key];
+      if (Array.isArray(params)) {
+      params.forEach((param) => {
+        if (param?.enabled){
+          if (typeof param.name === 'string' && param.name.includes('{{')) {
+              param.name = (interpolate as (str: string, vars: Record<string, unknown>) => string)(param.name, vars);
+            }
+            if (typeof param.value === 'string' && param.value.includes('{{')) {
+              param.value = (interpolate as (str: string, vars: Record<string, unknown>) => string)(param.value, vars);
+            }
+        }
+      })
+      }
+    })
+  }
+
 
   // Write back interpolated config to both locations
   if ((requestCopy.auth as { oauth2?: Record<string, unknown> })?.oauth2) {

--- a/src/webview/components/RequestPane/Auth/OAuth2/AdditionalParams/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/AdditionalParams/index.tsx
@@ -220,6 +220,7 @@ const AdditionalParams = ({
                     value
                   })}
                   collection={collection}
+                  item={item}
                   onSave={handleSave}
                   isCompact
                 />
@@ -235,6 +236,7 @@ const AdditionalParams = ({
                     value
                   })}
                   collection={collection}
+                  item={item}
                   onSave={handleSave}
                 />
               </td>

--- a/tests/e2e/fixtures/oauth2-additional-params-collection.json
+++ b/tests/e2e/fixtures/oauth2-additional-params-collection.json
@@ -1,0 +1,104 @@
+{
+  "name": "OAuth2 Additional Params",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "Get Resource With Additional Params",
+      "filename": "get-resource-with-additional-params.bru",
+      "seq": 1,
+      "settings": {
+        "encodeUrl": true
+      },
+      "tags": [],
+      "request": {
+        "url": "http://127.0.0.1:8081/api/auth/oauth2/resource",
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": {
+          "mode": "none",
+          "formUrlEncoded": [],
+          "multipartForm": [],
+          "file": []
+        },
+        "script": {},
+        "vars": {
+          "req": [
+            {
+              "uid": "var1",
+              "name": "tokenUrl",
+              "value": "http://127.0.0.1:8081/api/auth/oauth2/client_credentials/token_with_audience",
+              "enabled": true,
+              "local": false
+            },
+            {
+              "uid": "var2",
+              "name": "myClientId",
+              "value": "test-client",
+              "enabled": true,
+              "local": false
+            },
+            {
+              "uid": "var3",
+              "name": "myClientSecret",
+              "value": "test-secret",
+              "enabled": true,
+              "local": false
+            },
+            {
+              "uid": "var4",
+              "name": "myAudience",
+              "value": "my-api",
+              "enabled": true,
+              "local": false
+            }
+          ],
+          "res": []
+        },
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": {
+          "mode": "oauth2",
+          "oauth2": {
+            "grantType": "client_credentials",
+            "accessTokenUrl": "{{tokenUrl}}",
+            "clientId": "{{myClientId}}",
+            "clientSecret": "{{myClientSecret}}",
+            "scope": "",
+            "credentialsPlacement": "body",
+            "credentialsId": "credentials",
+            "tokenPlacement": "header",
+            "tokenHeaderPrefix": "Bearer",
+            "tokenQueryKey": "access_token",
+            "autoFetchToken": true,
+            "autoRefreshToken": false,
+            "additionalParameters": {
+              "authorization": [],
+              "token": [
+                {
+                  "name": "audience",
+                  "value": "{{myAudience}}",
+                  "sendIn": "body",
+                  "enabled": true
+                }
+              ],
+              "refresh": []
+            }
+          }
+        }
+      }
+    }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "OAuth2 Additional Params",
+    "type": "collection",
+    "ignore": [
+      "node_modules",
+      ".git"
+    ]
+  }
+}

--- a/tests/e2e/server/auth/oauth2.ts
+++ b/tests/e2e/server/auth/oauth2.ts
@@ -152,6 +152,29 @@ router.post('/client_credentials/token', (req: Request, res: Response) => {
   res.json(issueTokens(clientId, scope));
 });
 
+// ─── Client Credentials with required additional param ───────────────────────
+// Requires `audience` in the request body to succeed (validates additional params interpolation)
+
+router.post('/client_credentials/token_with_audience', (req: Request, res: Response) => {
+  const { clientId, clientSecret } = extractClientCredentials(req);
+  const { grant_type, scope, audience } = req.body;
+
+  if (grant_type !== 'client_credentials') {
+    res.status(400).json({ error: 'invalid_grant', error_description: 'Expected grant_type=client_credentials' });
+    return;
+  }
+  if (!clientId || !validateClient(clientId, clientSecret)) {
+    res.status(401).json({ error: 'invalid_client', error_description: 'Invalid client credentials' });
+    return;
+  }
+  if (audience !== 'my-api') {
+    res.status(400).json({ error: 'invalid_request', error_description: `Expected audience=my-api, got ${audience}` });
+    return;
+  }
+
+  res.json(issueTokens(clientId, scope));
+});
+
 // ─── Password Credentials ────────────────────────────────────────────────────
 
 router.post('/password_credentials/token', (req: Request, res: Response) => {

--- a/tests/e2e/specs/oauth2.spec.ts
+++ b/tests/e2e/specs/oauth2.spec.ts
@@ -292,6 +292,49 @@ test.describe('OAuth2 Authentication', () => {
     await sendRequest(currentEditor, 200);
   });
 
+  test('Interpolation: OAuth2 additional parameters with {{variables}} resolve correctly', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const fixturePath = path.resolve(__dirname, '../fixtures/oauth2-additional-params-collection.json');
+
+    // Import the collection that has {{myAudience}} in additionalParameters.token
+    // The server endpoint requires audience=my-api in the body to succeed
+    await importCollection(page, sidebar, fixturePath, tmpDir, 'OAuth2 Additional Params');
+
+    // Open the request
+    const editor = await openRequest(page, sidebar, 'OAuth2 Additional Params', 'Get Resource With Additional Params');
+
+    // Switch to Auth tab — OAuth2 should already be configured from the fixture
+    const authTab = editor.locator('[role="tab"]').filter({ hasText: 'Auth' });
+    await expect(authTab).toBeVisible({ timeout: 10_000 });
+    await authTab.click();
+    await expect(editor.locator('[data-testid="oauth2-get-token-btn"]')).toBeVisible({ timeout: 10_000 });
+
+    // Verify the {{myAudience}} variable in additional params is highlighted as valid (green, not red)
+    const additionalParamsSection = editor.locator('.oauth2-additional-params-wrapper');
+    await expect(additionalParamsSection).toBeVisible({ timeout: 5_000 });
+    // Click the "Token" tab to reveal the additional param
+    await additionalParamsSection.locator('.tab').filter({ hasText: 'Token' }).click();
+    // The variable should be rendered with cm-variable-valid (green), not cm-variable-invalid (red)
+    await expect(additionalParamsSection.locator('span.cm-variable-valid')).toBeVisible({ timeout: 5_000 });
+    await expect(additionalParamsSection.locator('span.cm-variable-invalid')).toHaveCount(0);
+
+    // Click "Get Access Token" — this triggers the manual fetch path which must
+    // interpolate {{myAudience}} → "my-api" in the additional parameter before
+    // sending it to the token endpoint
+    const getTokenBtn = editor.locator('[data-testid="oauth2-get-token-btn"]');
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+    await getTokenBtn.click();
+
+    // Verify token was fetched (interpolation of additional params worked)
+    // If interpolation failed, the server returns 400 and no token appears
+    await expect(editor.locator('[data-testid="oauth2-token-title"]').first()).toBeVisible({ timeout: 15_000 });
+    await expect(getTokenBtn).toBeEnabled({ timeout: 5_000 });
+
+    // Send authenticated request — verifies the token is valid
+    const currentEditor = await getActiveEditorFrame(page, editor);
+    await sendRequest(currentEditor, 200);
+  });
+
   // ─── Validation ──────────────────────────────────────────────────────
 
   test('Validation: missing Client ID shows error toast', async ({ page, tmpDir }) => {


### PR DESCRIPTION
## Summary
- OAuth2 "Additional Parameters" containing `{{variables}}` were sent as raw template strings instead of interpolated values during manual token fetch
- Variables in additional params appeared red (invalid) in the editor despite being defined in the Vars tab
- Fixes https://github.com/usebruno/bruno-vscode/issues/19

## Problem
1. `interpolateOAuth2Config()` resolved `{{variables}}` in basic OAuth2 fields (clientId, clientSecret, scope, etc.) but skipped `additionalParameters` entirely. The manual "Get Access Token" flow only uses this function, so additional param variables were never interpolated.
2. The `AdditionalParams` component passed `collection` but not `item` to the editor components, so `getAllVariables()` couldn't resolve request-level variables for syntax highlighting.

## Solution
- Added additional parameter interpolation (authorization, token, refresh) to `interpolateOAuth2Config()` in `oauth2-handlers.ts`
- Passed `item` prop to `SingleLineEditor` and `MultiLineEditor` in `AdditionalParams` component

## Test plan
- [x] Added e2e test with a server endpoint that requires an interpolated additional parameter (`audience=my-api`) — token fetch fails if interpolation doesn't work
- [x] Added UI assertion verifying variables render with `cm-variable-valid` (green) not `cm-variable-invalid` (red)
- [x] All 12 OAuth2 e2e tests pass