### PR TITLE
fix: request tag changes now trigger draft state and sync across tabs

### DIFF
--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -21,7 +21,8 @@ import {
   scriptEnvironmentUpdateEvent,
   streamDataReceived,
   addTransientRequest,
-  removeTransientRequest
+  removeTransientRequest,
+  updateCollectionTagsList
 } from 'providers/ReduxStore/slices/collections';
 import {
   collectionAddEnvFileEvent,
@@ -122,6 +123,10 @@ const useIpcEvents = () => {
       }
       if (type === 'change') {
         dispatch(collectionChangeFileEvent(val as CollectionChangeFileEventPayload));
+        const changeMeta = (val as CollectionChangeFileEventPayload)?.meta;
+        if (changeMeta?.collectionUid) {
+          dispatch(updateCollectionTagsList({ collectionUid: changeMeta.collectionUid }));
+        }
       }
       if (type === 'unlink') {
         setTimeout(() => {

--- a/src/webview/providers/ReduxStore/middlewares/autosave/middleware.ts
+++ b/src/webview/providers/ReduxStore/middlewares/autosave/middleware.ts
@@ -49,6 +49,8 @@ const actionsToIntercept = [
   'collections/deleteVar',
   'collections/moveVar',
   'collections/updateRequestDocs',
+  'collections/addRequestTag',
+  'collections/deleteRequestTag',
   'collections/runRequestEvent',
   'collections/updateCollectionPresets',
 

--- a/src/webview/providers/ReduxStore/middlewares/draft/middleware.ts
+++ b/src/webview/providers/ReduxStore/middlewares/draft/middleware.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { handleMakeTabParmanent } from './utils';
 import { findCollectionByUid, findItemInCollection } from 'utils/collections';
 import { hasRequestChanges }from 'utils/collections';
+import { updateCollectionTagsList } from '../../slices/collections';
 
 interface actionsToInterceptProps {
   dispatch?: boolean;
@@ -52,6 +53,8 @@ const actionsToIntercept = [
   'collections/moveVar',
   'collections/setRequestVars',
   'collections/updateRequestDocs',
+  'collections/addRequestTag',
+  'collections/deleteRequestTag',
   'collections/runRequestEvent', // TODO: This doesn't necessarily related to a draft state, need to rethink.
 
   'collections/addFolderHeader',
@@ -120,6 +123,13 @@ export const draftDetectMiddleware = ({
       const item = collection ? findItemInCollection(collection, itemUid) : null;
       if ((item as any)?.isTransient) {
         scheduleTransientSync(item);
+      }
+    }
+
+    if (action.type === 'collections/addRequestTag' || action.type === 'collections/deleteRequestTag') {
+      const { collectionUid } = action.payload || {};
+      if (collectionUid) {
+        dispatch(updateCollectionTagsList({ collectionUid }));
       }
     }
   }

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1465,15 +1465,10 @@ export const collectionsSlice = createSlice({
       if (collection) {
         const item = findItemInCollection(collection, itemUid);
         if (item) {
-          if (!item.tags) item.tags = [];
-          if (!item.tags.includes(tag)) {
-            item.tags.push(tag);
-          }
-          if (item.draft) {
-            if (!item.draft.tags) item.draft.tags = [];
-            if (!item.draft.tags.includes(tag)) {
-              item.draft.tags.push(tag);
-            }
+          const draft = ensureDraft(item);
+          if (!draft.tags) draft.tags = [];
+          if (!draft.tags.includes(tag)) {
+            draft.tags.push(tag);
           }
         }
       }
@@ -1485,11 +1480,9 @@ export const collectionsSlice = createSlice({
       if (collection) {
         const item = findItemInCollection(collection, itemUid);
         if (item) {
-          if (item.tags) {
-            item.tags = item.tags.filter(t => t !== tag);
-          }
-          if (item.draft?.tags) {
-            item.draft.tags = item.draft.tags.filter(t => t !== tag);
+          const draft = ensureDraft(item);
+          if (draft.tags) {
+            draft.tags = draft.tags.filter(t => t !== tag);
           }
         }
       }

--- a/src/webview/providers/ReduxStore/slices/collections/request-tags.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/request-tags.spec.ts
@@ -23,7 +23,7 @@ function makeState(item: any): any {
 }
 
 describe('addRequestTag', () => {
-  test('adds tag to item.tags', () => {
+  test('creates draft and adds tag only to draft.tags (not item.tags)', () => {
     const item = { uid: 'req-1', name: 'Test', type: 'http-request', tags: [], request: { url: '' } };
     const state = makeState(item);
 
@@ -34,10 +34,14 @@ describe('addRequestTag', () => {
     }));
 
     const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toContain('smoke');
+    // item.tags stays unchanged (saved state)
+    expect(updatedItem.tags).toEqual([]);
+    // draft is created with the new tag
+    expect(updatedItem.draft).toBeDefined();
+    expect(updatedItem.draft.tags).toContain('smoke');
   });
 
-  test('adds tag to item.draft.tags when draft exists', () => {
+  test('adds tag to existing draft.tags', () => {
     const item = {
       uid: 'req-1',
       name: 'Test',
@@ -61,39 +65,14 @@ describe('addRequestTag', () => {
     }));
 
     const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toContain('regression');
+    // item.tags unchanged
+    expect(updatedItem.tags).toEqual(['existing']);
+    // draft.tags updated
+    expect(updatedItem.draft.tags).toContain('existing');
     expect(updatedItem.draft.tags).toContain('regression');
   });
 
-  test('initializes draft.tags if draft exists but tags is undefined', () => {
-    const item = {
-      uid: 'req-1',
-      name: 'Test',
-      type: 'http-request',
-      tags: [],
-      request: { url: '' },
-      draft: {
-        uid: 'req-1',
-        name: 'Test',
-        type: 'http-request',
-        request: { url: 'http://edited.com' }
-        // no tags field
-      }
-    };
-    const state = makeState(item);
-
-    const result = collectionsReducer(state, addRequestTag({
-      collectionUid: 'col-1',
-      itemUid: 'req-1',
-      tag: 'api'
-    }));
-
-    const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toContain('api');
-    expect(updatedItem.draft.tags).toContain('api');
-  });
-
-  test('does not add duplicate tags', () => {
+  test('does not add duplicate tags to draft', () => {
     const item = {
       uid: 'req-1',
       name: 'Test',
@@ -111,13 +90,12 @@ describe('addRequestTag', () => {
     }));
 
     const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toEqual(['smoke']);
     expect(updatedItem.draft.tags).toEqual(['smoke']);
   });
 });
 
 describe('deleteRequestTag', () => {
-  test('removes tag from item.tags', () => {
+  test('creates draft and removes tag only from draft.tags', () => {
     const item = { uid: 'req-1', name: 'Test', type: 'http-request', tags: ['smoke', 'api'], request: { url: '' } };
     const state = makeState(item);
 
@@ -128,10 +106,14 @@ describe('deleteRequestTag', () => {
     }));
 
     const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toEqual(['api']);
+    // item.tags stays unchanged (saved state)
+    expect(updatedItem.tags).toEqual(['smoke', 'api']);
+    // draft is created with the tag removed
+    expect(updatedItem.draft).toBeDefined();
+    expect(updatedItem.draft.tags).toEqual(['api']);
   });
 
-  test('removes tag from both item.tags and item.draft.tags', () => {
+  test('removes tag from existing draft.tags', () => {
     const item = {
       uid: 'req-1',
       name: 'Test',
@@ -149,7 +131,9 @@ describe('deleteRequestTag', () => {
     }));
 
     const updatedItem = result.collections[0].items[0];
-    expect(updatedItem.tags).toEqual(['api']);
+    // item.tags unchanged
+    expect(updatedItem.tags).toEqual(['smoke', 'api']);
+    // draft.tags updated
     expect(updatedItem.draft.tags).toEqual(['api']);
   });
 });


### PR DESCRIPTION
## Summary
- Tag add/remove on the request panel now properly triggers draft (unsaved) state and enables the save button
- Tag list refreshes across all webview panels (including runner) after save

## Problem
Adding or removing tags on a request did not trigger the dirty/draft state. The save button in the URL bar stayed disabled, and the runner panel's tag filter list didn't update after saving tag changes.

## Root Cause
1. `addRequestTag`/`deleteRequestTag` reducers modified `item.tags` directly without creating a draft via `ensureDraft()`, so `hasRequestChanges()` never detected a difference
2. Tag actions were missing from both the draft and autosave middleware intercept lists
3. `updateCollectionTagsList` was never dispatched after tag changes or file change events, so the runner's `allTags` was stale

## Solution
- Reducers now only modify `draft.tags` (via `ensureDraft`), leaving `item.tags` as the saved state
- Added `collections/addRequestTag` and `collections/deleteRequestTag` to both middleware intercept lists
- Draft middleware dispatches `updateCollectionTagsList` after tag actions
- `useIpcEvents` dispatches `updateCollectionTagsList` after `change` events from the file watcher

## Files Changed
- `src/webview/providers/ReduxStore/slices/collections/index.ts`
- `src/webview/providers/ReduxStore/middlewares/draft/middleware.ts`
- `src/webview/providers/ReduxStore/middlewares/autosave/middleware.ts`
- `src/webview/providers/App/useIpcEvents.ts`
- `src/webview/providers/ReduxStore/slices/collections/request-tags.spec.ts`