### PR TITLE
fix: update @usebruno/lang and filestore, skip non-request files in parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "@tippyjs/react": "^4.2.6",
         "@usebruno/common": "0.18.0",
         "@usebruno/converters": "0.17.1",
-        "@usebruno/filestore": "0.7.1",
+        "@usebruno/filestore": "0.8.1",
         "@usebruno/js": "0.46.1",
-        "@usebruno/lang": "0.34.0",
+        "@usebruno/lang": "0.35.0",
         "@usebruno/requests": "0.15.2",
         "@usebruno/schema": "0.23.0",
         "@usebruno/vm2": "3.9.19",
@@ -6734,13 +6734,13 @@
       }
     },
     "node_modules/@usebruno/filestore": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@usebruno/filestore/-/filestore-0.7.1.tgz",
-      "integrity": "sha512-Z3naSNkwbhKf400o38eGH9m6Qi1+b2M/9wDkVm4LOi4D775hafYVvtJ6aXCNo2taF7j/s//YzRQR4zlx3Xwwfg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@usebruno/filestore/-/filestore-0.8.1.tgz",
+      "integrity": "sha512-baMtUGqoVfiY4/PfJZP+zyo81Sjba+QrIvrgLAaI443pBhuLdbv4uMFniCrz1cqo/LWHb0sQPDUQzXxBx99mkw==",
       "license": "MIT",
       "dependencies": {
         "@types/nanoid": "^2.1.0",
-        "@usebruno/lang": "0.34.0",
+        "@usebruno/lang": "0.35.0",
         "ajv": "^8.17.1",
         "lodash": "^4.17.21",
         "yaml": "^2.3.4"
@@ -6785,9 +6785,9 @@
       "license": "MIT"
     },
     "node_modules/@usebruno/lang": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@usebruno/lang/-/lang-0.34.0.tgz",
-      "integrity": "sha512-/yHM9+m2JqPjXviBWaHaUTG0N/ajn7pU0wiw3wqo6YMA5KOpCy8iZw3vi3ZlTT9A0IzRO9zPaEAAZGhMMiFVmA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@usebruno/lang/-/lang-0.35.0.tgz",
+      "integrity": "sha512-OI9XWn8kgXBVQTeSTHtcW1nGE7uSy2Xr0X79MyUPScVrMSJdkKF5JEZuKo9fkifRKvwqrxGi/OcJLzYgWQXEUg==",
       "license": "MIT",
       "dependencies": {
         "arcsecond": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "bugs": {
     "url": "https://github.com/usebruno/bruno/issues"
   },
-  "extensionKind": ["workspace"],
+  "extensionKind": [
+    "workspace"
+  ],
   "engines": {
     "vscode": "^1.80.0"
   },
@@ -463,9 +465,9 @@
     "@tippyjs/react": "^4.2.6",
     "@usebruno/common": "0.18.0",
     "@usebruno/converters": "0.17.1",
-    "@usebruno/filestore": "0.7.1",
+    "@usebruno/filestore": "0.8.1",
     "@usebruno/js": "0.46.1",
-    "@usebruno/lang": "0.34.0",
+    "@usebruno/lang": "0.35.0",
     "@usebruno/requests": "0.15.2",
     "@usebruno/schema": "0.23.0",
     "@usebruno/vm2": "3.9.19",

--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -1972,7 +1972,15 @@ get {
     }
 
     const format = getCollectionFormat(collectionPath);
-    const requestFiles = searchForRequestFiles(collectionPath, collectionPath);
+    const allFiles = searchForRequestFiles(collectionPath, collectionPath);
+    const requestFiles = allFiles.filter((filePath) => {
+      const basename = path.basename(filePath);
+      if (basename === 'folder.bru' || basename === 'folder.yml') return false;
+      if (basename === 'collection.bru' || basename === 'opencollection.yml') return false;
+      if (basename === 'bruno.json') return false;
+      if (path.basename(path.dirname(filePath)) === 'environments') return false;
+      return true;
+    });
 
     const PARSE_PARALLELISM = 20;
 
@@ -2013,6 +2021,15 @@ get {
     const [{ collectionUid, pathname }] = args as [{ collectionUid: string; pathname: string }];
 
     if (!hasRequestExtension(pathname)) {
+      return;
+    }
+
+    const basename = path.basename(pathname);
+    if (basename === 'folder.bru' || basename === 'folder.yml' ||
+        basename === 'collection.bru' || basename === 'opencollection.yml') {
+      return;
+    }
+    if (path.basename(path.dirname(pathname)) === 'environments') {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Bump `@usebruno/lang` 0.34.0 → 0.35.0 and `@usebruno/filestore` 0.7.1 → 0.8.1
- Filter out non-request files (`folder.bru`, `collection.bru`, environment files) in `renderer:mount-collection` and `renderer:load-request` handlers before calling `parseRequest`

## Problem
Opening BRU-format collections (e.g. bruno-testbench) produced noisy `parseBruRequest error` console warnings. `folder.bru` files with `auth { mode: inherit }` and environment `.bru` files with `vars {}` were being fed to the request parser which doesn't recognize those grammar blocks.

## Root Cause
`renderer:mount-collection` used `searchForRequestFiles()` which returns ALL `.bru` files including `folder.bru`, `collection.bru`, and environment files. `renderer:load-request` also had no file-type guard. Both called `parseRequest()` on every file regardless of type.

## Solution
- Filter non-request files before parsing in both handlers
- Update `@usebruno/lang` and `@usebruno/filestore` to latest versions

## Files Changed
- `package.json` / `package-lock.json` — dependency bumps
- `src/extension/ipc/collection.ts` — file type filtering in two handlers