### PR TITLE
fix: old folder persists in sidebar after drag-and-drop move

### DIFF
--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -784,6 +784,9 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
       }
 
       validatePathIsInsideCollection(sourcePathname);
+      const sourceIsDirectory = fs.statSync(sourcePathname).isDirectory();
+      const collectionPath = findCollectionPathByItemPath(sourcePathname);
+      const collectionUid = collectionPath ? generateUidBasedOnHash(collectionPath) : null;
 
       const sourceDirname = path.dirname(sourcePathname);
       const pathnamesBefore = await getPaths(sourcePathname);
@@ -794,6 +797,12 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
       pathnamesAfter?.forEach((_, index) => {
         moveRequestUid(pathnamesBefore[index], pathnamesAfter[index]);
       });
+      if (sourceIsDirectory && collectionUid) {
+        broadcastToAllWebviews('main:collection-tree-updated', 'unlinkDir', {
+          directory: { pathname: posixifyPath(sourcePathname) },
+          meta: { collectionUid }
+        });
+      }
 
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Broadcast `unlinkDir` event after directory move so the old folder is removed from the sidebar

## Problem
When dragging a folder into another folder, the folder appeared in the new location but the old folder remained visible in the sidebar. The move couldn't be "reverted" because the stale folder entry persisted.

## Root Cause
VS Code's `createFileSystemWatcher` only watches file patterns (`**/*.bru` / `**/*.yml`), not directory deletions. When `removePath` deletes a folder during a move, the watcher fires `unlink` events for the `.bru` files inside but **not** for the directory itself. The Redux store never received an `unlinkDir` event, so the empty folder node stayed in the collection tree.

## Solution
After `removePath` completes in the `renderer:move-item` handler, check if the source was a directory and broadcast an `unlinkDir` event to all webviews. The existing `collectionUnlinkDirectoryEvent` reducer handles the removal from the Redux store.

## Test plan
- [ ] Drag a folder into another folder → verify old folder disappears from sidebar
- [ ] Drag the folder back out → verify it moves correctly and old location is cleaned up
- [ ] Drag a request file (not folder) → verify normal move still works
- [x] TypeScript typecheck passes

JIRA: https://usebruno.atlassian.net/browse/VSCODE-46