### PR TITLE
fix: copy-paste and clone losing request URL and body data

### DIFF
--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -847,6 +847,38 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
     }
   });
 
+  registerHandler('renderer:clone-request', async (args) => {
+    const [sourcePathname, destPathname, newName, newSeq] = args as [string, string, string, number];
+
+    try {
+      if (!fs.existsSync(sourcePathname)) {
+        throw new Error(`source: ${sourcePathname} does not exist`);
+      }
+      if (fs.existsSync(destPathname)) {
+        throw new Error(`destination: ${destPathname} already exists`);
+      }
+
+      const collectionPath = findCollectionPathByItemPath(sourcePathname);
+      if (!collectionPath) {
+        throw new Error('Collection not found for the given pathname');
+      }
+
+      const format = getCollectionFormat(collectionPath);
+      const content = fs.readFileSync(sourcePathname, 'utf8');
+      const parsed = await parseRequest(content, { format });
+
+      parsed.name = newName;
+      parsed.seq = newSeq;
+
+      const newContent = await stringifyRequest(parsed, { format });
+      await writeFile(destPathname, newContent);
+
+      return { success: true };
+    } catch (error) {
+      throw error;
+    }
+  });
+
   registerHandler('renderer:copy-item', async (args) => {
     const [sourcePath, destinationPath] = args as [string, string];
 

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -1041,9 +1041,6 @@ export const cloneItem = (newName: string, newFilename: string, itemUid: string,
 
     const parentItem = findParentItemInCollection(collectionCopy, itemUid);
     const filename = resolveRequestFilename(newFilename, collection.format);
-    const itemToSave = refreshUidsInItem(transformRequestToSaveToFilesystem(item));
-    set(itemToSave, 'name', trim(newName));
-    set(itemToSave, 'filename', trim(filename));
     if (!parentItem) {
       const reqWithSameNameExists = find(
         collection.items,
@@ -1053,11 +1050,9 @@ export const cloneItem = (newName: string, newFilename: string, itemUid: string,
         const fullPathname = path.join(collection.pathname, filename);
         const { ipcRenderer } = window;
         const requestItems = filter(collection.items, (i) => i.type !== 'folder');
-        itemToSave.seq = requestItems ? requestItems.length + 1 : 1;
+        const newSeq = requestItems ? requestItems.length + 1 : 1;
 
-        itemSchema
-          .validate(itemToSave)
-          .then(() => ipcRenderer.invoke('renderer:new-request', fullPathname, itemToSave))
+        ipcRenderer.invoke('renderer:clone-request', item.pathname, fullPathname, trim(newName), newSeq)
           .then(resolve)
           .catch(reject);
 
@@ -1082,11 +1077,9 @@ export const cloneItem = (newName: string, newFilename: string, itemUid: string,
         const fullName = path.join(dirname, filename);
         const { ipcRenderer } = window;
         const requestItems = filter(parentItem.items, (i) => i.type !== 'folder');
-        itemToSave.seq = requestItems ? requestItems.length + 1 : 1;
+        const newSeq = requestItems ? requestItems.length + 1 : 1;
 
-        itemSchema
-          .validate(itemToSave)
-          .then(() => ipcRenderer.invoke('renderer:new-request', fullName, itemToSave))
+        ipcRenderer.invoke('renderer:clone-request', item.pathname, fullName, trim(newName), newSeq)
           .then(resolve)
           .catch(reject);
 
@@ -1159,17 +1152,12 @@ export const pasteItem = (targetCollectionUid: string, targetItemUid: string | n
           const { newName, newFilename } = generateUniqueName(copiedItem.name, existingItems, false);
 
           const filename = resolveRequestFilename(newFilename, targetCollection.format);
-          const itemToSave = refreshUidsInItem(transformRequestToSaveToFilesystem(copiedItem));
-          set(itemToSave, 'name', trim(newName));
-          set(itemToSave, 'filename', trim(filename));
-
           const fullPathname = path.join(targetParentPathname, filename);
           const { ipcRenderer } = window;
           const requestItems = filter(existingItems, (i) => i.type !== 'folder');
-          itemToSave.seq = requestItems ? requestItems.length + 1 : 1;
+          const newSeq = requestItems ? requestItems.length + 1 : 1;
 
-          await itemSchema.validate(itemToSave);
-          await ipcRenderer.invoke('renderer:new-request', fullPathname, itemToSave, targetCollection.format);
+          await ipcRenderer.invoke('renderer:clone-request', copiedItem.pathname, fullPathname, trim(newName), newSeq);
 
           dispatch(insertTaskIntoQueue({
             uid: uuid(),


### PR DESCRIPTION
## Summary
- Add `renderer:clone-request` IPC handler that reads source file from disk for full request data
- Update `pasteItem` and `cloneItem` actions to use the new handler

## Problem
When copying/cloning a request via the context menu, the pasted request was missing its URL, body, headers, and other data. Only the name and method were preserved.

## Root Cause
The copy-paste flow serialized the item from Redux state using `transformRequestToSaveToFilesystem()`. However, items in Redux can be **partially parsed** (meta-only for sidebar performance), where `request.url` is `''`, `request.body` is `{ mode: 'none' }`, etc. The serialized clone inherited this incomplete data.

## Solution
Added a `renderer:clone-request` IPC handler that reads the source `.bru`/`.yml` file directly from disk (getting the complete request data), updates the name/seq, and writes the clone. Updated both `pasteItem` and `cloneItem` actions to use this handler instead of `renderer:new-request`.

## Test plan
- [ ] Copy a request via context menu → paste in same folder → verify URL, body, headers are preserved
- [ ] Copy a request → paste in different folder → verify full data preserved
- [ ] Clone/duplicate a request → verify full data preserved
- [ ] Copy a partially-loaded request (one that hasn't been opened yet) → paste → verify URL is present
- [x] TypeScript typecheck passes

JIRA: https://usebruno.atlassian.net/browse/VSCODE-59