### PR TITLE
fix(sidebar) - Highlight active request/item

### DIFF
--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -80,7 +80,7 @@ const isEnvironmentsFolder = (pathname: string, collectionPath: string): boolean
   return path.normalize(dirname) === path.normalize(envDirectory);
 };
 
-const isFolderRootFile = (pathname: string, collectionPath: string): boolean => {
+export const isFolderRootFile = (pathname: string, collectionPath: string): boolean => {
   const basename = path.basename(pathname);
   const format = getCollectionFormat(collectionPath);
 
@@ -92,7 +92,7 @@ const isFolderRootFile = (pathname: string, collectionPath: string): boolean => 
   return false;
 };
 
-const isCollectionRootFile = (pathname: string, collectionPath: string): boolean => {
+export const isCollectionRootFile = (pathname: string, collectionPath: string): boolean => {
   const dirname = path.dirname(pathname);
   const basename = path.basename(pathname);
 

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -19,6 +19,7 @@ import { setMessageSender as setWatcherMessageSender } from '../app/collection-w
 import collectionWatcher from '../app/collection-watcher';
 import { defaultWorkspaceManager } from '../store/default-workspace';
 import { registerDocument, unregisterDocument } from './dirty-state-manager';
+import { notifyActiveItemToSidebar } from '../ipc/collection';
 
 interface IpcMessage {
   type: 'invoke' | 'send';
@@ -73,10 +74,25 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
 
     registerDocument(document);
 
+    const collectionRoot = findCollectionRoot(filePath);
+
+    // The sidebar item this editor represents, so the sidebar can highlight it
+    // (collection.bru → collection, folder.bru → folder, otherwise the request).
+    const editorFileName = path.basename(filePath);
+    const isCollectionRootFile = editorFileName === 'collection.bru' || editorFileName === 'opencollection.yml';
+    const isFolderRootFile = editorFileName === 'folder.bru' || editorFileName === 'folder.yml';
+    const activeItemUid = collectionRoot && isCollectionRootFile
+      ? generateUidBasedOnHash(collectionRoot)
+      : isFolderRootFile
+        ? generateUidBasedOnHash(path.dirname(filePath))
+        : generateUidBasedOnHash(filePath);
+
     stateManager.setActiveEditorWebview(webviewPanel.webview);
+    notifyActiveItemToSidebar(activeItemUid);
     webviewPanel.onDidChangeViewState((e) => {
       if (e.webviewPanel.active) {
         stateManager.setActiveEditorWebview(webviewPanel.webview);
+        notifyActiveItemToSidebar(activeItemUid);
       }
     });
 
@@ -85,8 +101,6 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       unregisterDocument(document.uri.fsPath);
       viewDataByWebview.delete(webviewPanel.webview);
     });
-
-    const collectionRoot = findCollectionRoot(filePath);
 
     const pendingVariables = pendingVariablesModeRequests.get(filePath);
     if (pendingVariables) {

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -15,11 +15,15 @@ import {
   openCollectionForSingleRequest,
   setMessageSender as setCollectionsMessageSender
 } from '../app/collections';
-import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
+import {
+  setMessageSender as setWatcherMessageSender,
+  isCollectionRootFile,
+  isFolderRootFile
+} from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import { defaultWorkspaceManager } from '../store/default-workspace';
 import { registerDocument, unregisterDocument } from './dirty-state-manager';
-import { notifyActiveItemToSidebar } from '../ipc/collection';
+import { notifyActiveItemToSidebar, clearActiveItemFromSidebar } from '../ipc/collection';
 
 interface IpcMessage {
   type: 'invoke' | 'send';
@@ -78,14 +82,17 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
 
     // The sidebar item this editor represents, so the sidebar can highlight it
     // (collection.bru → collection, folder.bru → folder, otherwise the request).
-    const editorFileName = path.basename(filePath);
-    const isCollectionRootFile = editorFileName === 'collection.bru' || editorFileName === 'opencollection.yml';
-    const isFolderRootFile = editorFileName === 'folder.bru' || editorFileName === 'folder.yml';
-    const activeItemUid = collectionRoot && isCollectionRootFile
-      ? generateUidBasedOnHash(collectionRoot)
-      : isFolderRootFile
-        ? generateUidBasedOnHash(path.dirname(filePath))
-        : generateUidBasedOnHash(filePath);
+    // Reuses the collection-watcher detection helpers, which apply the
+    // collection-root check and collection-format awareness, so the editor and
+    // the watcher agree on what a given file represents.
+    let activeItemUid: string;
+    if (collectionRoot && isCollectionRootFile(filePath, collectionRoot)) {
+      activeItemUid = generateUidBasedOnHash(collectionRoot);
+    } else if (collectionRoot && isFolderRootFile(filePath, collectionRoot)) {
+      activeItemUid = generateUidBasedOnHash(path.dirname(filePath));
+    } else {
+      activeItemUid = generateUidBasedOnHash(filePath);
+    }
 
     stateManager.setActiveEditorWebview(webviewPanel.webview);
     notifyActiveItemToSidebar(activeItemUid);
@@ -93,10 +100,13 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       if (e.webviewPanel.active) {
         stateManager.setActiveEditorWebview(webviewPanel.webview);
         notifyActiveItemToSidebar(activeItemUid);
+      } else {
+        clearActiveItemFromSidebar(activeItemUid);
       }
     });
 
     webviewPanel.onDidDispose(() => {
+      clearActiveItemFromSidebar(activeItemUid);
       stateManager.removeWebview(webviewPanel.webview);
       unregisterDocument(document.uri.fsPath);
       viewDataByWebview.delete(webviewPanel.webview);

--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -84,6 +84,15 @@ export function setSidebarWebviewGetter(getter: () => vscode.Webview | undefined
   sidebarWebviewGetter = getter;
 }
 
+// Tell the sidebar which item (request/folder/collection) is open in the active
+// editor, so it can highlight the matching row. Pass null to clear.
+export function notifyActiveItemToSidebar(itemUid: string | null): void {
+  const sidebar = sidebarWebviewGetter?.();
+  if (sidebar) {
+    stateManager.sendTo(sidebar, 'main:set-active-item', itemUid);
+  }
+}
+
 interface Environment {
   name: string;
   variables: Array<{ name: string; value: string; secret?: boolean; uid?: string }>;

--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -84,12 +84,26 @@ export function setSidebarWebviewGetter(getter: () => vscode.Webview | undefined
   sidebarWebviewGetter = getter;
 }
 
+// Tracks the item the sidebar is currently highlighting, so a deactivating or
+// closing panel can clear the highlight without stomping a newer active item.
+let activeSidebarItemUid: string | null = null;
+
 // Tell the sidebar which item (request/folder/collection) is open in the active
 // editor, so it can highlight the matching row. Pass null to clear.
 export function notifyActiveItemToSidebar(itemUid: string | null): void {
+  activeSidebarItemUid = itemUid;
   const sidebar = sidebarWebviewGetter?.();
   if (sidebar) {
     stateManager.sendTo(sidebar, 'main:set-active-item', itemUid);
+  }
+}
+
+// Clear the sidebar highlight, but only if `itemUid` is still the highlighted
+// item. Safe to call when a panel deactivates or is disposed regardless of
+// event ordering: if another item became active first, this is a no-op.
+export function clearActiveItemFromSidebar(itemUid: string): void {
+  if (activeSidebarItemUid === itemUid) {
+    notifyActiveItemToSidebar(null);
   }
 }
 

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -19,7 +19,7 @@ import {
   hasHandler
 } from '../ipc/handlers';
 import { openCollection, loadCollectionMetadata, setMessageSender as setCollectionsMessageSender } from '../app/collections';
-import { notifyActiveItemToSidebar } from '../ipc/collection';
+import { notifyActiveItemToSidebar, clearActiveItemFromSidebar } from '../ipc/collection';
 import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import { AppItem } from '@bruno-types';
@@ -84,10 +84,13 @@ export async function openTransientRequestPanel(
     if (e.webviewPanel.active) {
       stateManager.setActiveEditorWebview(panel.webview);
       notifyActiveItemToSidebar(itemUid);
+    } else {
+      clearActiveItemFromSidebar(itemUid);
     }
   });
 
   panel.onDidDispose(() => {
+    clearActiveItemFromSidebar(itemUid);
     if (savedPanels.has(itemUid)) {
       savedPanels.delete(itemUid);
       stateManager.removeWebview(panel.webview);

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -19,6 +19,7 @@ import {
   hasHandler
 } from '../ipc/handlers';
 import { openCollection, loadCollectionMetadata, setMessageSender as setCollectionsMessageSender } from '../app/collections';
+import { notifyActiveItemToSidebar } from '../ipc/collection';
 import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import { AppItem } from '@bruno-types';
@@ -78,9 +79,11 @@ export async function openTransientRequestPanel(
   stateManager.addWebview(panel.webview);
   stateManager.setActiveEditorWebview(panel.webview);
 
+  notifyActiveItemToSidebar(itemUid);
   panel.onDidChangeViewState((e) => {
     if (e.webviewPanel.active) {
       stateManager.setActiveEditorWebview(panel.webview);
+      notifyActiveItemToSidebar(itemUid);
     }
   });
 

--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.ts
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/StyledWrapper.ts
@@ -129,6 +129,10 @@ const Wrapper = styled.div`
         background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
       }
 
+      span.item-name {
+        color: ${(props) => props.theme.sidebar.collection.item.activeColor};
+      }
+
       .indent-block {
         border-right: 1px solid ${(props) => props.theme.border.border1} !important;
       }

--- a/src/webview/components/Sidebar/Collections/Collection/StyledWrapper.ts
+++ b/src/webview/components/Sidebar/Collections/Collection/StyledWrapper.ts
@@ -77,6 +77,10 @@ const Wrapper = styled.div`
       &:hover {
         background: ${(props) => props.theme.sidebar.collection.item.bg} !important;
       }
+
+      #sidebar-collection-name {
+        color: ${(props) => props.theme.sidebar.collection.item.activeColor};
+      }
     }
 
     &.collection-keyboard-focused {

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -46,7 +46,7 @@ import {
   postResponseTestResultsReceived
 } from 'providers/ReduxStore/slices/collections/index';
 import { addLog } from 'providers/ReduxStore/slices/logs';
-import { addTab } from 'providers/ReduxStore/slices/tabs';
+import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 import { findItemInCollectionByPathname, findCollectionByUid, getDefaultRequestPaneTab } from 'utils/collections';
 import { uuid } from 'utils/common';
 import type { Preferences } from '@bruno-types';
@@ -421,6 +421,12 @@ const useIpcEvents = () => {
       }
     });
 
+    // Highlight the sidebar item whose request/folder/collection is open in the
+    // active editor. The extension sends the item's uid (or null to clear).
+    const removeActiveItemListener = ipcRenderer.on('main:set-active-item', (itemUid: unknown) => {
+      dispatch(focusTab({ uid: (itemUid as string) ?? null }));
+    });
+
 
     const removeGlobalEnvironmentsUpdatesListener = ipcRenderer.on('main:load-global-environments', (val: unknown) => {
       dispatch(updateGlobalEnvironments(val));
@@ -662,6 +668,7 @@ const useIpcEvents = () => {
       removeSystemProxyEnvUpdatesListener();
       removeAddTransientRequestListener();
       removeTransientRequestClosedListener();
+      removeActiveItemListener();
       removeGlobalEnvironmentsUpdatesListener();
       removeSnapshotHydrationListener();
       removeSecurityConfigUpdatedListener();

--- a/src/webview/themes/vscode.ts
+++ b/src/webview/themes/vscode.ts
@@ -287,7 +287,10 @@ export const createVSCodeTheme = (mode: 'light' | 'dark') => {
       },
       collection: {
         item: {
-          bg: colors.sidebarBg,
+          // Active/selected item — use VS Code's list selection colors so it's
+          // distinguishable from the sidebar background (was sidebarBg = invisible).
+          bg: colors.listActiveBg,
+          activeColor: colors.listActiveFg,
           hoverBg: colors.listHoverBg,
           focusBorder: colors.focusBorder,
           indentBorder: `solid 1px ${colors.widgetBorder}`,

--- a/src/webview/themes/vscode.ts
+++ b/src/webview/themes/vscode.ts
@@ -287,8 +287,6 @@ export const createVSCodeTheme = (mode: 'light' | 'dark') => {
       },
       collection: {
         item: {
-          // Active/selected item — use VS Code's list selection colors so it's
-          // distinguishable from the sidebar background (was sidebarBg = invisible).
           bg: colors.listActiveBg,
           activeColor: colors.listActiveFg,
           hoverBg: colors.listHoverBg,

--- a/tests/e2e/fixtures/two-requests-collection.json
+++ b/tests/e2e/fixtures/two-requests-collection.json
@@ -1,0 +1,55 @@
+{
+  "name": "Highlight Collection",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "Alpha Request",
+      "filename": "alpha-request.bru",
+      "seq": 1,
+      "settings": { "encodeUrl": true },
+      "tags": [],
+      "request": {
+        "url": "https://echo.usebruno.com/alpha",
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": { "mode": "none", "formUrlEncoded": [], "multipartForm": [], "file": [] },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": { "mode": "none" }
+      }
+    },
+    {
+      "type": "http",
+      "name": "Beta Request",
+      "filename": "beta-request.bru",
+      "seq": 2,
+      "settings": { "encodeUrl": true },
+      "tags": [],
+      "request": {
+        "url": "https://echo.usebruno.com/beta",
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": { "mode": "none", "formUrlEncoded": [], "multipartForm": [], "file": [] },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": { "mode": "none" }
+      }
+    }
+  ],
+  "environments": [],
+  "brunoConfig": {
+    "version": "1",
+    "name": "Highlight Collection",
+    "type": "collection",
+    "ignore": ["node_modules", ".git"]
+  }
+}

--- a/tests/e2e/specs/sidebar-active-item.spec.ts
+++ b/tests/e2e/specs/sidebar-active-item.spec.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+import { test, expect } from '../fixtures';
+import {
+  openBrunoSidebar,
+  importCollection,
+  openRequest,
+} from '../utils/actions';
+import { buildCommonLocators } from '../utils/locators';
+
+// The active request's sidebar row carries this class when highlighted.
+const ACTIVE_CLASS = /item-focused-in-tab/;
+
+test.describe('Sidebar active item highlight', () => {
+  test('highlights the request open in the active editor and moves with it', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const fixturePath = path.resolve(__dirname, '../fixtures/two-requests-collection.json');
+    const collectionName = 'Highlight Collection';
+
+    await importCollection(page, sidebar, fixturePath, tmpDir, collectionName);
+
+    const row = (name: string) => buildCommonLocators(sidebar).sidebar.itemRow(name);
+
+    // Opening a request highlights its sidebar row.
+    await openRequest(page, sidebar, collectionName, 'Alpha Request');
+    await expect(row('Alpha Request')).toHaveClass(ACTIVE_CLASS, { timeout: 2_000 });
+
+    // Opening another moves the highlight; the previous row is no longer active.
+    await openRequest(page, sidebar, collectionName, 'Beta Request');
+    await expect(row('Beta Request')).toHaveClass(ACTIVE_CLASS, { timeout: 2_000 });
+    await expect(row('Alpha Request')).not.toHaveClass(ACTIVE_CLASS, { timeout: 2_000 });
+  });
+});

--- a/tests/e2e/utils/locators.ts
+++ b/tests/e2e/utils/locators.ts
@@ -7,7 +7,10 @@ export type FrameLike = Frame | Page;
 export const buildCommonLocators = (frame: FrameLike) => ({
   sidebar: {
     collectionName: (name: string) =>
-      frame.getByTestId('sidebar-collection-row').filter({ hasText: name })
+      frame.getByTestId('sidebar-collection-row').filter({ hasText: name }),
+    // A request/folder row in the collection tree.
+    itemRow: (name: string) =>
+      frame.getByTestId('sidebar-collection-item-row').filter({ hasText: name })
   },
   collectionSettings: {
     container: () => frame.getByTestId('collection-settings'),


### PR DESCRIPTION
## Summary
The active request/folder/collection in the sidebar wasn't visually highlighted — the selected item looked identical to the others. This makes the item open in the active editor stand out, and the highlight follows the active editor as you switch tabs, matching VS Code's explorer.

## Root cause
Two independent gaps:
1. **The highlight class was never applied.** In sidebar mode, clicking a request opens a VS Code editor and returned early **without ever setting `activeTabUid`**, so `isTabForItemActive` (`activeTabUid === item.uid`) was always false and the `item-focused-in-tab` class was never added.
2. **Even when applied, the color was invisible.** `sidebar.collection.item.bg` was set to `sidebarBg` — the same color as the sidebar background.

## Changes
- **Sync the highlight from the active editor:**
  - `src/extension/ipc/collection.ts` — added `notifyActiveItemToSidebar(uid)`, which sends `main:set-active-item` to the sidebar only (reusing the existing sidebar-webview getter).
  - `src/extension/editors/bruno-editor-provider.ts` — computes the item uid (collection / folder / request) and notifies the sidebar on open and on `onDidChangeViewState` (becoming active).
  - `src/extension/panels/transient-request-panel.ts` — notifies on activate for transient requests.
  - `src/webview/providers/App/useIpcEvents.ts` — the sidebar listens for `main:set-active-item` and dispatches `focusTab({ uid })`, setting `activeTabUid`.
- **Make the highlight visible:** `src/webview/themes/vscode.ts` — `sidebar.collection.item.bg` → `list.activeSelectionBackground`, plus `activeColor` → `list.activeSelectionForeground`. Applied the active foreground to the item/collection name in `CollectionItem/StyledWrapper.ts` and `Collection/StyledWrapper.ts`. Uses VS Code's own tokens, so it adapts to light/dark themes.

## Testing
- Added e2e `tests/e2e/specs/sidebar-active-item.spec.ts` (with fixture `tests/e2e/fixtures/two-requests-collection.json`): imports a collection with two requests, opens each, and asserts the active row gets `item-focused-in-tab` and that the highlight moves off the previous row.


Jira issue: VSCODE-69