### PR TITLE
fix: normalize paths in env-secrets and collection-security store lookups

### DIFF
--- a/src/extension/store/collection-security.ts
+++ b/src/extension/store/collection-security.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import * as vscode from 'vscode';
 import { find } from 'lodash';
 
@@ -35,7 +36,7 @@ class CollectionSecurityStore {
 
   setSecurityConfigForCollection(collectionPathname: string, securityConfig: SecurityConfig): void {
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
 
     if (!collection) {
       collections.push({
@@ -54,7 +55,7 @@ class CollectionSecurityStore {
 
   getSecurityConfigForCollection(collectionPathname: string): SecurityConfig {
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
     return collection?.securityConfig || {};
   }
 }

--- a/src/extension/store/env-secrets.spec.ts
+++ b/src/extension/store/env-secrets.spec.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Mock the encryption module to return predictable values
+vi.mock('../utils/encryption', () => ({
+  encryptStringSafe: (str: string) => ({
+    success: true,
+    value: str ? `encrypted:${str}` : ''
+  }),
+  decryptStringSafe: (str: string) => {
+    if (str.startsWith('encrypted:')) {
+      return { success: true, value: str.replace('encrypted:', '') };
+    }
+    return { success: false, value: '' };
+  }
+}));
+
+import { EnvironmentSecretsStore, setExtensionContext } from './env-secrets';
+
+/**
+ * Creates a mock VS Code ExtensionContext with an in-memory globalState.
+ */
+function createMockContext() {
+  const store = new Map<string, unknown>();
+  return {
+    globalState: {
+      get<T>(key: string, defaultValue?: T): T {
+        return (store.get(key) as T) ?? (defaultValue as T);
+      },
+      update(key: string, value: unknown) {
+        store.set(key, value);
+        return Promise.resolve();
+      }
+    }
+  } as any;
+}
+
+describe('EnvironmentSecretsStore', () => {
+  let secretsStore: EnvironmentSecretsStore;
+
+  beforeEach(() => {
+    secretsStore = new EnvironmentSecretsStore();
+    setExtensionContext(createMockContext());
+  });
+
+  test('stores and retrieves secret environment variables', () => {
+    const collectionPath = '/Users/test/my-collection';
+    const environment = {
+      name: 'Development',
+      variables: [
+        { name: 'API_KEY', value: 'secret-key-123', secret: true },
+        { name: 'BASE_URL', value: 'https://api.example.com', secret: false }
+      ]
+    };
+
+    secretsStore.storeEnvSecrets(collectionPath, environment);
+    const secrets = secretsStore.getEnvSecrets(collectionPath, { name: 'Development' });
+
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].name).toBe('API_KEY');
+    expect(secrets[0].value).toBe('encrypted:secret-key-123');
+  });
+
+  test('only stores variables marked as secret', () => {
+    secretsStore.storeEnvSecrets('/col', {
+      name: 'env',
+      variables: [
+        { name: 'PUBLIC', value: 'visible', secret: false },
+        { name: 'PRIVATE', value: 'hidden', secret: true },
+        { name: 'ALSO_PUBLIC', value: 'shown' }
+      ]
+    });
+
+    const secrets = secretsStore.getEnvSecrets('/col', { name: 'env' });
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].name).toBe('PRIVATE');
+  });
+
+  // Test path normalization — path.resolve() on macOS normalizes these:
+  // - trailing slashes
+  // - double slashes
+  // - relative segments (..)
+  // This validates the fix even on macOS; on Windows path.resolve also normalizes / vs \
+
+  test('retrieves secrets when stored path has trailing slash', () => {
+    const storedPath = '/Users/test/my-collection/';
+    const lookupPath = '/Users/test/my-collection';
+
+    secretsStore.storeEnvSecrets(storedPath, {
+      name: 'Dev',
+      variables: [{ name: 'KEY', value: 'val', secret: true }]
+    });
+
+    const secrets = secretsStore.getEnvSecrets(lookupPath, { name: 'Dev' });
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].name).toBe('KEY');
+  });
+
+  test('retrieves secrets when paths differ by relative segments', () => {
+    const storedPath = '/Users/test/../test/my-collection';
+    const lookupPath = '/Users/test/my-collection';
+
+    secretsStore.storeEnvSecrets(storedPath, {
+      name: 'Staging',
+      variables: [{ name: 'TOKEN', value: 'tok', secret: true }]
+    });
+
+    const secrets = secretsStore.getEnvSecrets(lookupPath, { name: 'Staging' });
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].name).toBe('TOKEN');
+  });
+
+  test('retrieves secrets when lookup path has double slashes', () => {
+    const storedPath = '/Users/test/my-collection';
+    const lookupPath = '/Users/test//my-collection';
+
+    secretsStore.storeEnvSecrets(storedPath, {
+      name: 'QA',
+      variables: [{ name: 'SECRET', value: 's', secret: true }]
+    });
+
+    const secrets = secretsStore.getEnvSecrets(lookupPath, { name: 'QA' });
+    expect(secrets).toHaveLength(1);
+  });
+
+  test('does not create duplicate entries for equivalent paths', () => {
+    const path1 = '/Users/test/my-collection/';
+    const path2 = '/Users/test/my-collection';
+
+    secretsStore.storeEnvSecrets(path1, {
+      name: 'Dev',
+      variables: [{ name: 'A', value: 'first', secret: true }]
+    });
+
+    secretsStore.storeEnvSecrets(path2, {
+      name: 'Dev',
+      variables: [{ name: 'A', value: 'updated', secret: true }]
+    });
+
+    const secrets = secretsStore.getEnvSecrets(path2, { name: 'Dev' });
+    expect(secrets).toHaveLength(1);
+    expect(secrets[0].value).toBe('encrypted:updated');
+  });
+
+  test('rename works across equivalent paths', () => {
+    const storedPath = '/Users/test/collection/';
+    const renamePath = '/Users/test/collection';
+
+    secretsStore.storeEnvSecrets(storedPath, {
+      name: 'OldName',
+      variables: [{ name: 'SECRET', value: 'val', secret: true }]
+    });
+
+    secretsStore.renameEnvironment(renamePath, 'OldName', 'NewName');
+
+    const secrets = secretsStore.getEnvSecrets(renamePath, { name: 'NewName' });
+    expect(secrets).toHaveLength(1);
+
+    const oldSecrets = secretsStore.getEnvSecrets(storedPath, { name: 'OldName' });
+    expect(oldSecrets).toHaveLength(0);
+  });
+
+  test('delete works across equivalent paths', () => {
+    const storedPath = '/Users/test/collection';
+    const deletePath = '/Users/test/../test/collection';
+
+    secretsStore.storeEnvSecrets(storedPath, {
+      name: 'ToDelete',
+      variables: [{ name: 'KEY', value: 'val', secret: true }]
+    });
+
+    secretsStore.deleteEnvironment(deletePath, 'ToDelete');
+
+    const secrets = secretsStore.getEnvSecrets(storedPath, { name: 'ToDelete' });
+    expect(secrets).toHaveLength(0);
+  });
+
+  test('returns empty when collection not found', () => {
+    const secrets = secretsStore.getEnvSecrets('/nonexistent', { name: 'Dev' });
+    expect(secrets).toHaveLength(0);
+  });
+
+  test('returns empty when environment not found', () => {
+    secretsStore.storeEnvSecrets('/col', {
+      name: 'Dev',
+      variables: [{ name: 'KEY', value: 'val', secret: true }]
+    });
+
+    const secrets = secretsStore.getEnvSecrets('/col', { name: 'Nonexistent' });
+    expect(secrets).toHaveLength(0);
+  });
+});

