### PR TITLE
fix: resolve posixified webview paths to native before watcher/store lookups

### DIFF
--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -1615,14 +1615,25 @@ class CollectionWatcher {
   }
 
   removeWatcher(watchPath: string, collectionUid?: string): void {
-    if (this.watchers.has(watchPath)) {
-      const watchers = this.watchers.get(watchPath)!;
+    // The Map key may have been stored with posixified separators (opened from webview)
+    // or native separators (opened from file dialog). Try both formats.
+    const nativePath = path.resolve(watchPath);
+    const posixPath = posixifyPath(nativePath);
+    const effectivePath = this.watchers.has(nativePath) ? nativePath
+      : this.watchers.has(posixPath) ? posixPath
+      : watchPath;
+
+    if (this.watchers.has(effectivePath)) {
+      const watchers = this.watchers.get(effectivePath)!;
       watchers.forEach(w => w.dispose());
-      this.watchers.delete(watchPath);
+      this.watchers.delete(effectivePath);
     }
 
-    this.pathToCollectionUid.delete(watchPath);
-    this.scannedCollections.delete(watchPath);
+    // Clean up all possible key formats
+    this.pathToCollectionUid.delete(nativePath);
+    this.pathToCollectionUid.delete(posixPath);
+    this.scannedCollections.delete(nativePath);
+    this.scannedCollections.delete(posixPath);
 
     if (collectionUid) {
       this.cleanupLoadingState(collectionUid);

--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -330,10 +330,12 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
     const [collectionPath] = args as [string];
 
     try {
-      watcher.removeWatcher(collectionPath);
+      // Paths from the webview are posixified; resolve to native for watcher/store lookups
+      const nativePath = path.resolve(collectionPath);
+      watcher.removeWatcher(nativePath);
 
       const lastOpenedStore = new LastOpenedCollections();
-      lastOpenedStore.remove(collectionPath);
+      lastOpenedStore.remove(nativePath);
 
       return { success: true };
     } catch (error) {
@@ -345,10 +347,12 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
     const [collectionPath, _collectionUid, workspaceId] = args as [string, string, string];
 
     try {
-      watcher.removeWatcher(collectionPath);
+      // Paths from the webview are posixified; resolve to native for watcher/store/fs lookups
+      const nativePath = path.resolve(collectionPath);
+      watcher.removeWatcher(nativePath);
 
       const lastOpenedStore = new LastOpenedCollections();
-      lastOpenedStore.remove(collectionPath);
+      lastOpenedStore.remove(nativePath);
 
       let workspacePath: string | null = null;
       if (workspaceId === 'default' || !workspaceId) {
@@ -359,7 +363,7 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
 
       if (workspacePath) {
         try {
-          const result = await removeFromWorkspaceYml(workspacePath, collectionPath);
+          const result = await removeFromWorkspaceYml(workspacePath, nativePath);
           // Use defaultWorkspaceManager UID ('default') to match what Redux expects
           const wsUid = (workspaceId === 'default' || !workspaceId)
             ? defaultWorkspaceManager.getDefaultWorkspaceUid()
@@ -1537,12 +1541,14 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
     const [collectionUid, collectionPath] = args as [string, string];
 
     try {
+      // Paths from the webview are posixified; resolve to native for watcher/store lookups
+      const nativePath = path.resolve(collectionPath);
       if (watcher && collectionPath) {
-        watcher.removeWatcher(collectionPath, collectionUid);
+        watcher.removeWatcher(nativePath, collectionUid);
       }
 
       const lastOpenedStore = new LastOpenedCollections();
-      lastOpenedStore.remove(collectionPath);
+      lastOpenedStore.remove(nativePath);
 
       sendToWebview('main:collection-closed', collectionUid);
 

--- a/src/extension/store/last-opened-collections.ts
+++ b/src/extension/store/last-opened-collections.ts
@@ -45,10 +45,13 @@ class LastOpenedCollections {
   }
 
   remove(collectionPath: string): void {
+    // path.resolve normalizes posixified paths (from webview) to native separators
+    // so they match the resolved paths returned by getAll()
+    const resolved = path.resolve(collectionPath);
     let collections = this.getAll();
 
-    if (collections.includes(collectionPath)) {
-      collections = filter(collections, (c) => c !== collectionPath);
+    if (collections.includes(resolved)) {
+      collections = filter(collections, (c) => c !== resolved);
       this.setInStorage('lastOpenedCollections', collections);
     }
   }


### PR DESCRIPTION
## Summary
- Resolve posixified paths from the webview to native separators at the IPC boundary before passing to `removeWatcher()` / `lastOpenedStore.remove()`
- Make `removeWatcher()` try both native and posixified key formats for robustness since collections may have been opened via either path format
- Fix `LastOpenedCollections.remove()` to resolve paths before comparison against stored resolved paths

## Problem
On Windows, the close/remove collection handlers received posixified paths (forward slashes) from the webview but passed them directly to the collection watcher Map and last-opened store, which use native-separator paths (backslashes) as keys. This caused lookup misses — the watcher was never cleaned up, the store entry persisted, and the collection reappeared as a ghost entry.

## Root Cause
Paths sent to the webview are posixified via `posixifyPath()` for cross-platform consistency. When the webview sends paths back (e.g., on close/remove), they retain forward slashes. On macOS/Linux this is a no-op, but on Windows `C:/Users/foo` !== `C:\Users\foo` for Map lookups and string comparisons.

## Files Changed
- `src/extension/ipc/collection.ts` — `renderer:close-collection`, `renderer:remove-collection`, `sidebar:close-collection` handlers
- `src/extension/app/collection-watcher.ts` — `removeWatcher()` method
- `src/extension/store/last-opened-collections.ts` — `remove()` method

## Test plan
- [x] Verified on Windows: removed collections no longer reappear as ghost entries
- [x] Existing e2e collection-removal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)