### PR TITLE
fix: add multiline validation error for header name and value fields

### DIFF
--- a/src/webview/components/CollectionSettings/Headers/index.tsx
+++ b/src/webview/components/CollectionSettings/Headers/index.tsx
@@ -4,20 +4,11 @@ import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import { setCollectionHeaders } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
-import SingleLineEditor from 'components/SingleLineEditor';
 import EditableTable from 'components/EditableTable';
+import HeaderEditor, { getHeaderRowError } from 'components/HeaderEditor';
 import StyledWrapper from './StyledWrapper';
-import { headers as StandardHTTPHeaders } from 'know-your-http-well';
-import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import BulkEditor from 'components/BulkEditor/index';
 import Button from 'ui/Button';
-
-interface headerAutoCompleteListProps {
-  collection?: React.ReactNode;
-}
-
-
-const headerAutoCompleteList = StandardHTTPHeaders.map((e: any) => e.header);
 
 const Headers = ({
   collection
@@ -46,42 +37,20 @@ const Headers = ({
       isKeyField: true,
       placeholder: 'Name',
       width: '30%',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={handleSave}
-          onChange={(newValue: any) => onChange(newValue.replace(/[\r\n]/g, ''))}
-          autocomplete={headerAutoCompleteList}
-          collection={collection}
-          placeholder={isLastEmptyRow ? 'Name' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="name" value={value} theme={storedTheme} onSave={handleSave} onChange={onChange}
+          collection={collection} rowUid={row.uid} isLastEmptyRow={isLastEmptyRow}
+          placeholder={isLastEmptyRow ? 'Name' : ''} />
       )
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={handleSave}
-          onChange={onChange}
-          collection={collection}
-          autocomplete={MimeTypes}
-          placeholder={isLastEmptyRow ? 'Value' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="value" value={value} theme={storedTheme} onSave={handleSave} onChange={onChange}
+          collection={collection} rowUid={row.uid} isLastEmptyRow={isLastEmptyRow}
+          placeholder={isLastEmptyRow ? 'Value' : ''} />
       )
     }
   ];
@@ -118,6 +87,7 @@ const Headers = ({
         rows={headers}
         onChange={handleHeadersChange}
         defaultRow={defaultRow}
+        getRowError={getHeaderRowError}
       />
       <div className="flex justify-end mt-2">
         <button className="text-link select-none" onClick={toggleBulkEditMode}>

--- a/src/webview/components/FolderSettings/Headers/index.tsx
+++ b/src/webview/components/FolderSettings/Headers/index.tsx
@@ -4,21 +4,11 @@ import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import { setFolderHeaders } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
-import SingleLineEditor from 'components/SingleLineEditor';
 import EditableTable from 'components/EditableTable';
+import HeaderEditor, { getHeaderRowError } from 'components/HeaderEditor';
 import StyledWrapper from './StyledWrapper';
-import { headers as StandardHTTPHeaders } from 'know-your-http-well';
-import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import BulkEditor from 'components/BulkEditor/index';
 import Button from 'ui/Button';
-
-interface headerAutoCompleteListProps {
-  collection?: React.ReactNode;
-  folder: React.ReactNode;
-}
-
-
-const headerAutoCompleteList = StandardHTTPHeaders.map((e: any) => e.header);
 
 const Headers = ({
   collection,
@@ -52,43 +42,20 @@ const Headers = ({
       isKeyField: true,
       placeholder: 'Name',
       width: '30%',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={handleSave}
-          onChange={(newValue: any) => onChange(newValue.replace(/[\r\n]/g, ''))}
-          autocomplete={headerAutoCompleteList}
-          collection={collection}
-          placeholder={isLastEmptyRow ? 'Name' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="name" value={value} theme={storedTheme} onSave={handleSave} onChange={onChange}
+          collection={collection} rowUid={row.uid} isLastEmptyRow={isLastEmptyRow}
+          placeholder={isLastEmptyRow ? 'Name' : ''} />
       )
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={handleSave}
-          onChange={onChange}
-          collection={collection}
-          item={folder}
-          autocomplete={MimeTypes}
-          placeholder={isLastEmptyRow ? 'Value' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="value" value={value} theme={storedTheme} onSave={handleSave} onChange={onChange}
+          collection={collection} item={folder} rowUid={row.uid} isLastEmptyRow={isLastEmptyRow}
+          placeholder={isLastEmptyRow ? 'Value' : ''} />
       )
     }
   ];
@@ -125,6 +92,7 @@ const Headers = ({
         rows={headers}
         onChange={handleHeadersChange}
         defaultRow={defaultRow}
+        getRowError={getHeaderRowError}
       />
       <div className="flex justify-end mt-2">
         <button className="text-link select-none" onClick={toggleBulkEditMode}>

--- a/src/webview/components/HeaderEditor/index.tsx
+++ b/src/webview/components/HeaderEditor/index.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback } from 'react';
+import SingleLineEditor from 'components/SingleLineEditor';
+import { IconAlertCircle } from '@tabler/icons';
+import { Tooltip } from 'react-tooltip';
+import { headers as StandardHTTPHeaders } from 'know-your-http-well';
+import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
+
+const headerNameRegex = /^[^\s\r\n]*$/;
+const headerValueRegex = /^[^\r\n]*$/;
+
+export const headerAutoCompleteList = StandardHTTPHeaders.map((e: any) => e.header);
+
+export const getHeaderRowError = (row: any, _index: any, key: any): string | null => {
+  if (key === 'name') {
+    if (!row.name || row.name.trim() === '') return null;
+    if (!headerNameRegex.test(row.name)) {
+      return 'Header name cannot contain spaces or newlines';
+    }
+  }
+  if (key === 'value') {
+    if (!row.value) return null;
+    if (!headerValueRegex.test(row.value)) {
+      return 'Header value cannot contain newlines';
+    }
+  }
+  return null;
+};
+
+interface HeaderEditorProps {
+  value: string;
+  theme: any;
+  onSave: () => void;
+  onChange: (value: string) => void;
+  onRun?: () => void;
+  collection: any;
+  item?: any;
+  placeholder?: string;
+  type: 'name' | 'value';
+  rowUid?: string;
+  isLastEmptyRow?: boolean;
+}
+
+const HeaderEditor = ({
+  value,
+  theme,
+  onSave,
+  onChange,
+  onRun,
+  collection,
+  item,
+  placeholder,
+  type,
+  rowUid,
+  isLastEmptyRow
+}: HeaderEditorProps) => {
+  const error = type === 'name'
+    ? (value && !headerNameRegex.test(value) ? 'Header name cannot contain spaces or newlines' : null)
+    : (value && !headerValueRegex.test(value) ? 'Header value cannot contain newlines' : null);
+
+  const handleChange = type === 'name'
+    ? (newValue: string) => onChange(newValue.replace(/[\r\n]/g, ''))
+    : onChange;
+
+  return (
+    <div className="flex items-center w-full">
+      <div className="flex-1">
+        <SingleLineEditor
+          value={value || ''}
+          theme={theme}
+          onSave={onSave}
+          onChange={handleChange}
+          onRun={onRun}
+          autocomplete={type === 'name' ? headerAutoCompleteList : MimeTypes}
+          collection={collection}
+          item={item}
+          placeholder={placeholder}
+        />
+      </div>
+      {error && !isLastEmptyRow && (
+        <span className="ml-1">
+          <IconAlertCircle
+            data-tooltip-id={`error-${rowUid}-${type}`}
+            className="text-red-600 cursor-pointer"
+            size={20}
+          />
+          <Tooltip className="tooltip-mod" id={`error-${rowUid}-${type}`} html={error} />
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default HeaderEditor;

--- a/src/webview/components/RequestPane/RequestHeaders/index.tsx
+++ b/src/webview/components/RequestPane/RequestHeaders/index.tsx
@@ -4,21 +4,10 @@ import { useDispatch } from 'react-redux';
 import { useTheme } from 'providers/Theme';
 import { moveRequestHeader, setRequestHeaders } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
-import SingleLineEditor from 'components/SingleLineEditor';
 import EditableTable from 'components/EditableTable';
+import HeaderEditor, { getHeaderRowError } from 'components/HeaderEditor';
 import StyledWrapper from './StyledWrapper';
-import { headers as StandardHTTPHeaders } from 'know-your-http-well';
-import { MimeTypes } from 'utils/codemirror/autocompleteConstants';
 import BulkEditor from '../../BulkEditor';
-
-interface headerAutoCompleteListProps {
-  item?: React.ReactNode;
-  collection?: React.ReactNode;
-  addHeaderText?: unknown;
-}
-
-
-const headerAutoCompleteList = StandardHTTPHeaders.map((e: any) => e.header);
 
 const RequestHeaders = ({
   item,
@@ -62,46 +51,20 @@ const RequestHeaders = ({
       isKeyField: true,
       placeholder: 'Name',
       width: '30%',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={(newValue: any) => onChange(newValue.replace(/[\r\n]/g, ''))}
-          autocomplete={headerAutoCompleteList}
-          onRun={handleRun}
-          collection={collection}
-          item={item}
-          placeholder={isLastEmptyRow ? 'Name' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="name" value={value} theme={storedTheme} onSave={onSave} onChange={onChange}
+          onRun={handleRun} collection={collection} item={item} rowUid={row.uid}
+          isLastEmptyRow={isLastEmptyRow} placeholder={isLastEmptyRow ? 'Name' : ''} />
       )
     },
     {
       key: 'value',
       name: 'Value',
       placeholder: 'Value',
-      render: ({
-        row,
-        value,
-        onChange,
-        isLastEmptyRow
-      }: any) => (
-        <SingleLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={onChange}
-          onRun={handleRun}
-          autocomplete={MimeTypes}
-          collection={collection}
-          item={item}
-          placeholder={isLastEmptyRow ? 'Value' : ''}
-        />
+      render: ({ row, value, onChange, isLastEmptyRow }: any) => (
+        <HeaderEditor type="value" value={value} theme={storedTheme} onSave={onSave} onChange={onChange}
+          onRun={handleRun} collection={collection} item={item} rowUid={row.uid}
+          isLastEmptyRow={isLastEmptyRow} placeholder={isLastEmptyRow ? 'Value' : ''} />
       )
     }
   ];
@@ -133,6 +96,7 @@ const RequestHeaders = ({
         rows={headers || []}
         onChange={handleHeadersChange}
         defaultRow={defaultRow}
+        getRowError={getHeaderRowError}
         reorderable={true}
         onReorder={handleHeaderDrag}
       />


### PR DESCRIPTION
## Summary
- Extract shared `HeaderEditor` component with inline multiline validation
- Apply validation to request, folder, and collection level header tables

## Problem
No error message was displayed when entering multiline header values. HTTP headers cannot contain newlines (RFC 7230), and users had no feedback about invalid input.

## Solution
Created a shared `HeaderEditor` component (`src/webview/components/HeaderEditor/`) that wraps `SingleLineEditor` with:
- Regex validation: header names cannot contain spaces or newlines, header values cannot contain newlines
- Error icon with tooltip shown inline next to the field
- Newline stripping on the name field (matching existing behavior)

Updated all three header table components to use the shared component:
- `RequestPane/RequestHeaders` (request level)
- `FolderSettings/Headers` (folder level)
- `CollectionSettings/Headers` (collection level)

Also exports `getHeaderRowError` for use with `EditableTable`'s `getRowError` prop.

## Test plan
- [ ] Enter a multiline value in a request header name → verify error icon appears
- [ ] Enter a multiline value in a request header value → verify error icon appears
- [ ] Hover over the error icon → verify tooltip shows explanation
- [ ] Verify same behavior on folder-level and collection-level headers
- [x] TypeScript typecheck passes