### PR TITLE
fix: HTML preview shows raw source instead of rendering when response contains embedded JS

### DIFF
--- a/src/webview/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.tsx
+++ b/src/webview/components/ResponsePane/QueryResult/QueryResultPreview/HtmlPreview.tsx
@@ -1,25 +1,20 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { isValidHtml } from 'utils/common/index';
-import { escapeHtml, isValidHtmlSnippet } from 'utils/response/index';
+import { escapeHtml } from 'utils/response/index';
 
-interface HtmlPreviewProps {
-  data: string;
-  baseUrl: string;
-}
-
-const HtmlPreview: React.FC<HtmlPreviewProps> = React.memo(({ data, baseUrl }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
+const HtmlPreview = React.memo(({ data, baseUrl }: { data: string; baseUrl: string }) => {
+  const webviewContainerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!webviewContainerRef.current) return;
 
     const checkDragging = () => {
-      const hasDraggingParent = containerRef.current?.closest('.dragging');
+      const hasDraggingParent = webviewContainerRef.current?.closest('.dragging');
       setIsDragging(!!hasDraggingParent);
     };
 
-    const watchTarget = containerRef.current.closest('.main-section')
+    // Watch from a common ancestor where .dragging gets added
+    const watchTarget = webviewContainerRef.current.closest('.main-section')
       || document.body;
 
     const mutationObserver = new MutationObserver(checkDragging);
@@ -29,12 +24,13 @@ const HtmlPreview: React.FC<HtmlPreviewProps> = React.memo(({ data, baseUrl }) =
       subtree: true
     });
 
+    // Check initial state
     checkDragging();
 
     return () => mutationObserver.disconnect();
   }, []);
 
-  if (isValidHtml(data) || isValidHtmlSnippet(data)) {
+  const renderHtmlPreview = (data: string, baseUrl: string, isDragging: boolean, webviewContainerRef: React.RefObject<HTMLDivElement>) => {
     const htmlContent = data.includes('<head>')
       ? data.replace('<head>', `<head><base href="${escapeHtml(baseUrl)}">`)
       : `<head><base href="${escapeHtml(baseUrl)}"></head>${data}`;
@@ -43,19 +39,22 @@ const HtmlPreview: React.FC<HtmlPreviewProps> = React.memo(({ data, baseUrl }) =
 
     return (
       <div
-        ref={containerRef}
-        className="h-full bg-white"
+        ref={webviewContainerRef}
+        className="h-full bg-white webview-container"
         style={dragStyles}
       >
+        {/* VS Code webviews can't use Electron's <webview> tag - an iframe
+            with srcDoc is the platform-native equivalent here, achieving
+            the same "just render whatever we're given" behavior as desktop. */}
         <iframe
           srcDoc={htmlContent}
           sandbox="allow-scripts"
-          className="h-full w-full bg-white border-none"
+          className="h-full bg-white border-none"
           style={dragStyles}
         />
       </div>
     );
-  }
+  };
 
   // For all other data types, render safely as formatted text
   let displayContent = '';
@@ -63,18 +62,12 @@ const HtmlPreview: React.FC<HtmlPreviewProps> = React.memo(({ data, baseUrl }) =
     displayContent = String(data);
   } else if (typeof data === 'object') {
     displayContent = JSON.stringify(data, null);
-  } else if (typeof data === 'string') {
-    displayContent = data;
   } else {
     displayContent = String(data);
   }
 
   return (
-    <pre
-      className="bg-white font-mono text-[13px] whitespace-pre-wrap break-words overflow-auto overflow-x-hidden p-4 text-[#24292f] w-full max-w-full h-full box-border relative"
-    >
-      {displayContent}
-    </pre>
+    <>{renderHtmlPreview(displayContent, baseUrl, isDragging, webviewContainerRef)}</>
   );
 });
 

--- a/src/webview/globalStyles.ts
+++ b/src/webview/globalStyles.ts
@@ -284,6 +284,11 @@ const GlobalStyle = createGlobalStyle`
 
   // Autocomplete hints dropdown container
   .CodeMirror-hints {
+    position: absolute;
+    overflow-y: auto;
+    max-height: 20em;
+    margin: 0;
+    list-style: none;
     z-index: 50 !important;
     background: ${(props) => props.theme.dropdown.bg};
     ${(props) =>
@@ -306,6 +311,9 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.5rem;
     font-size: ${(props) => props.theme.font.size.sm};
     cursor: pointer;
+    margin: 0;
+    padding: 0 0.5rem;
+    white-space: nowrap;
   }
 
   .CodeMirror-brunoVarInfo :first-child {


### PR DESCRIPTION
### Description

Fixes #92

When a response has `Content-Type: text/html` and "Preview" is toggled
on with format set to "HTML", Bruno Desktop correctly renders the HTML
(executing embedded scripts/styles). The VS Code/Cursor extension
instead displayed the raw HTML/JS/CSS source as plain text, even with
the exact same "Preview" + "HTML" format selected.

**Root cause:** the extension's `HtmlPreview` component had an internal
validation gate (`isValidHtml(data) || isValidHtmlSnippet(data)`) that
doesn't exist in Bruno Desktop's equivalent component at all. Desktop
renders whatever content it's given, unconditionally, once the user has
explicitly chosen HTML format + Preview.

That validation worked by scanning the *entire* response with a regex
looking for HTML tag patterns - including the raw JavaScript inside
`<script>` tags - and checking each match against a hardcoded tag
whitelist. Any `<` (less-than) comparison operator in real embedded JS,
e.g. `for (i = 0; i < array.length; i++)`, gets misread as an HTML tag
opening. If the following identifier wasn't in the whitelist, the
*entire* response was rejected as "not valid HTML" and fell back to raw
text - silently overriding the user's own explicit format + preview
choice.

This is common in any HTML response with a substantial embedded script.
The original report used a Symfony PHP debug-dump page, whose
interactive tree-view script is exactly this pattern (starts with
`<script>Sfdump = window.Sfdump...`).

**Fix:** removed the internal validation entirely, matching Desktop's
behavior - once `QueryResultPreview` has already routed to `HtmlPreview`
(which only happens when the user has selected HTML format with Preview
on), render unconditionally via a sandboxed iframe.

Desktop uses Electron's `<webview>` tag with a `data:` URL; the
extension's webview runs in a standard sandboxed context where
`<webview>` isn't available, so this uses
`<iframe srcDoc={...} sandbox="allow-scripts">` instead - the
platform-appropriate equivalent, with the same "run the embedded JS,
restrict everything else" behavior.

`isValidHtml` / `isValidHtmlSnippet` are now unused anywhere else in the
codebase (confirmed via search) - worth a follow-up cleanup PR to remove
them, out of scope here.

### Testing

- Reproduced the bug locally with a minimal HTML file containing a
  `<script>` block with a `<` comparison against a capitalized
  identifier
- Verified the fix against real-world pages with substantial embedded
  JS (google.com) and a simple baseline case (httpbin.org/html)
- Confirmed via `git stash` before/after comparison: raw text with the
  validation in place, correctly rendered with it removed
- Full webview typecheck before/after: identical pre-existing error
  count, zero new errors introduced

#### Contribution Checklist:
- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have added screenshots or gifs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno-vscode/blob/main/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**