### PR TITLE
fix: transient request not appearing in sidebar after save

### DIFF
--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -36,6 +36,8 @@ const transientPanels = new Map<string, vscode.WebviewPanel>();
 // Store transient item data so we can forward it to new panels
 const transientItems = new Map<string, Record<string, unknown>>();
 
+const savedPanels = new Set<string>();
+
 export function storeTransientItem(itemUid: string, item: Record<string, unknown>): void {
   transientItems.set(itemUid, item);
 }
@@ -83,6 +85,15 @@ export async function openTransientRequestPanel(
   });
 
   panel.onDidDispose(() => {
+    if (savedPanels.has(itemUid)) {
+      savedPanels.delete(itemUid);
+      stateManager.removeWebview(panel.webview);
+      transientPanels.delete(itemUid);
+      transientItems.delete(itemUid);
+      stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+      return;
+    }
+
     const GRACE_MS = 10_000;
 
     const timer = setTimeout(() => {
@@ -309,7 +320,7 @@ async function saveTransientRequest(
     const content = await stringifyRequestViaWorker({ ...itemData, name, filename }, { format });
     fs.writeFileSync(fullPath, content, 'utf-8');
 
-    // Close the transient panel
+    savedPanels.add(itemUid);
     panel.dispose();
 
     // Open the saved file in the regular editor

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1633,7 +1633,7 @@ export const collectionsSlice = createSlice({
         currentSubItems = childItem.items;
       }
 
-      if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name)) {
+      if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name && !f.isTransient)) {
         const currentItem = find(currentSubItems, (i) => i.uid === data?.uid);
         if (currentItem) {
           // Preserve existing draft and response if they exist (don't overwrite unsaved changes)
@@ -1762,7 +1762,7 @@ export const collectionsSlice = createSlice({
           currentSubItems = childItem.items;
         }
 
-        if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name)) {
+        if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name && !f.isTransient)) {
           const currentItem = find(currentSubItems, (i) => i.uid === data?.uid);
           if (currentItem) {
             const existingDraft = currentItem.draft;


### PR DESCRIPTION
## Summary
- Fixed transient requests not showing in sidebar after being saved to disk
- Skip the restoration modal when a transient panel is closed via save

## Problem
When saving a transient request, the file watcher detects the new file and dispatches `collectionAddFileEvent`. However, the reducer's dedup check (`!currentSubItems.find((f) => f.name === data?.name)`) matched the existing transient item by name, preventing the saved file's item from being added to the sidebar tree. After the 10s grace period, the transient item was also removed — leaving nothing in the sidebar.

## Solution
- Added `&& !f.isTransient` to the name collision check in both `collectionAddFileEvent` and `collectionAddFilesEvent` reducers, so transient items don't block real files from being inserted
- Track panels closed via save with a `savedPanels` set so the dispose handler skips the "Undo to restore" toast and cleans up immediately

## Files Changed
- `src/webview/providers/ReduxStore/slices/collections/index.ts` — dedup check fix
- `src/extension/panels/transient-request-panel.ts` — skip restoration modal on save