### PR TITLE
fix: folder-level variables not saving due to wrong draft path

### DIFF
--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -2714,9 +2714,9 @@ export const collectionsSlice = createSlice({
         ...(type === 'response' ? { local } : {})
       }));
       if (type === 'request') {
-        set(folder, 'draft.request.vars.req', mappedVars);
+        set(folder, 'draft.root.request.vars.req', mappedVars);
       } else if (type === 'response') {
-        set(folder, 'draft.request.vars.res', mappedVars);
+        set(folder, 'draft.root.request.vars.res', mappedVars);
       }
     },
 


### PR DESCRIPTION
## Summary
- Fixed folder-level variables (pre-request and post-response) not being added/saved

## Problem
Users were unable to add variables at the folder level. Changes made in the Vars tab of folder settings were silently lost.

## Root Cause
The `setFolderVars` reducer wrote vars to `folder.draft.request.vars.req` instead of `folder.draft.root.request.vars.req` (missing `root` in the path). The UI reads from `draft.root.request.vars`, so the written values were never visible and never persisted to disk.

## Solution
Fixed the `set()` paths in the `setFolderVars` reducer from `draft.request.vars.{req|res}` to `draft.root.request.vars.{req|res}`, matching the pattern used by `setCollectionVars`.

## Files Changed
- `src/webview/providers/ReduxStore/slices/collections/index.ts`