### PR TITLE
fix(path-param) - Edit path param value in popup

### DIFF
--- a/src/webview/components/RequestPane/QueryParams/index.tsx
+++ b/src/webview/components/RequestPane/QueryParams/index.tsx
@@ -188,6 +188,7 @@ const QueryParams = ({
         </div>
         {pathParams && pathParams.length > 0 ? (
           <EditableTable
+            testId="path-params-table"
             columns={pathColumns}
             rows={pathParams}
             onChange={() => {}}

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -176,7 +176,8 @@ import {
   addFolderVar,
   updateFolderVar,
   addCollectionVar,
-  updateCollectionVar
+  updateCollectionVar,
+  updatePathParam
 } from './index';
 
 import { each } from 'lodash';
@@ -2217,6 +2218,35 @@ export const updateVariableInScope = (variableName: any, newValue: any, scopeInf
             .then(() => {
               toast.success(`Variable "${variableName}" updated`);
             })
+            .then(resolve)
+            .catch(reject);
+        }
+
+        case 'path': {
+          const { item } = data;
+
+          if (!item) {
+            return reject(new Error('Request item not found'));
+          }
+
+          const requestItem = findItemInCollection(collection, item.uid);
+          if (!requestItem) {
+            return reject(new Error('Request item not found'));
+          }
+
+          const params = get(requestItem, 'draft.request.params') || get(requestItem, 'request.params') || [];
+          const pathParam = params.find((p: any) => p.type === 'path' && p.name === variableName);
+          if (!pathParam) {
+            return reject(new Error('Path parameter not found'));
+          }
+
+          dispatch(updatePathParam({
+            collectionUid,
+            itemUid: item.uid,
+            pathParam: { uid: pathParam.uid, name: pathParam.name, value: newValue }
+          }));
+
+          return dispatch(saveRequest(item.uid, collectionUid, true))
             .then(resolve)
             .catch(reject);
         }

--- a/src/webview/utils/codemirror/brunoVarInfo.tsx
+++ b/src/webview/utils/codemirror/brunoVarInfo.tsx
@@ -265,8 +265,8 @@ export const renderVarInfo = (token: any, options: any) => {
     }
   }
 
-  // Check if variable is read-only (process.env, runtime, dynamic/faker, oauth2, path, and undefined variables cannot be edited)
-  const isReadOnly = scopeInfo.type === 'process.env' || scopeInfo.type === 'runtime' || scopeInfo.type === 'dynamic' || scopeInfo.type === 'oauth2' || scopeInfo.type === 'path' || scopeInfo.type === 'undefined';
+  // Check if variable is read-only (process.env, runtime, dynamic/faker, oauth2, and undefined variables cannot be edited)
+  const isReadOnly = scopeInfo.type === 'process.env' || scopeInfo.type === 'runtime' || scopeInfo.type === 'dynamic' || scopeInfo.type === 'oauth2' || scopeInfo.type === 'undefined';
 
   const rawValue = scopeInfo.value || '';
 

--- a/src/webview/utils/codemirror/brunoVarInfo.tsx
+++ b/src/webview/utils/codemirror/brunoVarInfo.tsx
@@ -566,11 +566,6 @@ export const renderVarInfo = (token: any, options: any) => {
       readOnlyNote.className = 'var-readonly-note';
       readOnlyNote.textContent = 'read-only';
       into.appendChild(readOnlyNote);
-    } else if (scopeInfo.type === 'path') {
-      const readOnlyNote = document.createElement('div');
-      readOnlyNote.className = 'var-readonly-note';
-      readOnlyNote.textContent = 'Edit in Params tab';
-      into.appendChild(readOnlyNote);
     } else if (scopeInfo.type === 'undefined') {
       const readOnlyNote = document.createElement('div');
       readOnlyNote.className = 'var-readonly-note';

--- a/tests/e2e/specs/path-params.spec.ts
+++ b/tests/e2e/specs/path-params.spec.ts
@@ -6,7 +6,7 @@ import {
   openNewRequestPanel,
   createRequest,
   openRequest,
-  openRequestPaneTab,
+  openRequestPaneTab
 } from '../utils/actions';
 import { buildCommonLocators } from '../utils/locators';
 
@@ -20,15 +20,15 @@ async function editPathParamViaPopover(
   const locators = buildCommonLocators(editor);
 
   const paramSpan = locators.requestUrl.pathParamToken(paramName);
-  await expect(paramSpan).toBeVisible({ timeout: 5000 });
+  await expect(paramSpan).toBeVisible({ timeout: 5_000 });
 
   // Retry the hover: move off the token first so a fresh mouseover fires.
   const popover = locators.varPopover.container();
   await expect(async () => {
     await locators.requestUrl.editor().hover({ position: { x: 2, y: 2 } });
     await paramSpan.hover();
-    await expect(popover).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: 5000 });
+    await expect(popover).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 5_000 });
 
   const editableDisplay = locators.varPopover.editableDisplay();
   await expect(editableDisplay).toBeVisible({ timeout: 5_000 });
@@ -85,6 +85,6 @@ test.describe('Path parameters', () => {
     await expect(async () => {
       const value = await getPathParamTableValue(editor);
       expect(value).toBe(paramValue);
-    }).toPass({ timeout: 5000 });
+    }).toPass({ timeout: 5_000 });
   });
 });

