### PR TITLE
fix: restore missing Generate Code button in request toolbar

### DIFF
--- a/src/webview/components/RequestPane/GenerateCode/StyledWrapper.ts
+++ b/src/webview/components/RequestPane/GenerateCode/StyledWrapper.ts
@@ -1,0 +1,124 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 480px;
+  max-height: 60vh;
+
+  .toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+    padding-bottom: 10px;
+  }
+
+  .left-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .select-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .select-arrow {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    color: ${(props) => props.theme.dropdown.mutedText};
+  }
+
+  .native-select {
+    background: ${(props) => props.theme.input.bg};
+    border: 1px solid ${(props) => props.theme.input.border};
+    border-radius: 3px;
+    color: ${(props) => props.theme.requestTabPanel.url.icon};
+    font-size: ${(props) => props.theme.font.size.sm};
+    padding: 6px 28px 6px 10px;
+    min-width: 140px;
+    height: 32px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    appearance: none;
+    outline: none;
+    box-shadow: none;
+
+    &:hover {
+      border-color: ${(props) => props.theme.input.focusBorder};
+    }
+
+    &:focus {
+      outline: none;
+      border-color: ${(props) => props.theme.input.focusBorder};
+    }
+  }
+
+  .library-options {
+    display: flex;
+    gap: 6px;
+  }
+
+  .lib-btn {
+    height: 32px;
+    padding: 0 12px;
+    background: ${(props) => props.theme.input.bg};
+    border: 1px solid ${(props) => props.theme.input.border};
+    border-radius: 3px;
+    color: ${(props) => props.theme.requestTabPanel.url.icon};
+    font-size: ${(props) => props.theme.font.size.sm};
+    cursor: pointer;
+    transition: all 0.15s ease;
+    display: flex;
+    align-items: center;
+
+    &:hover {
+      background: ${(props) => props.theme.dropdown.hoverBg};
+      border-color: ${(props) => props.theme.input.focusBorder};
+    }
+
+    &.active {
+      background: ${(props) => props.theme.button.secondary.bg};
+      border-color: ${(props) => props.theme.button.secondary.border};
+      color: ${(props) => props.theme.button.secondary.color};
+    }
+  }
+
+  .right-controls {
+    display: flex;
+    align-items: center;
+
+    .interpolate-checkbox {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+      font-size: ${(props) => props.theme.font.size.base};
+      color: ${(props) => props.theme.requestTabPanel.url.icon};
+
+      input[type='checkbox'] {
+        cursor: pointer;
+        margin: 0;
+      }
+
+      &:hover {
+        opacity: 0.8;
+      }
+    }
+  }
+
+  .snippet-editor {
+    flex: 1;
+    min-height: 0;
+    border: ${(props) => props.theme.requestTabPanel.url.border};
+  }
+`;
+
+export default StyledWrapper;

--- a/src/webview/components/RequestPane/GenerateCode/index.tsx
+++ b/src/webview/components/RequestPane/GenerateCode/index.tsx
@@ -18,8 +18,6 @@ import {
 import { interpolateUrl, interpolateUrlPathParams } from 'utils/url';
 import StyledWrapper from './StyledWrapper';
 
-// Maps httpsnippet target keys to CodeMirror modes for readable syntax highlighting.
-// Falls back to plain text for targets with no close CodeMirror equivalent.
 const TARGET_TO_CM_MODE: Record<string, string> = {
   shell: 'shell',
   node: 'javascript',
@@ -46,9 +44,7 @@ const GenerateCodeItem = ({ item, collection }: GenerateCodeItemProps) => {
   const [shouldInterpolate, setShouldInterpolate] = useState(false);
 
   const languages = useMemo(() => getLanguages(), []);
-
-  // Groups the flat language list into { "Shell": [{target:'shell', client:'curl', ...}], "Node.js": [...] }
-  // matching the desktop app's main-language + library-button pattern.
+  
   const languageGroups = useMemo(() => {
     return languages.reduce((acc: Record<string, any[]>, lang: any) => {
       const mainLang = lang.name.split(' - ')[0];
@@ -79,14 +75,8 @@ const GenerateCodeItem = ({ item, collection }: GenerateCodeItemProps) => {
     if (!open || !request?.url || !activeLanguage) return '';
 
     try {
-      // Auth inheritance: walks folder -> collection, same as the request runner.
-      // NOTE: only handles collection/folder-level inheritance today; the desktop
-      // app's resolver additionally understands OAuth2 credential records, which
-      // this extension does not yet track locally.
+      
       const resolvedRequest = resolveInheritedAuth(item, collection);
-
-      // Header merging: collection root -> folders on the path -> request itself,
-      // later entries override earlier ones by header name (case-sensitive).
       const requestTreePath = getTreePathFromCollectionToItem(collection, item);
       const mergedHeaders = mergeHeaders(collection, request, requestTreePath);
 

--- a/src/webview/components/RequestPane/GenerateCode/index.tsx
+++ b/src/webview/components/RequestPane/GenerateCode/index.tsx
@@ -1,0 +1,217 @@
+import React, { useMemo, useState } from 'react';
+import get from 'lodash/get';
+import { HTTPSnippet } from 'httpsnippet';
+import { IconCode, IconCopy, IconChevronDown } from '@tabler/icons';
+import toast from 'react-hot-toast';
+import Modal from 'components/Modal';
+import CodeEditor from 'components/CodeEditor';
+import { useTheme } from 'providers/Theme';
+import { getLanguages } from 'utils/codegenerator/targets';
+import { buildHarRequest } from 'utils/codegenerator/har';
+import { getAuthHeaders } from 'utils/codegenerator/auth';
+import { resolveInheritedAuth } from 'utils/auth';
+import {
+  getAllVariables,
+  getTreePathFromCollectionToItem,
+  mergeHeaders
+} from 'utils/collections';
+import { interpolateUrl, interpolateUrlPathParams } from 'utils/url';
+import StyledWrapper from './StyledWrapper';
+
+// Maps httpsnippet target keys to CodeMirror modes for readable syntax highlighting.
+// Falls back to plain text for targets with no close CodeMirror equivalent.
+const TARGET_TO_CM_MODE: Record<string, string> = {
+  shell: 'shell',
+  node: 'javascript',
+  javascript: 'javascript',
+  python: 'python',
+  java: 'clike',
+  csharp: 'clike',
+  go: 'go',
+  php: 'php',
+  ruby: 'ruby',
+  swift: 'clike',
+  kotlin: 'clike',
+  objc: 'clike'
+};
+
+interface GenerateCodeItemProps {
+  item?: any;
+  collection?: any;
+}
+
+const GenerateCodeItem = ({ item, collection }: GenerateCodeItemProps) => {
+  const { theme, storedTheme } = useTheme();
+  const [open, setOpen] = useState(false);
+  const [shouldInterpolate, setShouldInterpolate] = useState(false);
+
+  const languages = useMemo(() => getLanguages(), []);
+
+  // Groups the flat language list into { "Shell": [{target:'shell', client:'curl', ...}], "Node.js": [...] }
+  // matching the desktop app's main-language + library-button pattern.
+  const languageGroups = useMemo(() => {
+    return languages.reduce((acc: Record<string, any[]>, lang: any) => {
+      const mainLang = lang.name.split(' - ')[0];
+      const libraryName = lang.name.split(' - ')[1] || 'default';
+      if (!acc[mainLang]) acc[mainLang] = [];
+      acc[mainLang].push({ ...lang, libraryName });
+      return acc;
+    }, {});
+  }, [languages]);
+
+  const mainLanguages = useMemo(() => Object.keys(languageGroups), [languageGroups]);
+
+  const [mainLanguage, setMainLanguage] = useState(mainLanguages[0]);
+  const availableLibraries = languageGroups[mainLanguage] || [];
+  const [library, setLibrary] = useState(availableLibraries[0]?.libraryName);
+
+  const activeLanguage = availableLibraries.find((l) => l.libraryName === library) || availableLibraries[0];
+
+  const handleMainLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newMainLang = e.target.value;
+    setMainLanguage(newMainLang);
+    setLibrary(languageGroups[newMainLang][0].libraryName);
+  };
+
+  const request = item.draft ? get(item, 'draft.request') : get(item, 'request');
+
+  const snippet = useMemo(() => {
+    if (!open || !request?.url || !activeLanguage) return '';
+
+    try {
+      // Auth inheritance: walks folder -> collection, same as the request runner.
+      // NOTE: only handles collection/folder-level inheritance today; the desktop
+      // app's resolver additionally understands OAuth2 credential records, which
+      // this extension does not yet track locally.
+      const resolvedRequest = resolveInheritedAuth(item, collection);
+
+      // Header merging: collection root -> folders on the path -> request itself,
+      // later entries override earlier ones by header name (case-sensitive).
+      const requestTreePath = getTreePathFromCollectionToItem(collection, item);
+      const mergedHeaders = mergeHeaders(collection, request, requestTreePath);
+
+      const authHeaders = getAuthHeaders(undefined, resolvedRequest.auth);
+      const headers = [...mergedHeaders, ...authHeaders];
+
+      let url = request.url;
+      if (shouldInterpolate) {
+        const variables = getAllVariables(collection, item);
+        url = interpolateUrl({ url, variables }) ?? url;
+      }
+      url = interpolateUrlPathParams(url, request.params || []);
+
+      const harRequest = buildHarRequest({
+        request: {
+          url,
+          method: request.method,
+          body: request.body,
+          params: request.params,
+          auth: resolvedRequest.auth
+        },
+        headers
+      });
+
+      const httpSnippet = new HTTPSnippet(harRequest);
+      return httpSnippet.convert(activeLanguage.target, activeLanguage.client) as string;
+    } catch (error) {
+      return `// Could not generate a snippet for this request.\n// ${(error as Error).message}`;
+    }
+  }, [open, activeLanguage, request, collection, item, shouldInterpolate]);
+
+  const cmMode = activeLanguage ? TARGET_TO_CM_MODE[activeLanguage.target] : undefined;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(snippet);
+    toast.success('Copied to clipboard');
+  };
+
+  if (!request) return null;
+
+  return (
+    <>
+      <div
+        title="Generate Code"
+        className="infotip mr-3"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        data-testid="generate-code-icon">
+            
+        <IconCode
+          color={theme.requestTabPanel.url.icon}
+          strokeWidth={1.5}
+          size={20}
+          className="cursor-pointer"
+        />
+        <span className="infotiptext text-xs">Generate Code</span>
+      </div>
+
+      {open ? (
+        <Modal
+          size="lg"
+          title="Generate Code"
+          hideFooter
+          handleCancel={() => setOpen(false)}
+          dataTestId="generate-code-modal"
+        >
+          <StyledWrapper>
+            <div className="toolbar">
+              <div className="left-controls">
+                <div className="select-wrapper">
+                  <select className="native-select" value={mainLanguage} onChange={handleMainLanguageChange}>
+                    {mainLanguages.map((lang) => (
+                      <option key={lang} value={lang}>
+                        {lang}
+                      </option>
+                    ))}
+                  </select>
+                  <IconChevronDown size={16} className="select-arrow" />
+                </div>
+
+                {availableLibraries.length > 1 && (
+                  <div className="library-options">
+                    {availableLibraries.map((lib) => (
+                      <button
+                        key={lib.libraryName}
+                        className={`lib-btn ${library === lib.libraryName ? 'active' : ''}`}
+                        onClick={() => setLibrary(lib.libraryName)}
+                      >
+                        {lib.libraryName}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="right-controls">
+                <label className="interpolate-checkbox" title="Replace {{variables}} with their resolved values">
+                  <input
+                    type="checkbox"
+                    checked={shouldInterpolate}
+                    onChange={(e) => setShouldInterpolate(e.target.checked)}
+                  />
+                  <span>Interpolate Variables</span>
+                </label>
+                <div className="cursor-pointer flex items-center ml-3" onClick={handleCopy} title="Copy to clipboard">
+                  <IconCopy color={theme.requestTabPanel.url.icon} strokeWidth={1.5} size={18} />
+                </div>
+              </div>
+            </div>
+            <div className="snippet-editor">
+              <CodeEditor
+                value={snippet}
+                theme={storedTheme}
+                mode={cmMode}
+                readOnly
+                enableBrunoVarInfo={false}
+              />
+            </div>
+          </StyledWrapper>
+        </Modal>
+      ) : null}
+    </>
+  );
+};
+
+export default GenerateCodeItem;

--- a/src/webview/components/RequestPane/QueryUrl/index.tsx
+++ b/src/webview/components/RequestPane/QueryUrl/index.tsx
@@ -22,6 +22,7 @@ import { isMacOS } from 'utils/common/platform';
 import { hasRequestChanges } from 'utils/collections';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
+import GenerateCodeItem from '../GenerateCode';
 
 interface QueryUrlProps {
   item?: React.ReactNode;
@@ -377,7 +378,11 @@ const QueryUrl = ({
           item={item}
           showNewlineArrow={true}
         />
+
         <div className="flex items-center h-full mr-2 cursor-pointer" id="send-request" onClick={handleRun}>
+          {['http-request', 'graphql-request'].includes(item.type) ? (
+            <GenerateCodeItem item={item} collection={collection} />
+          ) : null}        
           <div
             title="Save Request"
             className="infotip mr-3"


### PR DESCRIPTION
Fixes #78

## What
Restores the "Generate Code" feature advertised in this extension's own
README and in docs.usebruno.com/send-requests/REST/code-generator, but
missing from the actual UI as of v5.0.1.

## Root cause
src/webview/utils/codegenerator/* (targets.ts, har.ts, auth.ts) was fully
implemented but never imported by any component. The connecting UI appears
to have been dropped during the 5.0.0 rewrite, and neither the CHANGELOG
nor README were updated to reflect the gap.

## Fix
Adds a Generate Code button next to Save/Send in the request toolbar
(QueryUrl), for http-request and graphql-request items. Matches the
desktop app's UI pattern: a grouped language dropdown (Shell, Node.js,
Python...), library buttons when a language has more than one client,
and an "Interpolate Variables" checkbox.

Snippet generation uses:
- mergeHeaders() for collection -> folder -> request header merging
- resolveInheritedAuth() for folder/collection auth inheritance
- httpsnippet, via the existing (previously unused) local har.ts builder

## Known limitations
The desktop app's snippet-generator.js additionally uses buildHar() from
@usebruno/common for curl --digest/--ntlm flag handling and raw-vs-encoded
URL logic. That function isn't in any published @usebruno/common version
yet (checked up to 0.23.0), so this PR keeps the existing local har.ts
instead. OAuth2 auth inheritance also isn't resolved the same way the
desktop app's resolver handles it. Both are natural follow-ups once
buildHar() ships to npm.

## Testing
Manually verified against several request types (GET/POST, JSON body,
Bearer auth, path params, {{variable}} interpolation on/off) across
curl, Python, and Node.js snippets.