--- a/src/extension/store/env-secrets.ts
+++ b/src/extension/store/env-secrets.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import * as vscode from 'vscode';
 import { each, find, remove } from 'lodash';
 import { encryptStringSafe } from '../utils/encryption';
@@ -60,7 +61,7 @@ class EnvironmentSecretsStore {
     });
 
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
 
     if (!collection) {
       collections.push({
@@ -93,7 +94,7 @@ class EnvironmentSecretsStore {
 
   getEnvSecrets(collectionPathname: string, environment: { name?: string }): Secret[] {
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
     if (!collection) {
       return [];
     }
@@ -108,7 +109,7 @@ class EnvironmentSecretsStore {
 
   renameEnvironment(collectionPathname: string, oldName: string, newName: string): void {
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
     if (!collection) {
       return;
     }
@@ -124,7 +125,7 @@ class EnvironmentSecretsStore {
 
   deleteEnvironment(collectionPathname: string, environmentName: string): void {
     const collections = this.getCollections();
-    const collection = find(collections, (c) => c.path === collectionPathname);
+    const collection = find(collections, (c) => path.resolve(c.path) === path.resolve(collectionPathname));
     if (!collection) {
       return;
     }


### PR DESCRIPTION
## Summary
- Normalize paths with `path.resolve()` before comparison in `env-secrets` and `collection-security` stores
- Add unit tests for the env-secrets store covering path normalization, CRUD operations, and edge cases

## Problem
Secret environment variable values disappeared on save on Windows. The secrets store used posixified paths (from the webview) as keys but native-separator paths (from the file watcher) for retrieval. On Windows, `C:/Users/foo` !== `C:\Users\foo`, so the lookup failed and secrets were never hydrated back after saving.

## Root Cause
Same class of bug as #23 — posixified vs native path separator mismatch in extension stores. The `env-secrets.ts` and `collection-security.ts` stores both used direct string comparison (`c.path === collectionPathname`) without normalizing path separators.

## Solution
Replace all `c.path === collectionPathname` comparisons with `path.resolve(c.path) === path.resolve(collectionPathname)`. On Windows, `path.resolve()` normalizes forward slashes to backslashes, making both sides match.

## Test plan
- [x] 10 unit tests added for env-secrets store (path normalization, store/retrieve, rename, delete, duplicates, edge cases)
- [x] All existing tests pass

## Files Changed
- `src/extension/store/env-secrets.ts` — normalize 4 path comparisons
- `src/extension/store/collection-security.ts` — normalize 2 path comparisons
- `src/extension/store/env-secrets.spec.ts` — new unit test file (10 tests)