### PR TITLE
fix: sidebar crash on cross-format copy-paste request 

### DIFF
--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -390,7 +390,7 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
   });
 
   registerHandler('renderer:new-request', async (args) => {
-    const [pathname, request] = args as [string, { filename?: string; [key: string]: unknown }];
+    const [pathname, request] = args as [string, { filename?: string;[key: string]: unknown }];
 
     try {
       if (fs.existsSync(pathname)) {
@@ -829,11 +829,22 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
         for (const child of (sourceItem.items || [])) {
           if (child.type === 'folder') {
             await cloneFolderRecursive(child, path.join(destPath, child.filename));
-          } else {
-            // Clone request file - copy the source file directly
-            if (child.pathname && fs.existsSync(child.pathname)) {
+          } else if (child.pathname && fs.existsSync(child.pathname)) {
+            const sourceCollectionPath = findCollectionPathByItemPath(child.pathname);
+            const sourceFormat = sourceCollectionPath ? getCollectionFormat(sourceCollectionPath) : format;
+
+            if (sourceFormat === format) {
               const destFilePath = path.join(destPath, child.filename);
               fs.copyFileSync(child.pathname, destFilePath);
+            } else {
+              /* Cross-format paste (e.g. .bru -> .yml): re-serialize so the content matches the destination
+              extension, otherwise the sidebar can't parse it. Also swap the filename extension.*/
+              const childContent = fs.readFileSync(child.pathname, 'utf8');
+              const parsedChild = await parseRequest(childContent, { format: sourceFormat });
+              const childBaseName = path.basename(child.filename, path.extname(child.filename));
+              const destFilePath = path.join(destPath, `${childBaseName}.${format}`);
+              const newChildContent = await stringifyRequest(parsedChild, { format });
+              await writeFile(destFilePath, newChildContent);
             }
           }
         }
@@ -858,19 +869,27 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
         throw new Error(`destination: ${destPathname} already exists`);
       }
 
-      const collectionPath = findCollectionPathByItemPath(sourcePathname);
-      if (!collectionPath) {
+      const sourceCollectionPath = findCollectionPathByItemPath(sourcePathname);
+      if (!sourceCollectionPath) {
         throw new Error('Collection not found for the given pathname');
       }
 
-      const format = getCollectionFormat(collectionPath);
+      const destCollectionPath = findCollectionPathByItemPath(destPathname);
+      if (!destCollectionPath) {
+        throw new Error('Collection not found for the destination pathname');
+      }
+
+      /* Pasting across collections of different formats (e.g. .bru -> .yml) must write content that matches
+      the destination file extension, otherwise the file can't be re-parsed and the sidebar renders a broken item.*/
+      const sourceFormat = getCollectionFormat(sourceCollectionPath);
+      const destFormat = getCollectionFormat(destCollectionPath);
       const content = fs.readFileSync(sourcePathname, 'utf8');
-      const parsed = await parseRequest(content, { format });
+      const parsed = await parseRequest(content, { format: sourceFormat });
 
       parsed.name = newName;
       parsed.seq = newSeq;
 
-      const newContent = await stringifyRequest(parsed, { format });
+      const newContent = await stringifyRequest(parsed, { format: destFormat });
       await writeFile(destPathname, newContent);
 
       return { success: true };
@@ -1079,17 +1098,17 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
       // Use existing brunoConfig from collection if available, otherwise create new
       let brunoConfig: BrunoConfig = collection.brunoConfig || (format === 'yml'
         ? {
-            opencollection: '1.0.0',
-            name: collectionName,
-            type: 'collection',
-            ignore: ['node_modules', '.git']
-          }
+          opencollection: '1.0.0',
+          name: collectionName,
+          type: 'collection',
+          ignore: ['node_modules', '.git']
+        }
         : {
-            version: '1',
-            name: collectionName,
-            type: 'collection',
-            ignore: ['node_modules', '.git']
-          });
+          version: '1',
+          name: collectionName,
+          type: 'collection',
+          ignore: ['node_modules', '.git']
+        });
 
       if (format === 'yml') {
         const content = await stringifyCollection(collection.root || { meta: { name: collectionName } }, brunoConfig, { format });
@@ -1276,7 +1295,7 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
       );
 
       if (!valid) {
-        await fsExtra.remove(tempDir).catch(() => {});
+        await fsExtra.remove(tempDir).catch(() => { });
       }
 
       return { valid, tempZipPath: valid ? tempZipPath : '' };
@@ -1405,7 +1424,7 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
 
         await fsExtra.move(collectionDir, finalCollectionPath);
         if (tempDir !== collectionDir) {
-          await fsExtra.remove(tempDir).catch(() => {});
+          await fsExtra.remove(tempDir).catch(() => { });
         }
 
         const uid = generateUidBasedOnHash(finalCollectionPath);
@@ -1431,7 +1450,7 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
 
         return finalCollectionPath;
       } catch (error) {
-        await fsExtra.remove(tempDir).catch(() => {});
+        await fsExtra.remove(tempDir).catch(() => { });
         throw error;
       }
     } catch (error) {
@@ -2058,7 +2077,7 @@ get {
 
     const basename = path.basename(pathname);
     if (basename === 'folder.bru' || basename === 'folder.yml' ||
-        basename === 'collection.bru' || basename === 'opencollection.yml') {
+      basename === 'collection.bru' || basename === 'opencollection.yml') {
       return;
     }
     if (path.basename(path.dirname(pathname)) === 'environments') {

--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/RequestMethod/index.tsx
@@ -21,7 +21,7 @@ const getMethodText = (item: any, {
   if (isGrpc) return 'grpc';
   if (isWS) return 'ws';
   if (isGraphQL) return 'gql';
-  return item.request.method.length > 5
+  return item.request?.method?.length > 5
     ? item.request.method.substring(0, 3)
     : item.request.method;
 };
@@ -55,7 +55,7 @@ const RequestMethod = ({
 
   const flags = getMethodFlags(item);
   const methodText = getMethodText(item, flags);
-  const className = getClassname(item.request.method, flags);
+  const className = getClassname(item.request?.method, flags);
 
   return (
     <StyledWrapper>

--- a/tests/e2e/specs/cross-format-paste.spec.ts
+++ b/tests/e2e/specs/cross-format-paste.spec.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openNewRequestPanel,
+  createRequest,
+  openRequest,
+  copyItem,
+  pasteIntoCollection,
+  expandCollection,
+  collapseCollection,
+} from '../utils/actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+// Recursively collect every file under `dir`.
+function walkFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkFiles(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+// Regression test for the cross-format paste crash: copying a request out of a
+// `.bru` collection and pasting it into a `.yml` (OpenCollection) collection
+// used to serialize the request in the SOURCE format while naming the file with
+// the DESTINATION extension. The resulting `.yml` file held `.bru` syntax; the
+// watcher couldn't parse it, produced a partial item with no `request`, and the
+// sidebar crashed rendering the method badge — persisting across reloads.
+test.describe('Cross-format paste', () => {
+
+  test('paste a request from a .bru collection into a .yml collection', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+
+    const sourceCollection = 'Bru Source';
+    const targetCollection = 'Yml Target';
+    const requestName = 'Ping';
+    const requestUrl = `${TEST_SERVER}/ping`;
+
+    // Two collections of different on-disk formats.
+    await createCollection(page, sidebar, sourceCollection, tmpDir, 'bru');
+    await createCollection(page, sidebar, targetCollection, tmpDir, 'yml');
+
+    // A request in the .bru source collection.
+    const newReqPanel = await openNewRequestPanel(page, sidebar, sourceCollection);
+    await createRequest(page, newReqPanel, sidebar, sourceCollection, requestName, requestUrl, 'POST');
+
+    // Copy it, then paste into the .yml target collection.
+    await copyItem(sidebar, requestName);
+    await pasteIntoCollection(sidebar, targetCollection);
+
+    // The sidebar must survive the paste: both collection rows remain visible.
+    // (A crash unmounts the tree, so these vanish.)
+    await expect(sidebar.locator('.sidebar-header')).toBeVisible();
+    await expect(
+      sidebar.locator('[data-testid="sidebar-collection-row"]').filter({ hasText: sourceCollection })
+    ).toBeVisible();
+    await expect(
+      sidebar.locator('[data-testid="sidebar-collection-row"]').filter({ hasText: targetCollection })
+    ).toBeVisible();
+
+    // The pasted request renders in the target collection tree.
+    await expandCollection(sidebar, targetCollection);
+    await expect(
+      sidebar
+        .locator('[data-testid="sidebar-collection-item-row"]')
+        .filter({ hasText: requestName })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The definitive check: the pasted request file must be written in the
+    // DESTINATION format. It lives in a folder identified by the target's
+    // opencollection.yml; the request itself is a `.yml` file next to it.
+    const ocConfig = walkFiles(tmpDir).find((f) => path.basename(f) === 'opencollection.yml');
+    expect(ocConfig, 'target collection opencollection.yml should exist').toBeTruthy();
+    const targetDir = path.dirname(ocConfig as string);
+    const pastedFile = fs
+      .readdirSync(targetDir)
+      .find((name) => name.toLowerCase().endsWith('.yml') && name !== 'opencollection.yml');
+    expect(pastedFile, 'pasted request .yml file should exist in the target collection').toBeTruthy();
+
+    const pastedContent = fs.readFileSync(path.join(targetDir, pastedFile as string), 'utf8');
+    // OpenCollection (yml) requests start with an `info:` block. A `.bru`-format
+    // body (the bug) would instead contain a `meta {` block.
+    expect(pastedContent).toContain('info:');
+    expect(pastedContent).not.toContain('meta {');
+
+    // And it opens cleanly with the request data preserved across the
+    // conversion. Collapse the source first so the identically named source
+    // request is out of the DOM and we unambiguously open the pasted one.
+    await collapseCollection(sidebar, sourceCollection);
+    const editor = await openRequest(page, sidebar, targetCollection, requestName);
+    await expect(editor.locator('#request-url')).toContainText(requestUrl, { timeout: 10_000 });
+  });
+});

--- a/tests/e2e/specs/cross-format-paste.spec.ts
+++ b/tests/e2e/specs/cross-format-paste.spec.ts
@@ -15,7 +15,6 @@ import {
 
 const TEST_SERVER = 'http://127.0.0.1:8081';
 
-// Recursively collect every file under `dir`.
 function walkFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -26,12 +25,9 @@ function walkFiles(dir: string): string[] {
   return out;
 }
 
-// Regression test for the cross-format paste crash: copying a request out of a
-// `.bru` collection and pasting it into a `.yml` (OpenCollection) collection
-// used to serialize the request in the SOURCE format while naming the file with
-// the DESTINATION extension. The resulting `.yml` file held `.bru` syntax; the
-// watcher couldn't parse it, produced a partial item with no `request`, and the
-// sidebar crashed rendering the method badge — persisting across reloads.
+// Pasting a request across collections of different on-disk formats used to
+// write source-format content into a destination-named file, crashing the
+// sidebar. See VSCODE-75.
 test.describe('Cross-format paste', () => {
 
   test('paste a request from a .bru collection into a .yml collection', async ({ page, tmpDir }) => {
@@ -42,20 +38,16 @@ test.describe('Cross-format paste', () => {
     const requestName = 'Ping';
     const requestUrl = `${TEST_SERVER}/ping`;
 
-    // Two collections of different on-disk formats.
     await createCollection(page, sidebar, sourceCollection, tmpDir, 'bru');
     await createCollection(page, sidebar, targetCollection, tmpDir, 'yml');
 
-    // A request in the .bru source collection.
     const newReqPanel = await openNewRequestPanel(page, sidebar, sourceCollection);
     await createRequest(page, newReqPanel, sidebar, sourceCollection, requestName, requestUrl, 'POST');
 
-    // Copy it, then paste into the .yml target collection.
     await copyItem(sidebar, requestName);
     await pasteIntoCollection(sidebar, targetCollection);
 
-    // The sidebar must survive the paste: both collection rows remain visible.
-    // (A crash unmounts the tree, so these vanish.)
+    // A crash unmounts the tree, so surviving rows prove the sidebar is alive.
     await expect(sidebar.locator('.sidebar-header')).toBeVisible();
     await expect(
       sidebar.locator('[data-testid="sidebar-collection-row"]').filter({ hasText: sourceCollection })
@@ -64,7 +56,6 @@ test.describe('Cross-format paste', () => {
       sidebar.locator('[data-testid="sidebar-collection-row"]').filter({ hasText: targetCollection })
     ).toBeVisible();
 
-    // The pasted request renders in the target collection tree.
     await expandCollection(sidebar, targetCollection);
     await expect(
       sidebar
@@ -72,9 +63,6 @@ test.describe('Cross-format paste', () => {
         .filter({ hasText: requestName })
     ).toBeVisible({ timeout: 15_000 });
 
-    // The definitive check: the pasted request file must be written in the
-    // DESTINATION format. It lives in a folder identified by the target's
-    // opencollection.yml; the request itself is a `.yml` file next to it.
     const ocConfig = walkFiles(tmpDir).find((f) => path.basename(f) === 'opencollection.yml');
     expect(ocConfig, 'target collection opencollection.yml should exist').toBeTruthy();
     const targetDir = path.dirname(ocConfig as string);
@@ -83,15 +71,13 @@ test.describe('Cross-format paste', () => {
       .find((name) => name.toLowerCase().endsWith('.yml') && name !== 'opencollection.yml');
     expect(pastedFile, 'pasted request .yml file should exist in the target collection').toBeTruthy();
 
+    // The pasted file must hold YAML (`info:`), not `.bru` syntax (`meta {`).
     const pastedContent = fs.readFileSync(path.join(targetDir, pastedFile as string), 'utf8');
-    // OpenCollection (yml) requests start with an `info:` block. A `.bru`-format
-    // body (the bug) would instead contain a `meta {` block.
     expect(pastedContent).toContain('info:');
     expect(pastedContent).not.toContain('meta {');
 
-    // And it opens cleanly with the request data preserved across the
-    // conversion. Collapse the source first so the identically named source
-    // request is out of the DOM and we unambiguously open the pasted one.
+    // Collapse the source so the identically named source request leaves the DOM
+    // and we open the pasted one.
     await collapseCollection(sidebar, sourceCollection);
     const editor = await openRequest(page, sidebar, targetCollection, requestName);
     await expect(editor.locator('#request-url')).toContainText(requestUrl, { timeout: 10_000 });

--- a/tests/e2e/utils/actions.ts
+++ b/tests/e2e/utils/actions.ts
@@ -111,12 +111,14 @@ async function mockBrowseDirectory(frame: Frame, dirPath: string): Promise<void>
  * @param sidebar - The sidebar webview Frame
  * @param name - Collection name
  * @param location - Filesystem path where the collection will be stored
+ * @param format - On-disk format: 'yml' (OpenCollection, default) or 'bru'
  */
 export async function createCollection(
   page: Page,
   sidebar: Frame,
   name: string,
-  location: string
+  location: string,
+  format: 'yml' | 'bru' = 'yml'
 ): Promise<void> {
   // Open the "+" dropdown and click "Create collection"
   await sidebar.locator('[data-testid="collections-header-add-menu"]').click();
@@ -136,6 +138,13 @@ export async function createCollection(
 
   // Wait for formik to pick up the value before submitting
   await expect(editor.locator('#collectionLocation')).toHaveValue(location, { timeout: 5_000 });
+
+  // The format selector lives behind the "Options" toggle; only expand it when
+  // we need a non-default format.
+  if (format !== 'yml') {
+    await editor.locator('.advanced-toggle').click();
+    await editor.locator('#format').selectOption(format);
+  }
 
   // Submit the form
   await editor.locator('button[type="submit"]').filter({ hasText: 'Create Collection' }).click();
@@ -297,6 +306,28 @@ export async function expandCollection(
   );
 
   if (!isExpanded) {
+    await chevron.click();
+  }
+}
+
+/**
+ * Collapse a collection in the sidebar by clicking its chevron toggle.
+ * A collapsed collection removes its children from the DOM.
+ */
+export async function collapseCollection(
+  sidebar: Frame,
+  collectionName: string
+): Promise<void> {
+  const collectionRow = sidebar
+    .locator('[data-testid="sidebar-collection-row"]')
+    .filter({ hasText: collectionName });
+
+  const chevron = collectionRow.locator('svg.chevron-icon');
+  const isExpanded = await chevron.evaluate(
+    (el) => el.classList.contains('rotate-90')
+  );
+
+  if (isExpanded) {
     await chevron.click();
   }
 }
@@ -550,6 +581,37 @@ export async function deleteItem(
 
   // Wait for the item to disappear
   await expect(itemRow).not.toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Copy a request/folder to the in-app clipboard via its sidebar context menu.
+ *
+ * @param sidebar - The sidebar webview Frame
+ * @param itemName - Name of the request/folder to copy
+ */
+export async function copyItem(sidebar: Frame, itemName: string): Promise<void> {
+  const itemRow = sidebar
+    .locator('[data-testid="sidebar-collection-item-row"]')
+    .filter({ hasText: itemName });
+  await itemRow.hover();
+  await itemRow.locator('[data-testid="collection-item-menu"]').click();
+  await sidebar.locator('[role="menuitem"]').filter({ hasText: /^Copy$/ }).click();
+}
+
+/**
+ * Paste the in-app clipboard item into a collection's root via its context menu.
+ * The "Paste" entry only appears once something has been copied.
+ *
+ * @param sidebar - The sidebar webview Frame
+ * @param collectionName - Name of the destination collection
+ */
+export async function pasteIntoCollection(sidebar: Frame, collectionName: string): Promise<void> {
+  const collectionRow = sidebar
+    .locator('[data-testid="sidebar-collection-row"]')
+    .filter({ hasText: collectionName });
+  await collectionRow.hover();
+  await collectionRow.locator('[data-testid="collection-actions"]').click();
+  await sidebar.locator('[role="menuitem"]').filter({ hasText: /^Paste$/ }).click();
 }
 
 /**


### PR DESCRIPTION
## Summary
Fix the sidebar crash that happens when a request is copied from one collection and pasted into another collection that uses a different on-disk format (`.bru` ⟷ `.yml`/OpenCollection). The paste now writes the request in the destination collection's format, so it stays valid and the sidebar keeps working — including after reloading VS Code.

## Problem
- Copying a request from one collection and pasting it into another crashes the sidebar.
- After reloading VS Code, clicking the collection the request was pasted into crashes it again — so the collection becomes unusable.
- Repro: have two collections in different formats (one `.bru`, one `.yml`/OpenCollection) → copy a request from one → paste it into the other → the sidebar breaks → reload VS Code → click the target collection → it crashes again.
- Works fine in the Bruno desktop app, but not in the VS Code extension.

JIRA: https://usebruno.atlassian.net/browse/VSCODE-75

## Root Cause

- Bruno saves requests in one of two formats: the classic **`.bru`** format or the newer **`.yml`** (OpenCollection) format. A collection uses one or the other.

- When pasting a request into a collection of a *different* format, the extension named the new file with the **destination's** extension (e.g. `request.yml`) but saved its **contents in the source's format** (`.bru` text) — so a `.yml` file ended up full of `.bru` syntax.

- That file no longer matches its extension, so it can't be read back. The sidebar crashes trying to display a request it can't parse — and because the broken file stays saved on disk, the crash returns every time the collection is reopened. Pasting a whole folder hit the same issue.

- **The desktop app isn't affected, even though it supports both formats too** — the difference is *how* each app pastes:
  - **Desktop** keeps each request fully loaded in memory, so it pastes straight from that copy and always writes it in the **destination's** format. ✅
  - **The extension** only keeps a lightweight summary of each request loaded (for sidebar performance), so it can't paste from memory without losing data. It re-reads the original file and re-saves it instead — but re-saved using the **source's** format rather than the destination's. ❌

- **This fix brings the extension in line with desktop:** always save a pasted request in the destination collection's format.

## Solution

- **When pasting a request, always save it in the destination collection's format** — not the source's. This matches how the desktop app already behaves, so cross-format pastes now produce a valid file every time.

- **When pasting a folder, convert its requests only if the two formats actually differ.** If the source and destination use the same format, the files are copied over as-is — faster, and it preserves comments, formatting, and any fields untouched.

- **Made the sidebar resilient as a safety net:** if it ever encounters a request it can't fully read, it now skips the unreadable part instead of crashing the whole panel.

## Test plan
- [x] Copy a request from a `.bru` collection → paste into a `.yml` collection → sidebar stays alive and the request renders correctly
- [x] Added an e2e test that reproduces the crash and asserts the pasted `.yml` file is written in YAML, not `.bru` syntax (verified it fails without the fix and passes with it)
- [x] Same-format paste (`.bru` → `.bru`, `.yml` → `.yml`) still works
- [x] TypeScript typecheck passes (repo + e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)