--- a/tests/e2e/specs/path-params.spec.ts
+++ b/tests/e2e/specs/path-params.spec.ts
@@ -1,0 +1,90 @@
+import type { Page, Frame } from '@playwright/test';
+import { test, expect } from '../fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openNewRequestPanel,
+  createRequest,
+  openRequest,
+  openRequestPaneTab,
+} from '../utils/actions';
+import { buildCommonLocators } from '../utils/locators';
+
+// Edit a path param's value via the hover popover over its `:param` token.
+async function editPathParamViaPopover(
+  page: Page,
+  editor: Frame,
+  paramName: string,
+  value: string
+): Promise<void> {
+  const locators = buildCommonLocators(editor);
+
+  const paramSpan = locators.requestUrl.pathParamToken(paramName);
+  await expect(paramSpan).toBeVisible({ timeout: 5000 });
+
+  // Retry the hover: move off the token first so a fresh mouseover fires.
+  const popover = locators.varPopover.container();
+  await expect(async () => {
+    await locators.requestUrl.editor().hover({ position: { x: 2, y: 2 } });
+    await paramSpan.hover();
+    await expect(popover).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 5000 });
+
+  const editableDisplay = locators.varPopover.editableDisplay();
+  await expect(editableDisplay).toBeVisible({ timeout: 5_000 });
+  await editableDisplay.click();
+
+  const popoverEditor = locators.varPopover.editor();
+  await expect(popoverEditor).toBeVisible({ timeout: 5_000 });
+
+  // Retry select-all + type until the editor holds the full value.
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await expect(async () => {
+    await popoverEditor.click();
+    await expect(locators.varPopover.editorFocused()).toBeVisible({ timeout: 2_000 });
+    await page.keyboard.press(`${modifier}+a`);
+    await page.keyboard.type(value, { delay: 30 });
+    const typed = (await locators.varPopover.editorLine().textContent())?.trim();
+    expect(typed).toBe(value);
+  }).toPass({ timeout: 5_000 });
+
+  await page.keyboard.press('Enter');
+
+  // Remove lingering popovers so they can't intercept clicks below the URL bar.
+  await editor.evaluate(() => {
+    document.querySelectorAll('.CodeMirror-brunoVarInfo').forEach((el) => el.remove());
+  });
+  await expect(popover).toHaveCount(0, { timeout: 5_000 });
+}
+
+// Read the path param value from the Params -> Path table.
+async function getPathParamTableValue(editor: Frame): Promise<string> {
+  const valueLine = buildCommonLocators(editor).paramsTable.pathValueCell();
+  await expect(valueLine).toBeVisible({ timeout: 5_000 });
+  return (await valueLine.textContent())?.trim() ?? '';
+}
+
+test.describe('Path parameters', () => {
+  test('Edit a path param value from the URL hover popover', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Path Param Collection';
+    const requestName = 'Get User';
+    const requestUrl = 'https://echo.usebruno.com/:userId';
+    const paramValue = '42';
+
+    await createCollection(page, sidebar, collectionName, tmpDir);
+    const newReqPanel = await openNewRequestPanel(page, sidebar, collectionName);
+    await createRequest(page, newReqPanel, sidebar, collectionName, requestName, requestUrl, 'GET');
+
+    const editor = await openRequest(page, sidebar, collectionName, requestName);
+
+    await editPathParamViaPopover(page, editor, 'userId', paramValue);
+
+    // Edited value must propagate to the Params -> Path table.
+    await openRequestPaneTab(editor, 'Params');
+    await expect(async () => {
+      const value = await getPathParamTableValue(editor);
+      expect(value).toBe(paramValue);
+    }).toPass({ timeout: 5000 });
+  });
+});

