### PR TITLE
fix(variable-suggestion)-Suggest variables on entering key name

### DIFF
--- a/src/webview/globalStyles.ts
+++ b/src/webview/globalStyles.ts
@@ -284,6 +284,11 @@ const GlobalStyle = createGlobalStyle`
 
   // Autocomplete hints dropdown container
   .CodeMirror-hints {
+    position: absolute;
+    overflow-y: auto;
+    max-height: 20em;
+    margin: 0;
+    list-style: none;
     z-index: 50 !important;
     background: ${(props) => props.theme.dropdown.bg};
     ${(props) =>
@@ -306,6 +311,9 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.5rem;
     font-size: ${(props) => props.theme.font.size.sm};
     cursor: pointer;
+    margin: 0;
+    padding: 0 0.5rem;
+    white-space: nowrap;
   }
 
   .CodeMirror-brunoVarInfo :first-child {


### PR DESCRIPTION
**Issue**: Variable autocomplete suggestions weren't showing when typing.

**Change**: Added the missing structural properties to `.CodeMirror-hints` / `.CodeMirror-hint` — `position: absolute`, `overflow-y: auto`, `max-height`, `margin`, `list-style`, and item padding/`white-space` — so the dropdown appears correctly anchored, while keeping the existing theme colors.

Jira: VSCODE-66