### PR TITLE
fix: renamed request not appearing in sidebar under collection

### DIFF
--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1633,7 +1633,8 @@ export const collectionsSlice = createSlice({
         currentSubItems = childItem.items;
       }
 
-      if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name && !f.isTransient)) {
+      /** Dedup by uid (a hash of the pathname), not display name: a disk rename keeps meta.name, so a name check would drop the renamed file as a duplicate of the not-yet-removed old item. */
+      if (meta.name !== 'folder.bru') {
         const currentItem = find(currentSubItems, (i) => i.uid === data?.uid);
         if (currentItem) {
           // Preserve existing draft and response if they exist (don't overwrite unsaved changes)
@@ -1762,7 +1763,7 @@ export const collectionsSlice = createSlice({
           currentSubItems = childItem.items;
         }
 
-        if (meta.name !== 'folder.bru' && !currentSubItems.find((f) => f.name === data?.name && !f.isTransient)) {
+        if (meta.name !== 'folder.bru') {
           const currentItem = find(currentSubItems, (i) => i.uid === data?.uid);
           if (currentItem) {
             const existingDraft = currentItem.draft;

--- a/src/webview/providers/ReduxStore/slices/collections/rename-file.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/rename-file.spec.ts
@@ -79,11 +79,17 @@ describe('renaming a request file on disk', () => {
     };
 
     let state = makeState([item]);
+
+    // Re-add the same path/uid with a new name — an in-place update must replace
+    // the existing item rather than append a duplicate.
     state = collectionsReducer(state, collectionAddFileEvent(
-      addFilePayload('/test/req.bru', 'uid-1', 'My Request')
+      addFilePayload('/test/req.bru', 'uid-1', 'My Request (edited)')
     ));
 
     const requests = state.collections[0].items.filter((i: any) => i.type === 'http-request');
     expect(requests).toHaveLength(1);
+    expect(requests[0].uid).toBe('uid-1');
+    expect(requests[0].name).toBe('My Request (edited)');
+    expect(requests[0].pathname).toBe('/test/req.bru');
   });
 });

--- a/src/webview/providers/ReduxStore/slices/collections/rename-file.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/rename-file.spec.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => ({}));
+
+const {
+  default: collectionsReducer,
+  collectionAddFileEvent,
+  collectionUnlinkFileEvent
+} = await import('./index');
+
+function makeState(items: any[]): any {
+  return {
+    collections: [{
+      uid: 'col-1',
+      name: 'Test',
+      pathname: '/test',
+      items,
+      environments: [],
+      brunoConfig: {}
+    }],
+    collectionSortOrder: 'default',
+    activeConnections: {}
+  };
+}
+
+function addFilePayload(pathname: string, uid: string, name: string): any {
+  return {
+    meta: { collectionUid: 'col-1', pathname, name: pathname.split('/').pop() },
+    data: { uid, name, type: 'http-request', request: { url: '' } },
+    partial: true,
+    loading: false
+  };
+}
+
+describe('renaming a request file on disk', () => {
+  test('the renamed file is added even while the old item (same display name) is still present', () => {
+    // A rename surfaces as addFile(new) + unlink(old); the internal meta.name is
+    // unchanged, and VS Code offers no ordering guarantee — so the add must not
+    // be deduped against the not-yet-removed old item.
+    const oldItem = {
+      uid: 'uid-old',
+      name: 'My Request',
+      type: 'http-request',
+      filename: 'old.bru',
+      pathname: '/test/old.bru',
+      request: { url: '' }
+    };
+
+    let state = makeState([oldItem]);
+
+    // addFile for the new path arrives while the old item is still in the tree
+    state = collectionsReducer(state, collectionAddFileEvent(
+      addFilePayload('/test/new.bru', 'uid-new', 'My Request')
+    ));
+
+    let items = state.collections[0].items;
+    expect(items.find((i: any) => i.uid === 'uid-new')).toBeDefined();
+
+    // the deferred unlink of the old path then removes the stale item
+    state = collectionsReducer(state, collectionUnlinkFileEvent({
+      meta: { collectionUid: 'col-1', pathname: '/test/old.bru' }
+    } as any));
+
+    items = state.collections[0].items;
+    const surviving = items.filter((i: any) => i.type === 'http-request');
+    expect(surviving).toHaveLength(1);
+    expect(surviving[0].uid).toBe('uid-new');
+    expect(surviving[0].pathname).toBe('/test/new.bru');
+  });
+
+  test('re-adding the same file updates in place rather than duplicating', () => {
+    const item = {
+      uid: 'uid-1',
+      name: 'My Request',
+      type: 'http-request',
+      filename: 'req.bru',
+      pathname: '/test/req.bru',
+      request: { url: '' }
+    };
+
+    let state = makeState([item]);
+    state = collectionsReducer(state, collectionAddFileEvent(
+      addFilePayload('/test/req.bru', 'uid-1', 'My Request')
+    ));
+
+    const requests = state.collections[0].items.filter((i: any) => i.type === 'http-request');
+    expect(requests).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Identify a request in the sidebar by its file identity (derived from its path) instead of its display name(can be duplicate), so a request renamed on disk stays visible in the collection tree.
## Problem
- When a user renames a request file on disk (from a file manager or editor, outside the Bruno UI), the request disappears from the VS Code sidebar under its collection instead of staying visible.

- Repro: create and save a request in a collection → rename the file on disk → check the sidebar → the request is gone. Works fine in the Bruno desktop app.

- JIRA: [VSCODE-72]

## Root Cause
- VS Code reports a file rename as two separate events — "old file deleted" and "new file created" — with no guaranteed ordering, and the sidebar removes the old entry slightly later than it adds the new one. When the "new file" arrives, the sidebar asked *"does an item with this display name already exist here?"* to avoid duplicates. Renaming a file doesn't change the request's internal name, so the new file looked like a duplicate of the old (not-yet-removed) entry and was skipped. Moments later the old entry was removed too — leaving nothing.

- **Why desktop works:** the desktop app uses a file watcher (chokidar) that reliably removes the old entry *before* the new one is added, so the name check never collides. VS Code's watcher gives no such ordering guarantee, which is why the same name-based logic breaks here.

## Solution

- Deduplicate sidebar entries by each request's **file identity** (a fingerprint derived from its path) rather than its display name. A renamed file has a new path → a new identity → it is correctly recognized as the same request in a new location and stays in the tree, while the stale entry is cleaned up by its old path. This makes the behavior independent of the order VS Code happens to report the delete and create events. Applied consistently to both the single-file and batched "file added" paths; other flows (creating/saving requests, in-memory transient requests) are unchanged.

## Test plan
- [ ] Create and save a request, rename its file on disk → it stays visible in the sidebar with no duplicate
- [ ] Rename back and forth a few times → the tree stays correct regardless of event ordering
- [ ] Re-reading the same file updates it in place (no duplicate entry)
- [ ] Creating/saving a new request and transient (unsaved) requests behave as before (no regression)
- [ ] `npm run typecheck` passes; existing collections slice specs pass