--- a/tests/e2e/specs/path-params.spec.ts
+++ b/tests/e2e/specs/path-params.spec.ts
@@ -6,7 +6,8 @@ import {
   openNewRequestPanel,
   createRequest,
   openRequest,
-  openRequestPaneTab
+  openRequestPaneTab,
+  runCommand
 } from '../utils/actions';
 import { buildCommonLocators } from '../utils/locators';
 
@@ -80,10 +81,23 @@ test.describe('Path parameters', () => {
 
     await editPathParamViaPopover(page, editor, 'userId', paramValue);
 
-    // Edited value must propagate to the Params -> Path table.
+    // Edited value must propagate to the Params -> Path table (in-memory store).
     await openRequestPaneTab(editor, 'Params');
     await expect(async () => {
       const value = await getPathParamTableValue(editor);
+      expect(value).toBe(paramValue);
+    }).toPass({ timeout: 5_000 });
+
+    // Persistence: save to disk, close the tab, then reopen from a fresh editor and
+    // confirm the edited value survives.
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+s`);
+    await runCommand(page, 'View: Close Editor');
+
+    const reopened = await openRequest(page, sidebar, collectionName, requestName);
+    await openRequestPaneTab(reopened, 'Params');
+    await expect(async () => {
+      const value = await getPathParamTableValue(reopened);
       expect(value).toBe(paramValue);
     }).toPass({ timeout: 5_000 });
   });

--- a/tests/e2e/utils/actions.ts
+++ b/tests/e2e/utils/actions.ts
@@ -615,6 +615,20 @@ export async function pasteIntoCollection(sidebar: Frame, collectionName: string
 }
 
 /**
+ * Select a tab in the request editor's request pane (e.g. "Params", "Body", "Headers").
+ *
+ * @param editor - The request editor's webview Frame
+ * @param tabName - Visible label of the tab to select
+ */
+export async function openRequestPaneTab(editor: Frame, tabName: string): Promise<void> {
+  await editor
+    .locator('[role="tab"]')
+    .filter({ hasText: tabName })
+    .first()
+    .click();
+}
+
+/**
  * Run a VS Code command via the Command Palette.
  */
 export async function runCommand(page: Page, command: string): Promise<void> {

--- a/tests/e2e/utils/locators.ts
+++ b/tests/e2e/utils/locators.ts
@@ -32,11 +32,10 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     editorLine: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-line').first()
   },
   paramsTable: {
-    // Value cell of the path table (Params renders query table then path table).
+    // Value cell of the path-params table.
     pathValueCell: () =>
       frame
-        .getByTestId('editable-table')
-        .nth(1)
+        .getByTestId('path-params-table')
         .getByTestId('column-value')
         .locator('.CodeMirror-line')
         .first()

--- a/tests/e2e/utils/locators.ts
+++ b/tests/e2e/utils/locators.ts
@@ -1,22 +1,44 @@
 import { Frame, Page } from '@playwright/test';
 
-/**
- * Centralised Playwright locators for the e2e suite.
- *
- * In bruno-vscode the Bruno UI runs inside VS Code webview iframes, so the factory
- * takes the relevant `Frame` (or `Page`) instead of the top-level page.
- */
+// Centralised Playwright locators. The Bruno UI runs inside VS Code webview
+// iframes, so the factory takes a Frame (or Page).
 export type FrameLike = Frame | Page;
 
 export const buildCommonLocators = (frame: FrameLike) => ({
   sidebar: {
     collectionName: (name: string) =>
-      frame.locator('[data-testid="sidebar-collection-row"]').filter({ hasText: name })
+      frame.getByTestId('sidebar-collection-row').filter({ hasText: name })
   },
   collectionSettings: {
     container: () => frame.getByTestId('collection-settings'),
-    // Overview → Requests line, e.g. "2 requests in collection".
     requestsInfo: () => frame.getByTestId('collection-requests-count'),
     requestsNotLoaded: () => frame.getByTestId('collection-requests-not-loaded')
+  },
+  requestUrl: {
+    editor: () => frame.locator('#request-url'),
+    // A `:param` token highlighted in the URL editor.
+    pathParamToken: (name: string) =>
+      frame
+        .locator('#request-url .CodeMirror span.cm-variable-valid, #request-url .CodeMirror span.cm-variable-invalid')
+        .filter({ hasText: name })
+        .first()
+  },
+  // Var-info hover popover shown over a highlighted token.
+  varPopover: {
+    container: () => frame.locator('.CodeMirror-brunoVarInfo'),
+    editableDisplay: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editable-display'),
+    editor: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror'),
+    editorFocused: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-focused'),
+    editorLine: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-line').first()
+  },
+  paramsTable: {
+    // Value cell of the path table (Params renders query table then path table).
+    pathValueCell: () =>
+      frame
+        .getByTestId('editable-table')
+        .nth(1)
+        .getByTestId('column-value')
+        .locator('.CodeMirror-line')
+        .first()
   }
 });


### PR DESCRIPTION
### Summary
Path parameter values could not be edited from the variable-info popover that appears when hovering a `:param` token in the URL editor — the popover rendered the value as read-only. This makes path params editable inline (consistent with other editable variable scopes) and persists the change back to the request.

### Root cause
Two gaps:

In [brunoVarInfo.tsx](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/src/webview/utils/codemirror/brunoVarInfo.tsx), `'path'`was included in the `isReadOnly` list, so the popover rendered the read-only `.var-value-display` instead of an editable field.
Even if made editable, `updateVariableInScope` had no `'path'`case, so an edit had nowhere to go.

### Changes
[brunoVarInfo.tsx](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/src/webview/utils/codemirror/brunoVarInfo.tsx): removed `'path'` from the read-only scope check so the popover shows the editable value field for path params (`process.env`, `runtime`, `dynamic`, `oauth2`, and `undefined` remain read-only).
[collections/actions.tsx](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/src/webview/providers/ReduxStore/slices/collections/actions.tsx): added a `'path'` case to `updateVariableInScope` that locates the path param in the request's `draft/request` params by name, dispatches the existing `updatePathParam` reducer, and saves the request — so the edited value persists and propagates to the Params → Path table.

### Testing
Added e2e spec [path-params.spec.ts](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/tests/e2e/specs/path-params.spec.ts): creates a request with a `:userId` path param, edits the value via the URL hover popover, and asserts it propagates to the Params → Path table.
Added `openRequestPaneTab` helper in [actions.ts](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/tests/e2e/utils/actions.ts) and centralized the path-param/popover selectors in [locators.ts](vscode-webview://0jsdf3guaeijh38hbur17fj4n0ts2ae1c7g4f63pb0mnahm1t11u/tests/e2e/utils/locators.ts).


Jira ticket: VSCODE-32