### PR TITLE
fix: collection overview showing all requests as not loaded

### DIFF
--- a/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
+++ b/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
@@ -19,7 +19,8 @@ const RequestsNotLoaded = ({
   const dispatch = useDispatch();
   const tabs = useSelector((state: RootState) => state.tabs.tabs);
   const flattenedItems = flattenItems(collection.items);
-  const itemsFailedLoading = flattenedItems?.filter((item: any) => item?.partial && !item?.loading);
+  // `partial` is the normal lazy-load state, not a failure; only errored requests are "not loaded".
+  const itemsFailedLoading = flattenedItems?.filter((item: any) => isItemARequest(item) && item?.error);
 
   if (!itemsFailedLoading?.length) {
     return null;
@@ -48,7 +49,7 @@ const RequestsNotLoaded = ({
   };
 
   return (
-    <StyledWrapper className="w-full card my-2">
+    <StyledWrapper className="w-full card my-2" data-testid="collection-requests-not-loaded">
       <div className="flex items-center gap-2 px-3 py-2 title">
         <IconAlertTriangle size={16} className="warning-icon" />
         <span className="font-medium">Following requests were not loaded</span>
@@ -66,7 +67,7 @@ const RequestsNotLoaded = ({
         </thead>
         <tbody>
           {flattenedItems?.map((item: any, index: any) => (
-            item?.partial && !item?.loading ? (
+            isItemARequest(item) && item?.error ? (
               <tr key={index} className="cursor-pointer" onClick={handleRequestClick(item)}>
                 <td className="py-1.5 px-3">
                   {item?.pathname?.split(`${collection?.pathname}/`)?.[1]}

--- a/tests/e2e/specs/collection-overview.spec.ts
+++ b/tests/e2e/specs/collection-overview.spec.ts
@@ -60,5 +60,9 @@ test.describe('Collection overview', () => {
     // nested in a folder).
     const requestsInfo = buildCommonLocators(settings).collectionSettings.requestsInfo();
     await expect(requestsInfo).toHaveText('3 requests in collection', { timeout: 5_000 });
+
+    // Lazily-scanned requests are metadata-only (partial) until opened and must not be reported as "not loaded".
+    const requestsNotLoaded = buildCommonLocators(settings).collectionSettings.requestsNotLoaded();
+    await expect(requestsNotLoaded).toHaveCount(0);
   });
 });

--- a/tests/e2e/utils/locators.ts
+++ b/tests/e2e/utils/locators.ts
@@ -16,6 +16,7 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   collectionSettings: {
     container: () => frame.getByTestId('collection-settings'),
     // Overview → Requests line, e.g. "2 requests in collection".
-    requestsInfo: () => frame.getByTestId('collection-requests-count')
+    requestsInfo: () => frame.getByTestId('collection-requests-count'),
+    requestsNotLoaded: () => frame.getByTestId('collection-requests-not-loaded')
   }
 });


### PR DESCRIPTION
## Summary
- Fix the collection settings Overview so it stops reporting every request as "not loaded" after importing or opening a collection.

## Problem
- After importing/opening a collection, the Overview tab lists every request under "Following requests were not loaded", even though the same requests load fine and are usable from the sidebar.
- Repro: import or open a collection → open collection settings → Overview tab → every request appears under "Following requests were not loaded".

## Root Cause
- The `RequestsNotLoaded` card flags requests where `partial && !loading`. That filter comes from Bruno desktop, where `partial: true` means a request genuinely couldn't be fully loaded (too large / parse error).
- This extension repurposes `partial` for lazy loading: every request is scanned metadata-only (`partial: true`) and only fully parsed (`partial: false`) when opened. The card was previously dormant because the collection-settings webview had no request items — until `loadFullCollection` (#82) started streaming the full tree into it, at which point every normally-lazy request matched the filter.

## Solution
- Filter the "not loaded" list on the extension's real failure signal — `error`, set only when a request's metadata fails to parse — instead of `partial`. Normal lazily-scanned requests no longer show; genuinely failed requests still do.

## Test plan
- [ ] Import/open a collection → open settings → Overview → healthy requests are not listed as "not loaded"
- [ ] A request with unparseable metadata still appears under "not loaded"
- [ ] Request count still renders correctly (no regression)
- [ ] Added e2e coverage asserting the card is absent after a clean import
- [ ] TypeScript typecheck passes