### PR TITLE
fix (transient-requests) — "Untitled N" numbering starts at 1 and reuses freed numbers

### DIFF
--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -90,8 +90,6 @@ export async function openTransientRequestPanel(
   });
 
   panel.onDidDispose(() => {
-    // Remove the transient from all stores on close so its "Untitled N" number
-    // is freed right away. Item data is kept during the grace window for Undo.
     stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
 
     clearActiveItemFromSidebar(itemUid);
@@ -153,9 +151,7 @@ export async function openTransientRequestPanel(
 
     const item = transientItems.get(itemUid);
     if (item) {
-      // Broadcast so the sidebar store also tracks the transient (keeps
-      // "Untitled N" numbering right and restores it on Undo). The add is
-      // idempotent, so it's safe even though the sidebar already added it.
+      // Broadcast so the sidebar store also tracks the transient request.
       stateManager.broadcast('main:add-transient-request', {
         collectionUid,
         item

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -100,13 +100,16 @@ export async function openTransientRequestPanel(
       return;
     }
 
+    // Remove the transient from all stores on close so its "Untitled N" number
+    // is freed right away. Item data is kept during the grace window for Undo.
+    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+
     const GRACE_MS = 10_000;
 
     const timer = setTimeout(() => {
       stateManager.removeWebview(panel.webview);
       transientPanels.delete(itemUid);
       transientItems.delete(itemUid);
-      stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
     }, GRACE_MS);
 
     vscode.window.showInformationMessage(
@@ -151,7 +154,10 @@ export async function openTransientRequestPanel(
 
     const item = transientItems.get(itemUid);
     if (item) {
-      stateManager.sendTo(panel.webview, 'main:add-transient-request', {
+      // Broadcast so the sidebar store also tracks the transient (keeps
+      // "Untitled N" numbering right and restores it on Undo). The add is
+      // idempotent, so it's safe even though the sidebar already added it.
+      stateManager.broadcast('main:add-transient-request', {
         collectionUid,
         item
       });
@@ -249,7 +255,7 @@ export async function openTransientRequestPanel(
         }
         // Handle save transient request — args[0] is the serialized item data
         if (channel === 'transient:save-request' && args?.[0]) {
-          await saveTransientRequest(panel, itemUid, collectionPath, args[0] as Record<string, unknown>);
+          await saveTransientRequest(panel, itemUid, collectionUid, collectionPath, args[0] as Record<string, unknown>);
         }
         if (channel === 'transient:item-updated' && args?.[0]) {
           const { itemUid: updatedUid, item } = args[0] as { itemUid: string; item: Record<string, unknown> };
@@ -291,6 +297,7 @@ export function closeTransientPanel(itemUid: string): void {
 async function saveTransientRequest(
   panel: vscode.WebviewPanel,
   itemUid: string,
+  collectionUid: string,
   collectionPath: string,
   itemData: Record<string, unknown>
 ): Promise<void> {
@@ -325,6 +332,10 @@ async function saveTransientRequest(
     const { stringifyRequestViaWorker } = require('@usebruno/filestore');
     const content = await stringifyRequestViaWorker({ ...itemData, name, filename }, { format });
     fs.writeFileSync(fullPath, content, 'utf-8');
+
+    // Saved to disk — remove the in-memory transient from all stores now so its
+    // "Untitled N" number is freed.
+    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
 
     savedPanels.add(itemUid);
     panel.dispose();

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -90,19 +90,18 @@ export async function openTransientRequestPanel(
   });
 
   panel.onDidDispose(() => {
+    // Remove the transient from all stores on close so its "Untitled N" number
+    // is freed right away. Item data is kept during the grace window for Undo.
+    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
+
     clearActiveItemFromSidebar(itemUid);
     if (savedPanels.has(itemUid)) {
       savedPanels.delete(itemUid);
       stateManager.removeWebview(panel.webview);
       transientPanels.delete(itemUid);
       transientItems.delete(itemUid);
-      stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
       return;
     }
-
-    // Remove the transient from all stores on close so its "Untitled N" number
-    // is freed right away. Item data is kept during the grace window for Undo.
-    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
 
     const GRACE_MS = 10_000;
 
@@ -255,7 +254,7 @@ export async function openTransientRequestPanel(
         }
         // Handle save transient request — args[0] is the serialized item data
         if (channel === 'transient:save-request' && args?.[0]) {
-          await saveTransientRequest(panel, itemUid, collectionUid, collectionPath, args[0] as Record<string, unknown>);
+          await saveTransientRequest(panel, itemUid, collectionPath, args[0] as Record<string, unknown>);
         }
         if (channel === 'transient:item-updated' && args?.[0]) {
           const { itemUid: updatedUid, item } = args[0] as { itemUid: string; item: Record<string, unknown> };
@@ -297,7 +296,6 @@ export function closeTransientPanel(itemUid: string): void {
 async function saveTransientRequest(
   panel: vscode.WebviewPanel,
   itemUid: string,
-  collectionUid: string,
   collectionPath: string,
   itemData: Record<string, unknown>
 ): Promise<void> {
@@ -332,10 +330,6 @@ async function saveTransientRequest(
     const { stringifyRequestViaWorker } = require('@usebruno/filestore');
     const content = await stringifyRequestViaWorker({ ...itemData, name, filename }, { format });
     fs.writeFileSync(fullPath, content, 'utf-8');
-
-    // Saved to disk — remove the in-memory transient from all stores now so its
-    // "Untitled N" number is freed.
-    stateManager.broadcast('main:transient-request-closed', { collectionUid, itemUid });
 
     savedPanels.add(itemUid);
     panel.dispose();

--- a/src/webview/components/Sidebar/Collections/Collection/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/index.tsx
@@ -312,6 +312,12 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
 
   const newRequestMenuRef = useRef<any>(null);
 
+  // The menu is memoized on collection.uid, so its onClicks would capture a
+  // stale collection. Read the latest via a ref so "Untitled N" numbering
+  // reflects the current items.
+  const latestCollectionRef = useRef(collection);
+  latestCollectionRef.current = collection;
+
   const openTransientRequest = (item: any) => {
     dispatch(addTransientRequest({ collectionUid: collection.uid, item }));
     ipcRenderer.send('sidebar:open-transient-request', {
@@ -328,25 +334,25 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
       id: 'new-http',
       leftSection: IconApi,
       label: 'HTTP',
-      onClick: () => openTransientRequest(transientManager.createHttpRequest(collection))
+      onClick: () => openTransientRequest(transientManager.createHttpRequest(latestCollectionRef.current))
     },
     {
       id: 'new-graphql',
       leftSection: IconBrandGraphql,
       label: 'GraphQL',
-      onClick: () => openTransientRequest(transientManager.createGraphQLRequest(collection))
+      onClick: () => openTransientRequest(transientManager.createGraphQLRequest(latestCollectionRef.current))
     },
     {
       id: 'new-grpc',
       leftSection: IconNetwork,
       label: 'gRPC',
-      onClick: () => openTransientRequest(transientManager.createGrpcRequest(collection))
+      onClick: () => openTransientRequest(transientManager.createGrpcRequest(latestCollectionRef.current))
     },
     {
       id: 'new-ws',
       leftSection: IconPlugConnected,
       label: 'WebSocket',
-      onClick: () => openTransientRequest(transientManager.createWebSocketRequest(collection))
+      onClick: () => openTransientRequest(transientManager.createWebSocketRequest(latestCollectionRef.current))
     }
   ], [collection.uid]);
 

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1582,7 +1582,11 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (collection) {
         collection.items = collection.items || [];
-        collection.items.push(item);
+        // Guard against duplicates: the same transient can arrive from both the
+        // sidebar dispatch and the panel broadcast.
+        if (!collection.items.some((i: any) => i.uid === item.uid)) {
+          collection.items.push(item);
+        }
       }
     },
 

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1582,8 +1582,6 @@ export const collectionsSlice = createSlice({
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (collection) {
         collection.items = collection.items || [];
-        // Guard against duplicates: the same transient can arrive from both the
-        // sidebar dispatch and the panel broadcast.
         if (!collection.items.some((i: any) => i.uid === item.uid)) {
           collection.items.push(item);
         }

--- a/src/webview/utils/collections/index.tsx
+++ b/src/webview/utils/collections/index.tsx
@@ -863,6 +863,10 @@ export const isItemAnApp = (item: AppItem): boolean => {
   return item.type === 'app';
 };
 
+export const isItemTransientRequest = (item: AppItem): boolean => {
+  return isItemARequest(item) && !!(item as any)?.isTransient;
+};
+
 export const humanizeRequestBodyMode = (mode: string | null | undefined): string => {
   let label = 'No Body';
   switch (mode) {

--- a/src/webview/utils/transient-manager.spec.ts
+++ b/src/webview/utils/transient-manager.spec.ts
@@ -75,13 +75,11 @@ describe('transient request names', () => {
   });
 
   test('resets to "Untitled 1" once transients are saved/closed', () => {
-    // Once saved, the transient is removed, so numbering restarts at "Untitled 1".
     const item = transientManager.createHttpRequest({ ...bruCollection, items: [] });
     expect(item.name).toBe('Untitled 1');
   });
 
   test('ignores saved (non-transient) requests when numbering', () => {
-    // Saved requests aren't transients, so they aren't counted.
     const item = transientManager.createHttpRequest({
       ...bruCollection,
       items: [savedRequest('Untitled 3'), transientUntitled(1)]

--- a/src/webview/utils/transient-manager.spec.ts
+++ b/src/webview/utils/transient-manager.spec.ts
@@ -1,13 +1,9 @@
-import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { transientManager, type CollectionInfo } from './transient-manager';
+import { describe, test, expect, vi } from 'vitest';
 
-vi.mock('utils/common/index', () => {
-  let counter = 0;
-  return {
-    uuid: () => `mock-uid-${++counter}`,
-    sortByNameThenSequence: vi.fn()
-  };
-});
+// Stub vscode for the node test env; the real utils/collections helpers are used.
+vi.mock('vscode', () => ({}));
+
+import { transientManager, type CollectionInfo } from './transient-manager';
 
 const bruCollection: CollectionInfo = {
   uid: 'col-1',
@@ -32,12 +28,15 @@ const windowsCollection: CollectionInfo = {
   format: 'bru'
 };
 
-beforeEach(() => {
-  transientManager.resetCounter(bruCollection.uid);
-  transientManager.resetCounter(ymlCollection.uid);
-  transientManager.resetCounter(noFormatCollection.uid);
-  transientManager.resetCounter(windowsCollection.uid);
+// An open transient request as it appears in collection.items.
+const transientUntitled = (n: number) => ({
+  name: `Untitled ${n}`,
+  type: 'http-request',
+  request: {},
+  isTransient: true
 });
+// A saved (persisted) request — has no isTransient flag.
+const savedRequest = (name: string) => ({ name, type: 'http-request', request: {} });
 
 // ─── Common fields shared by all request types ──────────────────────────────
 
@@ -58,34 +57,51 @@ describe('common transient item fields', () => {
 
 // ─── Auto-incrementing names ────────────────────────────────────────────────
 
-describe('auto-incrementing names', () => {
-  test('first item is named "Untitled 1"', () => {
+describe('transient request names', () => {
+  test('first item is named "Untitled 1" when the collection is empty', () => {
     const item = transientManager.createHttpRequest(bruCollection);
     expect(item.name).toBe('Untitled 1');
   });
 
-  test('sequential items increment the counter', () => {
-    const first = transientManager.createHttpRequest(bruCollection);
-    const second = transientManager.createGraphQLRequest(bruCollection);
-    const third = transientManager.createGrpcRequest(bruCollection);
-    expect(first.name).toBe('Untitled 1');
-    expect(second.name).toBe('Untitled 2');
-    expect(third.name).toBe('Untitled 3');
+  test('increments above the highest existing open transient', () => {
+    const item = transientManager.createGraphQLRequest({ ...bruCollection, items: [transientUntitled(1)] });
+    expect(item.name).toBe('Untitled 2');
+
+    const item2 = transientManager.createGrpcRequest({
+      ...bruCollection,
+      items: [transientUntitled(1), transientUntitled(2)]
+    });
+    expect(item2.name).toBe('Untitled 3');
   });
 
-  test('different collections have independent counters', () => {
-    const a = transientManager.createHttpRequest(bruCollection);
-    const b = transientManager.createHttpRequest(ymlCollection);
+  test('resets to "Untitled 1" once transients are saved/closed', () => {
+    // Once saved, the transient is removed, so numbering restarts at "Untitled 1".
+    const item = transientManager.createHttpRequest({ ...bruCollection, items: [] });
+    expect(item.name).toBe('Untitled 1');
+  });
+
+  test('ignores saved (non-transient) requests when numbering', () => {
+    // Saved requests aren't transients, so they aren't counted.
+    const item = transientManager.createHttpRequest({
+      ...bruCollection,
+      items: [savedRequest('Untitled 3'), transientUntitled(1)]
+    });
+    expect(item.name).toBe('Untitled 2');
+  });
+
+  test('counts transients nested inside folders (flattenItems)', () => {
+    const items = [
+      { name: 'My Folder', type: 'folder', items: [transientUntitled(1), transientUntitled(2)] }
+    ];
+    const item = transientManager.createHttpRequest({ ...bruCollection, items });
+    expect(item.name).toBe('Untitled 3');
+  });
+
+  test('different collections are numbered independently', () => {
+    const a = transientManager.createHttpRequest({ ...bruCollection, items: [] });
+    const b = transientManager.createHttpRequest({ ...ymlCollection, items: [transientUntitled(1)] });
     expect(a.name).toBe('Untitled 1');
-    expect(b.name).toBe('Untitled 1');
-  });
-
-  test('resetCounter resets the naming sequence', () => {
-    transientManager.createHttpRequest(bruCollection);
-    transientManager.createHttpRequest(bruCollection);
-    transientManager.resetCounter(bruCollection.uid);
-    const item = transientManager.createHttpRequest(bruCollection);
-    expect(item.name).toBe('Untitled 1');
+    expect(b.name).toBe('Untitled 2');
   });
 });
 

--- a/src/webview/utils/transient-manager.ts
+++ b/src/webview/utils/transient-manager.ts
@@ -10,6 +10,7 @@
  */
 
 import { uuid } from 'utils/common/index';
+import { flattenItems, isItemTransientRequest } from 'utils/collections/index';
 
 interface TransientItem {
   uid: string;
@@ -28,17 +29,30 @@ interface CollectionInfo {
   uid: string;
   pathname: string;
   format?: string; // 'bru' or 'yml'
+  items?: any[]; // saved requests + open transients
 }
 
-// Track the next number for auto-generated names per collection
-const counters: Record<string, number> = {};
-
-function getNextName(collectionUid: string): string {
-  if (!counters[collectionUid]) {
-    counters[collectionUid] = 0;
+function getNextName(collection: CollectionInfo): string {
+  if (!collection || !collection.items) {
+    return 'Untitled 1';
   }
-  counters[collectionUid]++;
-  return `Untitled ${counters[collectionUid]}`;
+
+  const allItems = flattenItems(collection.items as any);
+  const transientRequests = allItems.filter((item: any) => isItemTransientRequest(item));
+
+  let maxNumber = 0;
+  transientRequests.forEach((item: any) => {
+    const match = item.name?.match(/^Untitled (\d+)$/);
+    if (match) {
+      const number = parseInt(match[1], 10);
+      if (number > maxNumber) {
+        maxNumber = number;
+      }
+    }
+  });
+
+  const nextName = `Untitled ${maxNumber + 1}`;
+  return nextName;
 }
 
 function getFileExtension(format?: string): string {
@@ -51,7 +65,7 @@ function buildTransientPath(collectionPathname: string, filename: string): strin
 }
 
 function generateItemMeta(collection: CollectionInfo): { name: string; filename: string; pathname: string } {
-  const name = getNextName(collection.uid);
+  const name = getNextName(collection);
   const ext = getFileExtension(collection.format);
   const filename = `${name}.${ext}`;
   const pathname = buildTransientPath(collection.pathname, filename);
@@ -174,10 +188,6 @@ const transientManager = {
       },
       settings: { timeout: 0, keepAliveInterval: 0 }
     };
-  },
-
-  resetCounter(collectionUid: string): void {
-    delete counters[collectionUid];
   }
 };
 

--- a/src/webview/utils/transient-manager.ts
+++ b/src/webview/utils/transient-manager.ts
@@ -33,26 +33,13 @@ interface CollectionInfo {
 }
 
 function getNextName(collection: CollectionInfo): string {
-  if (!collection || !collection.items) {
-    return 'Untitled 1';
-  }
-
-  const allItems = flattenItems(collection.items as any);
-  const transientRequests = allItems.filter((item: any) => isItemTransientRequest(item));
-
-  let maxNumber = 0;
-  transientRequests.forEach((item: any) => {
-    const match = item.name?.match(/^Untitled (\d+)$/);
-    if (match) {
-      const number = parseInt(match[1], 10);
-      if (number > maxNumber) {
-        maxNumber = number;
-      }
-    }
-  });
-
-  const nextName = `Untitled ${maxNumber + 1}`;
-  return nextName;
+  const items = flattenItems((collection?.items ?? []) as any);
+  const maxNumber = items.reduce((max: number, item: any) => {
+    if (!isItemTransientRequest(item)) return max;
+    const n = Number(item.name?.match(/^Untitled (\d+)$/)?.[1]);
+    return n > max ? n : max;
+  }, 0);
+  return `Untitled ${maxNumber + 1}`;
 }
 
 function getFileExtension(format?: string): string {

--- a/tests/e2e/specs/transient-request-name.spec.ts
+++ b/tests/e2e/specs/transient-request-name.spec.ts
@@ -17,7 +17,7 @@ test.describe('Transient request naming', () => {
 
     // First transient is "Untitled 1", the next increments to "Untitled 2".
     await createTransientRequest(sidebar, collectionName, 'http');
-    await expect(tab('Untitled 1')).toBeVisible({ timeout: 2_000 });
+    await expect(tab('Untitled 1')).toBeVisible();
 
     await createTransientRequest(sidebar, collectionName, 'http');
     await expect(tab('Untitled 2')).toBeVisible({ timeout: 2_000 });

--- a/tests/e2e/specs/transient-request-name.spec.ts
+++ b/tests/e2e/specs/transient-request-name.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createTransientRequest,
+  closeEditorTab,
+} from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+test.describe('Transient request naming', () => {
+  test('numbers new transient requests sequentially and reuses freed numbers', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Transient Name Collection';
+    await createCollection(page, sidebar, collectionName, tmpDir);
+
+    const tab = (title: string) => buildCommonLocators(page).workbench.editorTab(title);
+
+    // First transient is "Untitled 1", the next increments to "Untitled 2".
+    await createTransientRequest(sidebar, collectionName, 'http');
+    await expect(tab('Untitled 1')).toBeVisible({ timeout: 2_000 });
+
+    await createTransientRequest(sidebar, collectionName, 'http');
+    await expect(tab('Untitled 2')).toBeVisible({ timeout: 2_000 });
+
+    // Closing frees both numbers.
+    await closeEditorTab(page, 'Untitled 1');
+    await closeEditorTab(page, 'Untitled 2');
+
+    // A new transient reuses "Untitled 1" instead of continuing to "Untitled 3".
+    await createTransientRequest(sidebar, collectionName, 'http');
+    await expect(tab('Untitled 1')).toBeVisible({ timeout: 2_000 });
+    await expect(tab('Untitled 3')).toHaveCount(0, { timeout: 2_000 });
+  });
+});

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -880,6 +880,32 @@ export async function deleteItem(
 }
 
 /**
+ * Create a transient (unsaved) request from the collection's "+" menu.
+ * Opens a WebviewPanel titled "Untitled N".
+ */
+export async function createTransientRequest(
+  sidebar: Frame,
+  collectionName: string,
+  type: 'http' | 'graphql' | 'grpc' | 'ws' = 'http'
+): Promise<void> {
+  const locators = buildCommonLocators(sidebar);
+  await locators.sidebar.collectionName(collectionName).hover();
+  await locators.newRequestMenu.addButton(collectionName).click();
+  await locators.newRequestMenu.option(type).click();
+}
+
+/**
+ * Close a VS Code editor tab by its title (clicks the tab's close button).
+ */
+export async function closeEditorTab(page: Page, title: string): Promise<void> {
+  const locators = buildCommonLocators(page);
+  const tab = locators.workbench.editorTab(title);
+  await tab.hover();
+  await locators.workbench.editorTabClose(title).click();
+  await expect(tab).toHaveCount(0, { timeout: 2_000 });
+}
+
+/**
  * Copy a request/folder to the in-app clipboard via its sidebar context menu.
  *
  * @param sidebar - The sidebar webview Frame

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -47,6 +47,22 @@ export const buildCommonLocators = (frame: FrameLike) => ({
         .locator('.CodeMirror-line')
         .first()
   },
+  // The "+" transient-request menu on a collection row.
+  newRequestMenu: {
+    addButton: (collectionName: string) =>
+      frame
+        .getByTestId('sidebar-collection-row')
+        .filter({ hasText: collectionName })
+        .getByTestId('collection-new-request'),
+    // Menu option by request type: http | graphql | grpc | ws.
+    option: (type: string) => frame.getByTestId(`collection-new-request-new-${type}`)
+  },
+  // VS Code editor tab (workbench, not a webview) — pass the page to the factory.
+  workbench: {
+    editorTab: (title: string) => frame.locator('.tabs-container .tab').filter({ hasText: title }),
+    editorTabClose: (title: string) =>
+      frame.locator('.tabs-container .tab').filter({ hasText: title }).locator('.action-label.codicon-close')
+  },
   // New Request panel form.
   newRequest: {
     typeOption: (type: string) => frame.locator('.request-type-option').filter({ hasText: type }),


### PR DESCRIPTION
**Jira: VSCODE-45**
### Description
Freed up the number `N` once transient request is closed or saved. `Untitled N` request is saved/closed, new transient request gets created as `Untitled N` instead of `Untitled N+1`.
### Problem
Transient request `Untitled N` is closed/saved, new transient request is getting created as `Untitled N+1` instead of `Untitled N`
### Fix
1. Transient request `Untitled N` is closed, the event is broadcasted so the sidebar stays in sync.
2. Transient request `Untitled N` is saved, `Untitled N` with `isTransient: true` is removed from collection items so the new transient request will be created as `Untitled N` instead of `Untitled N+1`
### Before

https://github.com/user-attachments/assets/cb0140b2-8eb8-4b1d-a6b1-f2fd7689e55b

### After

https://github.com/user-attachments/assets/0dcf68ec-e099-40af-92d9-eb07ab1febd9

