### PR TITLE
fix: sidebar search crash on searching requests

### DIFF
--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
@@ -543,6 +543,15 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
     'is-sidebar-dragging': isSidebarDragging
   });
 
+  const { folderItems, requestItems } = useMemo(() => {
+    const children = item.items || [];
+    const folders = sortByNameThenSequence(filter(children, (i: any) => isItemAFolder(i)));
+    const requests = filter(children, (i: any) => isItemARequest(i)).sort((a: any, b: any) => a.seq - b.seq);
+    return { folderItems: folders, requestItems: requests };
+  }, [item.items]);
+  const indents = useMemo(() => range(item.depth), [item.depth]);
+  const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
+
   if (searchText && searchText.length) {
     if (isItemARequest(item)) {
       if (!doesRequestMatchSearchText(item, searchText)) {
@@ -554,15 +563,6 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
       }
     }
   }
-
-  const { folderItems, requestItems } = useMemo(() => {
-    const children = item.items || [];
-    const folders = sortByNameThenSequence(filter(children, (i: any) => isItemAFolder(i)));
-    const requests = filter(children, (i: any) => isItemARequest(i)).sort((a: any, b: any) => a.seq - b.seq);
-    return { folderItems: folders, requestItems: requests };
-  }, [item.items]);
-  const indents = useMemo(() => range(item.depth), [item.depth]);
-  const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
 
   return (
     <StyledWrapper className={className}>

--- a/src/webview/components/Sidebar/Collections/Collection/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/index.tsx
@@ -290,12 +290,6 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
     }
   }, [isCollectionFocused]);
 
-  if (searchText && (searchText as string).length) {
-    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
-      return null;
-    }
-  }
-
   const collectionRowClassName = classnames('flex py-1 collection-name items-center', {
     'item-hovered': isOver && dropType === 'adjacent',
     'drop-target': isOver && dropType === 'inside',
@@ -420,6 +414,12 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
       onClick: handleRemove
     }
   ], [hasCopiedItems, collection.uid]);
+
+  if (searchText && searchText.length) {
+    if (!doesCollectionHaveItemsMatchingSearchText(collection, searchText)) {
+      return null;
+    }
+  }
 
   return (
     <StyledWrapper className="flex flex-col" id={`collection-${collection.name.replace(/\s+/g, '-').toLowerCase()}`}>


### PR DESCRIPTION
## Summary

- Move the search-filter early `return` below all hooks in `Collection` and `CollectionItem` so typing in the sidebar collection search no longer crashes the webview.

## Problem

- Typing anything into the sidebar collection search box crashes the entire sidebar — it goes blank (search box included) with React error #300 in the webview devtools: *"Minified React error #300; Rendered fewer hooks than expected."*
- Repro: open a collection, click the search (magnifier) icon in the sidebar header, type any character → the sidebar unmounts and shows a blank panel. Works fine in the Bruno desktop app.
- JIRA: https://usebruno.atlassian.net/browse/VSCODE-67

## Root Cause

- `Collection` (`src/webview/components/Sidebar/Collections/Collection/index.tsx`) and `CollectionItem` (`src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx`) filter themselves out during search with an early `return null` for items that don't match the search text — but that return was placed *before* several of their `useMemo`/`useRef` hooks.
- This violates React's Rules of Hooks. With an empty search box the condition is false, so every hook runs and React records that count. The moment a character is typed, non-matching items hit the early `return null` and skip their trailing hooks, so React sees fewer hooks than the previous render, throws #300, and unmounts the whole sidebar tree (which is why even the search box disappears).
- It only surfaced now because the sidebar webview loads its bundle from `dist/webview` on disk, not the dev server — so the crash was masked by stale builds during development.

## Solution
Move the search early-`return null` in both components to run *after* all hooks, so the hook order and count are identical on every render regardless of whether an item matches the search. Filtering behavior is unchanged — non-matching items still render nothing. Also drops a redundant `(searchText as string)` cast for consistency with `CollectionItem`.

## Test plan
- [ ] Open a collection, toggle sidebar search, type a matching term → list filters correctly, no crash
- [ ] Type a non-matching term → list is empty, sidebar and search box stay mounted, no crash
- [ ] Clear the search → full collection tree returns
- [ ] Nested folders/requests still filter and expand as before
- [ ] Drag/drop, context menus, and collapse/expand still work on collections and items
- [ ] `npm run typecheck` passes; `npm run build:webview` succeeds

## Screenshots / Recordings
<img width="1470" height="801" alt="Screenshot 2026-07-10 at 6 05 58 PM" src="https://github.com/user-attachments/assets/de7e853a-edf7-4b2a-8418-c2bc6beacc56" />
