### PR TITLE
fix: OAuth2 authorization cancellation not working

### DIFF
--- a/src/extension/ipc/network/authorize-user-in-system-browser.ts
+++ b/src/extension/ipc/network/authorize-user-in-system-browser.ts
@@ -129,7 +129,7 @@ interface ImplicitFlowOptions {
 
 export async function getOAuth2AuthorizationCode(options: AuthorizationCodeOptions): Promise<AuthorizationResult> {
   if (isAuthorizationInProgress()) {
-    throw new Error('An OAuth2 authorization request is already in progress');
+    cancelAuthorization();
   }
 
   const { authorizationUrl, callbackUrl, clientId, scope, state, pkce, codeChallenge, additionalParameters } = options;
@@ -166,7 +166,7 @@ export async function getOAuth2AuthorizationCode(options: AuthorizationCodeOptio
 
 export async function getOAuth2ImplicitToken(options: ImplicitFlowOptions): Promise<AuthorizationResult> {
   if (isAuthorizationInProgress()) {
-    throw new Error('An OAuth2 authorization request is already in progress');
+    cancelAuthorization();
   }
 
   const { authorizationUrl, callbackUrl, clientId, scope, state, additionalParameters } = options;

--- a/src/extension/ipc/network/oauth2-handlers.ts
+++ b/src/extension/ipc/network/oauth2-handlers.ts
@@ -82,7 +82,9 @@ export function registerOAuth2Handlers(): void {
 
   // Cancel pending browser authorization
   registerHandler('renderer:cancel-oauth2-authorization-request', async () => {
+    const wasInProgress = isAuthorizationInProgress();
     cancelAuthorization();
+    return { success: true, cancelled: wasInProgress };
   });
 }
 

--- a/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
+++ b/src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import { cloneDeep, find } from 'lodash';
 import { IconX } from '@tabler/icons';
 import { interpolate } from '@usebruno/common';
-import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest, isOauth2AuthorizationRequestInProgress } from 'providers/ReduxStore/slices/collections/actions';
+import { fetchOauth2Credentials, clearOauth2Cache, refreshOauth2Credentials, cancelOauth2AuthorizationRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { getAllVariables } from 'utils/collections/index';
 import Button from 'ui/Button';
 import type { AppCollection, AppItem, OAuth2CredentialEntry } from '@bruno-types';
@@ -29,21 +29,9 @@ const Oauth2ActionButtons = ({
   const dispatch = useDispatch();
   const [fetchingToken, toggleFetchingToken] = useState(false);
   const [refreshingToken, toggleRefreshingToken] = useState(false);
-  const [fetchingAuthorizationCode, toggleFetchingAuthorizationCode] = useState(false);
-
-  useEffect(() => {
-    if (fetchingToken) {
-      const getRequestStatus = async () => {
-        try {
-          const inProgress = await (dispatch(isOauth2AuthorizationRequestInProgress()) as unknown as Promise<boolean>);
-          toggleFetchingAuthorizationCode(inProgress);
-        } catch (err) {
-          console.error('Error checking pending authorization:', err);
-        }
-      };
-      getRequestStatus();
-    }
-  }, [fetchingToken, dispatch]);
+  const oauth2Config = (request as any)?.auth?.oauth2 || {};
+  const isBrowserFlow = oauth2Config.grantType === 'authorization_code' || oauth2Config.grantType === 'implicit';
+  const showCancelButton = fetchingToken && isBrowserFlow;
 
   const allVariables = useMemo(() => getAllVariables(collection, item), [collection, item]);
 
@@ -91,7 +79,6 @@ const Oauth2ActionButtons = ({
       toast.error(err?.message || 'An error occurred while fetching token!');
     } finally {
       toggleFetchingToken(false);
-      toggleFetchingAuthorizationCode(false);
     }
   };
 
@@ -140,12 +127,9 @@ const Oauth2ActionButtons = ({
 
   const handleCancelAuthorization = async () => {
     try {
-      const result = await (dispatch(cancelOauth2AuthorizationRequest()) as unknown as Promise<{ success?: boolean; cancelled?: boolean }>);
-      if (result.success && result.cancelled) {
-        toast.error('Authorization cancelled');
-        toggleFetchingToken(false);
-        toggleFetchingAuthorizationCode(false);
-      }
+      await (dispatch(cancelOauth2AuthorizationRequest()) as unknown as Promise<{ success?: boolean; cancelled?: boolean }>);
+      toast.error('Authorization cancelled');
+      toggleFetchingToken(false);
     } catch (err) {
       console.error('Error cancelling authorization:', err);
       toast.error('Failed to cancel authorization');
@@ -178,7 +162,7 @@ const Oauth2ActionButtons = ({
             </Button>
           )
         : null}
-      {fetchingAuthorizationCode
+      {showCancelButton
         ? (
             <Button
               size="sm"


### PR DESCRIPTION
## Summary
- Cancel button now appears immediately for browser-based OAuth2 flows (authorization_code/implicit)
- Clicking "Get Access Token" again auto-cancels any stale authorization instead of erroring
- Cancel IPC handler returns proper result for UI feedback

## Problem
1. Cancel button never appeared — `isAuthorizationInProgress` was polled once via `useEffect` before the browser opened, always returning false
2. Second click on "Get Access Token" threw "already in progress" error because stale authorization state was never cleaned up
3. Cancel IPC handler returned `undefined`, so the UI couldn't detect successful cancellation

## Solution
- Show cancel button based on `fetchingToken && isBrowserFlow` instead of polling `isAuthorizationInProgress`
- Auto-cancel stale authorization in `getOAuth2AuthorizationCode`/`getOAuth2ImplicitToken` instead of throwing
- Return `{ success, cancelled }` from the cancel handler

## Files Changed
- `src/extension/ipc/network/authorize-user-in-system-browser.ts`
- `src/extension/ipc/network/oauth2-handlers.ts`
- `src/webview/components/RequestPane/Auth/OAuth2/Oauth2ActionButtons/index.tsx`