### PR TITLE
fix: relativeDate shows "0 month ago" between 28 and 29 days

### DIFF
--- a/src/webview/utils/common/index.tsx
+++ b/src/webview/utils/common/index.tsx
@@ -165,7 +165,7 @@ export const relativeDate = (dateString: string | Date): string => {
     return `${hoursDifference} hour${hoursDifference > 1 ? 's' : ''} ago`;
   } else if (daysDifference < 7) {
     return `${daysDifference} day${daysDifference > 1 ? 's' : ''} ago`;
-  } else if (weeksDifference < 4) {
+  } else if (daysDifference < 30) {
     return `${weeksDifference} week${weeksDifference > 1 ? 's' : ''} ago`;
   } else {
     return `${monthsDifference} month${monthsDifference > 1 ? 's' : ''} ago`;

--- a/src/webview/utils/common/relativeDate.spec.ts
+++ b/src/webview/utils/common/relativeDate.spec.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { relativeDate } from './index';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+
+const daysAgo = (days: number): Date => new Date(NOW.getTime() - days * DAY_MS);
+
+describe('relativeDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('reports recent times', () => {
+    expect(relativeDate(new Date(NOW.getTime() - 5 * 1000))).toBe('Few seconds ago');
+    expect(relativeDate(new Date(NOW.getTime() - 2 * 60 * 1000))).toBe('2 minutes ago');
+    expect(relativeDate(new Date(NOW.getTime() - 3 * 60 * 60 * 1000))).toBe('3 hours ago');
+  });
+
+  test('reports days and weeks', () => {
+    expect(relativeDate(daysAgo(3))).toBe('3 days ago');
+    expect(relativeDate(daysAgo(21))).toBe('3 weeks ago');
+    expect(relativeDate(daysAgo(27))).toBe('3 weeks ago');
+  });
+
+  test('does not report "0 month ago" between four weeks and a month', () => {
+    // 28 and 29 days used to fall through to the months branch where
+    // Math.floor(days / 30) is still 0, producing "0 month ago".
+    expect(relativeDate(daysAgo(28))).toBe('4 weeks ago');
+    expect(relativeDate(daysAgo(29))).toBe('4 weeks ago');
+  });
+
+  test('reports months from 30 days onward', () => {
+    expect(relativeDate(daysAgo(30))).toBe('1 month ago');
+    expect(relativeDate(daysAgo(70))).toBe('2 months ago');
+  });
+});


### PR DESCRIPTION
The notification timestamps use `relativeDate`, and there's a small gap in its cascade. The weeks branch checks `weeksDifference < 4`, which stops at 28 days, but the months branch reports `Math.floor(daysDifference / 30)`, which is still 0 until day 30. So anything 28 or 29 days old renders as "0 month ago".

The fix changes that branch to `daysDifference < 30` so those two days read "4 weeks ago", and the months branch only kicks in once a full month has actually passed. Behavior for every other range is unchanged.

I added a unit test in `src/webview/utils/common/relativeDate.spec.ts` covering the seconds/minutes/hours/days/weeks/months cases plus the 28 and 29 day boundary; `npx vitest run` passes (79 tests). Thanks for taking a look.