### PR TITLE
fix: allow collapsing collections/folders during search

### DIFF
--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
@@ -47,6 +47,7 @@ import { getRevealInFolderLabel } from 'utils/common/platform';
 import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
+import useSearchCollapse from 'hooks/useSearchCollapse';
 import { isSidebarMode, openRequestInVSCodeEditor } from 'utils/webviewMode';
 import { ipcRenderer } from 'utils/ipc';
 
@@ -86,9 +87,13 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
   const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
   const [dropType, setDropType] = useState<string | null>(null);
 
-  const hasSearchText = searchText && searchText?.trim?.()?.length;
-  const itemIsCollapsed = hasSearchText ? false : item.collapsed;
+  const hasSearchText = !!(searchText && searchText?.trim?.()?.length);
   const isFolder = isItemAFolder(item);
+  const { collapsed: itemIsCollapsed, toggleCollapsed } = useSearchCollapse(
+    hasSearchText,
+    item.collapsed,
+    () => dispatch(toggleCollectionItem({ itemUid: item.uid, collectionUid }))
+  );
 
   const [{ isDragging }, drag, dragPreview] = useDrag({
     type: 'collection-item',
@@ -264,12 +269,7 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
   const handleFolderCollapse = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    dispatch(
-      toggleCollectionItem({
-        itemUid: item.uid,
-        collectionUid: collectionUid
-      })
-    );
+    toggleCollapsed();
   };
 
   const handleFolderDoubleClick = (e: React.MouseEvent) => {

--- a/src/webview/components/Sidebar/Collections/Collection/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/index.tsx
@@ -49,6 +49,7 @@ import { getRevealInFolderLabel } from 'utils/common/platform';
 import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
+import useSearchCollapse from 'hooks/useSearchCollapse';
 import { ipcRenderer } from 'utils/ipc';
 import { addTransientRequest } from 'providers/ReduxStore/slices/collections';
 import transientManager from 'utils/transient-manager';
@@ -77,8 +78,12 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
     });
   };
 
-  const hasSearchText = searchText && searchText?.trim?.()?.length;
-  const collectionIsCollapsed = hasSearchText ? false : collection.collapsed;
+  const hasSearchText = !!(searchText && searchText?.trim?.()?.length);
+  const { collapsed: collectionIsCollapsed, toggleCollapsed } = useSearchCollapse(
+    hasSearchText,
+    collection.collapsed,
+    () => dispatch(toggleCollection(collection.uid))
+  );
 
   const iconClassName = classnames({
     'rotate-90': !collectionIsCollapsed
@@ -110,7 +115,7 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
   const handleCollectionCollapse = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    dispatch(toggleCollection(collection.uid));
+    toggleCollapsed();
   };
 
   const handleCollectionDoubleClick = (e: React.MouseEvent) => {

--- a/src/webview/hooks/useSearchCollapse/index.ts
+++ b/src/webview/hooks/useSearchCollapse/index.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+interface UseSearchCollapseResult {
+  collapsed: boolean;
+  toggleCollapsed: () => void;
+}
+
+/**
+ * Collapse state for a sidebar tree row that also honors an active search.
+ *
+ * During a search every matching branch auto-expands so results stay visible,
+ * yet the user can still collapse a branch — that choice lives in local state
+ * and resets when the search session ends. Without a search the persisted
+ * Redux `collapsed` flag drives the row.
+ */
+const useSearchCollapse = (
+  hasSearchText: boolean,
+  persistedCollapsed: boolean,
+  togglePersisted: () => void
+): UseSearchCollapseResult => {
+  const [searchCollapsed, setSearchCollapsed] = useState(false);
+  const [prevHasSearchText, setPrevHasSearchText] = useState(hasSearchText);
+
+  if (prevHasSearchText !== hasSearchText) {
+    setPrevHasSearchText(hasSearchText);
+    setSearchCollapsed(false);
+  }
+
+  const collapsed = hasSearchText ? searchCollapsed : persistedCollapsed;
+
+  const toggleCollapsed = () => {
+    if (hasSearchText) {
+      setSearchCollapsed((prev) => !prev);
+    } else {
+      togglePersisted();
+    }
+  };
+
+  return { collapsed, toggleCollapsed };
+};
+
+export default useSearchCollapse;


### PR DESCRIPTION
## Summary
Fix the sidebar so users can collapse a collection or folder again after searching for a request.

## Problem
- After searching in the sidebar, collections and folders can no longer be collapsed.
- Clicking the collapse chevron has no visible effect while a search is active.
- Repro: open the sidebar → search for a request → try to collapse a collection/folder → it stays expanded.
- JIRA: https://usebruno.atlassian.net/browse/VSCODE-70

## Root Cause
- During an active search, the tree force-expands every branch so matching requests stay visible.
- That override also suppressed the user's manual collapse action, so the dispatched toggle changed state that the view then ignored — leaving branches stuck open.

## Solution
- Track the collapse action during search as lightweight, per-row local state so collapsing/expanding works again without losing the "auto-reveal matches" behavior.
- Leave the persisted collapse state untouched during search, so clearing the search restores each branch to exactly how it was before.
- Reset per search session so results always start fully expanded and visible.

## Test plan
- [ ] Search → collapse a collection/folder → it collapses and can be re-expanded
- [ ] Clear the search → branches return to their pre-search collapse state
- [ ] Searching still auto-expands branches so matching requests are visible
- [ ] Non-search collapse/expand behaviour is unchanged (no regression)
- [ ] TypeScript typecheck passes and unit tests are green

🤖 Generated with [Claude Code](https://claude.com/claude-code)