### PR TITLE
fix: sidebar search crash on requests with numeric names

### DIFF
--- a/src/webview/utils/collections/search.spec.ts
+++ b/src/webview/utils/collections/search.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  doesRequestMatchSearchText,
+  doesCollectionHaveItemsMatchingSearchText
+} from './search';
+
+describe('doesRequestMatchSearchText', () => {
+  it('matches by name case-insensitively', () => {
+    expect(doesRequestMatchSearchText({ name: 'Get Users' }, 'users')).toBe(true);
+    expect(doesRequestMatchSearchText({ name: 'Get Users' }, 'posts')).toBe(false);
+  });
+
+  it('returns false when the name is missing', () => {
+    expect(doesRequestMatchSearchText({}, 'users')).toBe(false);
+    expect(doesRequestMatchSearchText({ name: null }, 'users')).toBe(false);
+    expect(doesRequestMatchSearchText(undefined, 'users')).toBe(false);
+  });
+
+  it('handles non-string names without throwing (old collections)', () => {
+    expect(doesRequestMatchSearchText({ name: 200 }, '200')).toBe(true);
+    expect(doesRequestMatchSearchText({ name: 200 }, '404')).toBe(false);
+  });
+});
+
+describe('doesCollectionHaveItemsMatchingSearchText', () => {
+  it('does not throw when a request has a numeric name', () => {
+    const collection = {
+      items: [
+        { type: 'http-request', request: {}, name: 200 },
+        { type: 'http-request', request: {}, name: 'Get Users' }
+      ]
+    };
+    expect(() => doesCollectionHaveItemsMatchingSearchText(collection, 'users')).not.toThrow();
+    expect(doesCollectionHaveItemsMatchingSearchText(collection, 'users')).toBeTruthy();
+  });
+});

--- a/src/webview/utils/collections/search.ts
+++ b/src/webview/utils/collections/search.ts
@@ -4,7 +4,9 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 
 export const doesRequestMatchSearchText = (request: any, searchText = '') => {
-  return request?.name?.toLowerCase().includes(searchText.toLowerCase());
+  const name = request?.name;
+  if (name === null || name === undefined) return false;
+  return String(name).toLowerCase().includes(searchText.toLowerCase());
 };
 
 export const doesFolderHaveItemsMatchSearchText = (item: any, searchText = '') => {


### PR DESCRIPTION
## Summary
Guard the sidebar search so it no longer crashes when a collection contains a request with a numeric name.

## Problem
- Typing in the sidebar search bar blanks the whole sidebar when the open collection has a request whose name is numeric (e.g. named 200). Works fine in the Bruno desktop app.
- Repro: open a collection with a request named 200 before opening that request → type in the sidebar search box → sidebar goes blank.
- JIRA: [https://usebruno.atlassian.net/browse/VSCODE-67]

## Root Cause
- Search calls request.name.toLowerCase(). For speed, the extension renders the sidebar from a lightweight meta scan (not a full parse), and that scan coerces numeric-looking values to numbers — so a numeric name reaches search as a JS number, which has no .toLowerCase.
- Desktop never hits this because it builds its tree via the @usebruno/lang grammar, where name is always a string. We keep the fast meta scan (a full up-front parse would freeze VS Code on large collections) to render sidebar tree instantly then a full grammar parse on demand when a request is opened. 

## Solution
- Make the sidebar search tolerant of non-string request names by converting the name to a string before matching. Numeric names now compare as text instead of crashing.

## Test plan
- [ ] Collection with a request named 200 → search → no crash, sidebar stays rendered
- [ ] Numeric name matches (200) / non-match (404) behaves correctly
- [ ] Normal string-name search still matches case-insensitively (no regression)
- [ ] npm test and npm run typecheck pass