### PR TITLE
fix: duplicate toast when opening an already-opened collection

### DIFF
--- a/src/extension/app/collections.ts
+++ b/src/extension/app/collections.ts
@@ -148,16 +148,15 @@ export const openCollectionDialog = async (watcher: CollectionWatcher): Promise<
 
   await Promise.all(openCollectionPromises);
 
-  // Show toast if user tried to open collections that were already open
-  if (alreadyOpenCount > 0 && messageSender) {
+  if (alreadyOpenCount > 0) {
     const message = alreadyOpenCount === 1
       ? 'Collection is already opened'
       : `${alreadyOpenCount} collections are already opened`;
-    messageSender('main:toast-success', message);
+    vscode.window.showInformationMessage(message);
   }
 
-  if (invalidPaths.length > 0 && messageSender) {
-    messageSender('main:display-error', `Some selected folders could not be opened: ${invalidPaths.join(', ')}`);
+  if (invalidPaths.length > 0) {
+    vscode.window.showErrorMessage(`Some selected folders could not be opened: ${invalidPaths.join(', ')}`);
   }
 };
 
@@ -219,8 +218,8 @@ export const openCollection = async (
     return { alreadyOpen: watcherExists };
   } catch (err) {
     const error = err as Error;
-    if (!options.dontSendDisplayErrors && messageSender) {
-      messageSender('main:display-error', error.message || 'An error occurred while opening the local collection');
+    if (!options.dontSendDisplayErrors) {
+      vscode.window.showErrorMessage(error.message || 'An error occurred while opening the local collection');
     }
     return { alreadyOpen: false };
   }


### PR DESCRIPTION
## Summary
- Replace webview-broadcast toasts with native VS Code notifications for open collection messages

## Problem
When opening an already-opened collection, the "Collection is already opened" toast appeared twice — once in the sidebar and once in the tab editor. Similarly, error messages like "The collection is not valid" showed in both places.

## Root Cause
The `openCollectionDialog` and `openCollection` functions used `messageSender` (which broadcasts to ALL webviews) to send `main:toast-success` and `main:display-error` events. Every webview with a `<Toaster>` rendered the notification independently.

## Solution
Replace `messageSender('main:toast-success', ...)` and `messageSender('main:display-error', ...)` with native `vscode.window.showInformationMessage` and `vscode.window.showErrorMessage`. These display a single notification in VS Code's notification area.

## Test plan
- [ ] Open an already-opened collection → verify single "Collection is already opened" notification
- [ ] Open an invalid folder (no bruno.json/opencollection.yml) → verify single error notification
- [ ] Open multiple invalid folders → verify single error listing them
- [x] TypeScript typecheck passes