### PR TITLE
fix(scripting): add script APIs for setting, updating, and deleting variables in VS code

### DIFF
--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -39,11 +39,8 @@ const getJsSandboxRuntime = (collection: Record<string, unknown>): string => {
     return 'nodevm';
   }
 
-  // The QuickJS (safe) sandbox cannot be esbuild-bundled into the extension: its wasm variant is an
-  // ESM module that resolves via `import.meta.url`, which is undefined in the CJS bundle, so the
-  // sandbox fails to initialize and every user script silently throws. Node's `vm` sandbox bundles
-  // cleanly (see `patchNodeVmPlugin` in esbuild.extension.mjs), so it is used until QuickJS can be
-  // bundled. Without this, scripting APIs (bru.setVar/setEnvVar/...) never run in the extension.
+  /** QuickJS's wasm sandbox can't be esbuild-bundled (its ESM loader needs `import.meta.url`), so it
+   *  fails to init and every script silently throws; node-vm bundles cleanly. */
   return 'nodevm';
 };
 

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -1144,6 +1144,9 @@ const registerNetworkIpc = (): void => {
         size: result.size,
         duration: result.duration,
         timeline: result.timeline,
+        // Interpolated URL actually sent (executeRequest resolves {{vars}} in place). Used as the
+        // <base href> for HTML previews so relative assets resolve; requestSent.url is still raw.
+        requestUrl: scriptRequest.url,
         error: result.error
       };
     } catch (error) {

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -39,8 +39,12 @@ const getJsSandboxRuntime = (collection: Record<string, unknown>): string => {
     return 'nodevm';
   }
 
-  // default runtime is `quickjs`
-  return 'quickjs';
+  // The QuickJS (safe) sandbox cannot be esbuild-bundled into the extension: its wasm variant is an
+  // ESM module that resolves via `import.meta.url`, which is undefined in the CJS bundle, so the
+  // sandbox fails to initialize and every user script silently throws. Node's `vm` sandbox bundles
+  // cleanly (see `patchNodeVmPlugin` in esbuild.extension.mjs), so it is used until QuickJS can be
+  // bundled. Without this, scripting APIs (bru.setVar/setEnvVar/...) never run in the extension.
+  return 'nodevm';
 };
 
 const promisifyStream = async (stream: Readable): Promise<Buffer> => {

--- a/src/extension/utils/script-runner.ts
+++ b/src/extension/utils/script-runner.ts
@@ -59,10 +59,8 @@ const createConsoleLogHandler = (collectionUid: string, requestUid: string) => {
   };
 };
 
-// Broadcast the variable changes a script produced. `main:script-environment-update` applies env +
-// runtime vars to the webview state (so they take effect in-session); `main:persistent-env-variables-update`
-// drives the disk write for variables the script marked persistent; global env vars persist via their
-// own channel.
+/** Broadcast a script's variable changes: env + runtime vars (in-session), persistent env vars
+ *  (disk write), and global env vars — each on its own webview channel. */
 const emitScriptVariableUpdates = (
   result: { envVariables?: unknown; runtimeVariables?: unknown; persistentEnvVariables?: Record<string, unknown>; globalEnvironmentVariables?: unknown },
   context: ScriptContext

--- a/src/extension/utils/script-runner.ts
+++ b/src/extension/utils/script-runner.ts
@@ -62,7 +62,7 @@ const createConsoleLogHandler = (collectionUid: string, requestUid: string) => {
 // Broadcast the variable changes a script produced. `main:script-environment-update` applies env +
 // runtime vars to the webview state (so they take effect in-session); `main:persistent-env-variables-update`
 // drives the disk write for variables the script marked persistent; global env vars persist via their
-// own channel. The persistent channel had no emitter before, so script-persisted env vars were dropped.
+// own channel.
 const emitScriptVariableUpdates = (
   result: { envVariables?: unknown; runtimeVariables?: unknown; persistentEnvVariables?: Record<string, unknown>; globalEnvironmentVariables?: unknown },
   context: ScriptContext

--- a/src/extension/utils/script-runner.ts
+++ b/src/extension/utils/script-runner.ts
@@ -59,6 +59,35 @@ const createConsoleLogHandler = (collectionUid: string, requestUid: string) => {
   };
 };
 
+// Broadcast the variable changes a script produced. `main:script-environment-update` applies env +
+// runtime vars to the webview state (so they take effect in-session); `main:persistent-env-variables-update`
+// drives the disk write for variables the script marked persistent; global env vars persist via their
+// own channel. The persistent channel had no emitter before, so script-persisted env vars were dropped.
+const emitScriptVariableUpdates = (
+  result: { envVariables?: unknown; runtimeVariables?: unknown; persistentEnvVariables?: Record<string, unknown>; globalEnvironmentVariables?: unknown },
+  context: ScriptContext
+): void => {
+  sendToWebview('main:script-environment-update', {
+    envVariables: result.envVariables,
+    runtimeVariables: result.runtimeVariables,
+    requestUid: context.requestUid,
+    collectionUid: context.collectionUid
+  });
+
+  if (result.persistentEnvVariables && Object.keys(result.persistentEnvVariables).length > 0) {
+    sendToWebview('main:persistent-env-variables-update', {
+      persistentEnvVariables: result.persistentEnvVariables,
+      collectionUid: context.collectionUid
+    });
+  }
+
+  if (result.globalEnvironmentVariables) {
+    sendToWebview('main:global-environment-variables-update', {
+      globalEnvironmentVariables: result.globalEnvironmentVariables
+    });
+  }
+};
+
 export const runPreRequestScript = async (
   request: unknown,
   context: ScriptContext
@@ -91,19 +120,7 @@ export const runPreRequestScript = async (
       context.collectionName
     );
 
-    sendToWebview('main:script-environment-update', {
-      envVariables: result.envVariables,
-      runtimeVariables: result.runtimeVariables,
-      persistentEnvVariables: result.persistentEnvVariables,
-      requestUid: context.requestUid,
-      collectionUid: context.collectionUid
-    });
-
-    if (result.globalEnvironmentVariables) {
-      sendToWebview('main:global-environment-variables-update', {
-        globalEnvironmentVariables: result.globalEnvironmentVariables
-      });
-    }
+    emitScriptVariableUpdates(result, context);
 
     const preReqTestResults = (result as any).results;
     if (preReqTestResults && preReqTestResults.length > 0) {
@@ -160,19 +177,7 @@ export const runPostResponseVars = (
     );
 
     if (result) {
-      sendToWebview('main:script-environment-update', {
-        envVariables: result.envVariables,
-        runtimeVariables: result.runtimeVariables,
-        persistentEnvVariables: result.persistentEnvVariables,
-        requestUid: context.requestUid,
-        collectionUid: context.collectionUid
-      });
-
-      if (result.globalEnvironmentVariables) {
-        sendToWebview('main:global-environment-variables-update', {
-          globalEnvironmentVariables: result.globalEnvironmentVariables
-        });
-      }
+      emitScriptVariableUpdates(result, context);
 
       if (result.error) {
         sendToWebview('main:display-error', { error: result.error });
@@ -221,19 +226,7 @@ export const runPostResponseScript = async (
       context.collectionName
     );
 
-    sendToWebview('main:script-environment-update', {
-      envVariables: result.envVariables,
-      runtimeVariables: result.runtimeVariables,
-      persistentEnvVariables: result.persistentEnvVariables,
-      requestUid: context.requestUid,
-      collectionUid: context.collectionUid
-    });
-
-    if (result.globalEnvironmentVariables) {
-      sendToWebview('main:global-environment-variables-update', {
-        globalEnvironmentVariables: result.globalEnvironmentVariables
-      });
-    }
+    emitScriptVariableUpdates(result, context);
 
     const postResTestResults = (result as any).results;
     if (postResTestResults && postResTestResults.length > 0) {

--- a/src/extension/utils/script-runner.ts
+++ b/src/extension/utils/script-runner.ts
@@ -1,6 +1,7 @@
 
 import { ScriptRuntime, VarsRuntime, TestRuntime, AssertRuntime, ScriptResult, TestResult, VarsResult } from '@usebruno/js';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import { sendToWebview } from '../ipc/handlers';
 import logsStore, { LogLevel } from '../store/logs';
 
@@ -59,11 +60,14 @@ const createConsoleLogHandler = (collectionUid: string, requestUid: string) => {
   };
 };
 
-/** Broadcast a script's variable changes: env + runtime vars (in-session), persistent env vars
- *  (disk write), and global env vars — each on its own webview channel. */
+/** Broadcast a script's variable changes on their webview channels: env + runtime vars for
+ *  in-session state, environment vars for the disk write (persist by default, only when the script
+ *  actually changed one), and global env vars. `envVarsBefore` is the pre-script snapshot used to
+ *  skip needless environment-file writes. */
 const emitScriptVariableUpdates = (
-  result: { envVariables?: unknown; runtimeVariables?: unknown; persistentEnvVariables?: Record<string, unknown>; globalEnvironmentVariables?: unknown },
-  context: ScriptContext
+  result: { envVariables?: Record<string, unknown>; runtimeVariables?: unknown; globalEnvironmentVariables?: unknown },
+  context: ScriptContext,
+  envVarsBefore?: Record<string, unknown>
 ): void => {
   sendToWebview('main:script-environment-update', {
     envVariables: result.envVariables,
@@ -72,9 +76,9 @@ const emitScriptVariableUpdates = (
     collectionUid: context.collectionUid
   });
 
-  if (result.persistentEnvVariables && Object.keys(result.persistentEnvVariables).length > 0) {
+  if (result.envVariables && !isEqual(result.envVariables, envVarsBefore)) {
     sendToWebview('main:persistent-env-variables-update', {
-      persistentEnvVariables: result.persistentEnvVariables,
+      persistentEnvVariables: result.envVariables,
       collectionUid: context.collectionUid
     });
   }
@@ -103,6 +107,8 @@ export const runPreRequestScript = async (
 
     const onConsoleLog = createConsoleLogHandler(context.collectionUid, context.requestUid);
 
+    // The runtime mutates envVars in place; snapshot first to detect script-made env changes.
+    const envVarsBefore = { ...context.envVars };
     const result = await scriptRuntime.runRequestScript(
       decomment(script),
       request,
@@ -118,7 +124,7 @@ export const runPreRequestScript = async (
       context.collectionName
     );
 
-    emitScriptVariableUpdates(result, context);
+    emitScriptVariableUpdates(result, context, envVarsBefore);
 
     const preReqTestResults = (result as any).results;
     if (preReqTestResults && preReqTestResults.length > 0) {
@@ -164,6 +170,7 @@ export const runPostResponseVars = (
       runtime: context.scriptingConfig?.runtime
     });
 
+    const envVarsBefore = { ...context.envVars };
     const result = varsRuntime.runPostResponseVars(
       postResponseVars,
       request,
@@ -175,7 +182,7 @@ export const runPostResponseVars = (
     );
 
     if (result) {
-      emitScriptVariableUpdates(result, context);
+      emitScriptVariableUpdates(result, context, envVarsBefore);
 
       if (result.error) {
         sendToWebview('main:display-error', { error: result.error });
@@ -208,6 +215,7 @@ export const runPostResponseScript = async (
 
     const onConsoleLog = createConsoleLogHandler(context.collectionUid, context.requestUid);
 
+    const envVarsBefore = { ...context.envVars };
     const result = await scriptRuntime.runResponseScript(
       decomment(script),
       request,
@@ -224,7 +232,7 @@ export const runPostResponseScript = async (
       context.collectionName
     );
 
-    emitScriptVariableUpdates(result, context);
+    emitScriptVariableUpdates(result, context, envVarsBefore);
 
     const postResTestResults = (result as any).results;
     if (postResTestResults && postResTestResults.length > 0) {

--- a/src/webview/components/ResponsePane/QueryResult/QueryResultPreview/index.tsx
+++ b/src/webview/components/ResponsePane/QueryResult/QueryResultPreview/index.tsx
@@ -101,7 +101,9 @@ const QueryResultPreview = ({
 
   switch (previewMode) {
     case 'preview-web': {
-      const baseUrl = item.requestSent?.url || '';
+      // Prefer the interpolated URL that was actually sent so relative assets resolve when the
+      // request URL uses variables; requestSent.url still holds the raw {{var}} form.
+      const baseUrl = (item.response as { requestUrl?: string })?.requestUrl || item.requestSent?.url || '';
       return <HtmlPreview data={data} baseUrl={baseUrl} />;
     }
     case 'preview-image': {

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -2241,19 +2241,21 @@ export const mergeAndPersistEnvironment
         const state = getState();
         const collection = findCollectionByUid(state.collections.collections, collectionUid);
 
+        // Best-effort persistence of script-set env vars: with no active environment there's nowhere
+        // to write, so resolve quietly instead of surfacing an unhandled rejection.
         if (!collection) {
-          return reject(new Error('Collection not found'));
+          return resolve();
         }
 
         const environmentUid = collection.activeEnvironmentUid;
         if (!environmentUid) {
-          return reject(new Error('No active environment found'));
+          return resolve();
         }
 
         const collectionCopy = safeCloneCollection(collection);
         const environment = findEnvironmentInCollection(collectionCopy, environmentUid);
         if (!environment) {
-          return reject(new Error('Environment not found'));
+          return resolve();
         }
 
         // Only proceed if there are persistent variables to save

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1985,12 +1985,41 @@ export const collectionsSlice = createSlice({
     scriptEnvironmentUpdateEvent: (state, action: PayloadAction<ScriptEnvironmentUpdateEventPayload>) => {
       const { collectionUid, envVariables, runtimeVariables } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection) {
+      if (!collection) {
+        return;
+      }
+
+      if (runtimeVariables) {
         collection.runtimeVariables = runtimeVariables;
-        if (collection.activeEnvironmentUid && envVariables) {
-          const env = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
-          if (env) {
-          }
+      }
+
+      // Apply env vars written by scripts (bru.setEnvVar / deleteEnvVar) to the active environment so
+      // they take effect within the session (visible in the UI and readable via getEnvVar). Disk
+      // persistence is handled separately by mergeAndPersistEnvironment. `envVariables` is the full
+      // set of enabled env vars after the script ran, so a var absent from it was deleted.
+      if (envVariables && collection.activeEnvironmentUid) {
+        const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
+        if (environment && Array.isArray(environment.variables)) {
+          Object.entries(envVariables).forEach(([name, value]) => {
+            if (name === '__name__') {
+              return;
+            }
+            const existing = environment.variables.find((v) => v.name === name && v.enabled);
+            if (existing) {
+              existing.value = value as typeof existing.value;
+            } else {
+              environment.variables.push({
+                uid: uuid(),
+                name,
+                value: value as never,
+                type: 'text',
+                enabled: true,
+                secret: false
+              });
+            }
+          });
+          // Drop enabled vars the script deleted (absent from the full enabled set); keep disabled ones.
+          environment.variables = environment.variables.filter((v) => !v.enabled || v.name in envVariables);
         }
       }
     },

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1993,11 +1993,9 @@ export const collectionsSlice = createSlice({
         collection.runtimeVariables = runtimeVariables;
       }
 
-      // Apply env vars written by scripts (bru.setEnvVar) to the active environment so they take
-      // effect within the session (visible in the UI and readable via getEnvVar). Disk persistence
-      // is handled separately by mergeAndPersistEnvironment. This merges values only — deletions are
-      // intentionally not reflected here, to stay consistent with the merge-only persist path (a
-      // reducer-only delete would reappear on reload from disk).
+      /** Apply script-set env vars to the active environment for in-session use; disk persistence is
+       *  handled by mergeAndPersistEnvironment. Merge-only — deletions aren't reflected here to match
+       *  the merge-only persist path. */
       if (envVariables && collection.activeEnvironmentUid) {
         const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
         if (environment && Array.isArray(environment.variables)) {

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1993,9 +1993,10 @@ export const collectionsSlice = createSlice({
         collection.runtimeVariables = runtimeVariables;
       }
 
-      /** Apply script-set env vars to the active environment for in-session use; disk persistence is
-       *  handled by mergeAndPersistEnvironment. Merge-only — deletions aren't reflected here to match
-       *  the merge-only persist path. */
+      /** Apply script-set env vars to the active environment for in-session use (visible in the UI,
+       *  readable via getEnvVar); mergeAndPersistEnvironment writes the same result to disk.
+       *  `envVariables` is the full enabled set after the script ran, so a var absent from it was
+       *  deleted (bru.deleteEnvVar) and is dropped; disabled vars are preserved. */
       if (envVariables && collection.activeEnvironmentUid) {
         const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
         if (environment && Array.isArray(environment.variables)) {
@@ -2017,6 +2018,9 @@ export const collectionsSlice = createSlice({
               });
             }
           });
+          environment.variables = environment.variables.filter(
+            (v) => !v.enabled || Object.prototype.hasOwnProperty.call(envVariables, v.name)
+          );
         }
       }
     },

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -1993,10 +1993,11 @@ export const collectionsSlice = createSlice({
         collection.runtimeVariables = runtimeVariables;
       }
 
-      // Apply env vars written by scripts (bru.setEnvVar / deleteEnvVar) to the active environment so
-      // they take effect within the session (visible in the UI and readable via getEnvVar). Disk
-      // persistence is handled separately by mergeAndPersistEnvironment. `envVariables` is the full
-      // set of enabled env vars after the script ran, so a var absent from it was deleted.
+      // Apply env vars written by scripts (bru.setEnvVar) to the active environment so they take
+      // effect within the session (visible in the UI and readable via getEnvVar). Disk persistence
+      // is handled separately by mergeAndPersistEnvironment. This merges values only — deletions are
+      // intentionally not reflected here, to stay consistent with the merge-only persist path (a
+      // reducer-only delete would reappear on reload from disk).
       if (envVariables && collection.activeEnvironmentUid) {
         const environment = findEnvironmentInCollection(collection, collection.activeEnvironmentUid);
         if (environment && Array.isArray(environment.variables)) {
@@ -2018,8 +2019,6 @@ export const collectionsSlice = createSlice({
               });
             }
           });
-          // Drop enabled vars the script deleted (absent from the full enabled set); keep disabled ones.
-          environment.variables = environment.variables.filter((v) => !v.enabled || v.name in envVariables);
         }
       }
     },

--- a/src/webview/utils/network/index.tsx
+++ b/src/webview/utils/network/index.tsx
@@ -55,7 +55,9 @@ export const sendNetworkRequest = async (item: any, collection: any, environment
             statusText: response.statusText,
             duration: response.duration,
             timeline: response.timeline,
-            stream: response.stream
+            stream: response.stream,
+            // Interpolated URL that was sent, used as the HTML-preview <base href>
+            requestUrl: (response as { requestUrl?: string }).requestUrl
           });
         })
         .catch((err) => reject(err));

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -49,6 +49,12 @@ app.get('/last-capture', (_req, res) => {
   res.json({ token: lastCapturedToken ?? null });
 });
 
+// Minimal HTML page (with a relative asset) to exercise the HTML response preview's <base href>.
+app.get('/htmlpage', (_req, res) => {
+  res.setHeader('Content-Type', 'text/html');
+  res.send('<html><head><title>t</title></head><body><img src="logo.png"/>hello</body></html>');
+});
+
 app.post('/api/echo/json', (req, res) => {
   res.json(req.body);
 });

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -38,6 +38,17 @@ app.get('/headers', (req, res) => {
   res.json(req.headers);
 });
 
+// Capture a header so e2e tests can assert (from Node) exactly what the extension SENT — used to
+// verify pre-request scripts ran and variables interpolated, without relying on the response UI.
+let lastCapturedToken: string | undefined;
+app.get('/capture', (req, res) => {
+  lastCapturedToken = req.headers['x-token'] as string | undefined;
+  res.json({ ok: true });
+});
+app.get('/last-capture', (_req, res) => {
+  res.json({ token: lastCapturedToken ?? null });
+});
+
 app.post('/api/echo/json', (req, res) => {
   res.json(req.body);
 });

--- a/tests/e2e/specs/html-preview-base-href.spec.ts
+++ b/tests/e2e/specs/html-preview-base-href.spec.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../fixtures';
+import { openBrunoSidebar, createCollection, openRequest, sendRequest } from '../utils/actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+function findCollectionDir(root: string): string {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+  throw new Error(`No collection (bruno.json) found under ${root}`);
+}
+
+test.describe('HTML response preview', () => {
+  test('base href uses the interpolated request URL when the URL contains a variable', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Html Preview';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.mkdirSync(path.join(collectionDir, 'environments'), { recursive: true });
+    fs.writeFileSync(path.join(collectionDir, 'environments', 'Local.bru'), `vars {\n  host: ${TEST_SERVER}\n}\n`, 'utf8');
+    // The request URL uses the {{host}} variable and returns an HTML page.
+    fs.writeFileSync(path.join(collectionDir, 'Page.bru'), [
+      'meta {', '  name: Page', '  type: http', '  seq: 1', '}', '',
+      'get {', '  url: {{host}}/htmlpage', '  body: none', '  auth: inherit', '}', ''
+    ].join('\n'), 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Page');
+
+    await editor.locator('[data-testid="environment-selector-trigger"]').click();
+    await editor.locator('.dropdown-item').filter({ hasText: 'Local' }).first().click();
+
+    await sendRequest(editor, 200);
+
+    // text/html auto-renders the preview iframe with an injected <base href>. Read its srcdoc and
+    // assert the base href is the interpolated URL, not the raw {{host}} form.
+    const previewFrame = editor.locator('iframe');
+    await expect(previewFrame).toBeVisible({ timeout: 15_000 });
+    await expect
+      .poll(async () => (await previewFrame.getAttribute('srcdoc')) || '', { timeout: 15_000 })
+      .toContain(`<base href="${TEST_SERVER}/htmlpage">`);
+    const srcdoc = (await previewFrame.getAttribute('srcdoc')) || '';
+    expect(srcdoc).not.toContain('{{host}}');
+  });
+});

--- a/tests/e2e/specs/script-set-vars.spec.ts
+++ b/tests/e2e/specs/script-set-vars.spec.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../fixtures';
+import { openBrunoSidebar, createCollection, openRequest, sendRequest } from '../utils/actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+// Find the collection directory created under tmpDir (the folder containing bruno.json).
+function findCollectionDir(root: string): string {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+  throw new Error(`No collection (bruno.json) found under ${root}`);
+}
+
+test.describe('Scripting: variable APIs', () => {
+  test('a pre-request script (bru.setVar) runs and its variable interpolates into the outgoing request', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Script Vars';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    // Write a request whose pre-request script sets `token`, used in a header echoed by the mock server.
+    const collectionDir = findCollectionDir(tmpDir);
+    const requestBru = [
+      'meta {',
+      '  name: Ping',
+      '  type: http',
+      '  seq: 1',
+      '}',
+      '',
+      'get {',
+      `  url: ${TEST_SERVER}/capture`,
+      '  body: none',
+      '  auth: inherit',
+      '}',
+      '',
+      'headers {',
+      '  x-token: {{token}}',
+      '}',
+      '',
+      'script:pre-request {',
+      "  bru.setVar('token', 'ABC123');",
+      '}',
+      ''
+    ].join('\n');
+    fs.writeFileSync(path.join(collectionDir, 'Ping.bru'), requestBru, 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Ping');
+    await sendRequest(editor, 200);
+
+    // Ground truth: query the mock server (from Node) for the header the extension actually sent.
+    // If the script ran and `{{token}}` interpolated, this is 'ABC123'; if the script never ran (the
+    // sandbox failed to initialize), it is the literal '{{token}}'.
+    const res = await fetch(`${TEST_SERVER}/last-capture`);
+    const { token } = (await res.json()) as { token: string | null };
+    expect(token).toBe('ABC123');
+  });
+});

--- a/tests/e2e/specs/script-set-vars.spec.ts
+++ b/tests/e2e/specs/script-set-vars.spec.ts
@@ -67,4 +67,41 @@ test.describe('Scripting: variable APIs', () => {
     const { token } = (await res.json()) as { token: string | null };
     expect(token).toBe('ABC123');
   });
+
+  test('bru.setEnvVar / bru.deleteEnvVar take effect and persist to the environment file', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Env Script Vars';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    // An environment with a seed var the script will delete.
+    fs.mkdirSync(path.join(collectionDir, 'environments'), { recursive: true });
+    fs.writeFileSync(path.join(collectionDir, 'environments', 'Local.bru'), 'vars {\n  seed: SEED\n}\n', 'utf8');
+    // Request whose pre-request script adds one env var and deletes the seed one.
+    fs.writeFileSync(path.join(collectionDir, 'Ping.bru'), [
+      'meta {', '  name: Ping', '  type: http', '  seq: 1', '}', '',
+      'get {', `  url: ${TEST_SERVER}/capture`, '  body: none', '  auth: inherit', '}', '',
+      'headers {', '  x-token: {{envTok}}', '}', '',
+      'script:pre-request {', "  bru.setEnvVar('envTok', 'ENVVAL');", "  bru.deleteEnvVar('seed');", '}', ''
+    ].join('\n'), 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Ping');
+
+    // Select the "Local" environment so the script has an active environment to write to.
+    await editor.locator('[data-testid="environment-selector-trigger"]').click();
+    await editor.locator('.dropdown-item').filter({ hasText: 'Local' }).first().click();
+
+    await sendRequest(editor, 200);
+
+    // In-request interpolation proves setEnvVar ran.
+    const res = await fetch(`${TEST_SERVER}/last-capture`);
+    const { token } = (await res.json()) as { token: string | null };
+    expect(token).toBe('ENVVAL');
+
+    // Persistence: the environment file gains the new var and loses the deleted one.
+    const envFile = path.join(collectionDir, 'environments', 'Local.bru');
+    await expect.poll(() => fs.readFileSync(envFile, 'utf8'), { timeout: 15_000 }).toContain('envTok: ENVVAL');
+    expect(fs.readFileSync(envFile, 'utf8')).not.toContain('seed: SEED');
+  });
 });


### PR DESCRIPTION
## Summary
Fix the scripting variable APIs so setting/deleting variables from a script (e.g. `bru.setVar`, `bru.setEnvVar`/`deleteEnvVar`, `bru.setGlobalEnvVar`) actually takes effect when a request runs. Previously these calls silently did nothing in the VS Code extension. Also fixes HTML response previews not loading images when the request URL uses a variable.

## Problem
- APIs for setting/deleting variables from pre-request / post-response scripts don't work in the VS Code Bruno version. Setting variables **manually** in the UI works, but setting them **from a script** has no effect.
  - Repro: pre-request `bru.setEnvVar("brunoSite", "www.usebruno.com")` → run → the variable is never set (not in the environment, `getEnvVar` returns nothing).
  - JIRA: https://usebruno.atlassian.net/browse/VSCODE-80
- HTML response preview: when the request URL contains a variable (e.g. `{{host}}/page`), images/assets inside the HTML don't load; without a variable they load fine.

## Root Cause
- **Scripts never ran.** Bruno runs user scripts in a sandboxed JS engine; the extension defaulted to the QuickJS (WebAssembly) sandbox, which can't survive being packed into the extension's single-file bundle and fails to start. Because a sandbox startup failure is caught quietly and the request continues, every script silently did nothing. (Desktop is unaffected — it doesn't bundle the sandbox the same way.)
- **Env changes weren't applied/persisted.** Even once scripts ran, environment variables set by a script weren't written back to the active environment or to disk (unlike global-environment variables, which persist by default), so `setEnvVar`/`deleteEnvVar` had no visible effect.
- **HTML preview base URL was raw.** The preview sets a `<base href>` from the request URL to resolve relative assets, but it used the un-interpolated URL (`{{host}}/page`), so relative image paths resolved against an invalid base.

## Solution
- Run scripts in the bundle-friendly Node sandbox so scripts execute reliably. (QuickJS stays available for developer mode; a follow-up will make it bundle-safe so it can return as the default.)
- Apply script-set environment variables to the active environment in-session (visible in the UI, readable via `getEnvVar`) and persist them by default, honoring deletions; only rewrite the environment file when a script actually changed it. Runtime and global-environment variables set from scripts take effect too.
- Use the interpolated request URL as the HTML preview's `<base href>` so relative assets resolve when the URL contains variables.

## Test plan
- [ ] `bru.setVar(...)` → value is usable within the same request
- [ ] `bru.setEnvVar(...)` / `bru.deleteEnvVar(...)` → variable is added/removed in the active environment and persists to the environment file
- [ ] `bru.setGlobalEnvVar(...)` with a global environment selected → variable is set
- [ ] Manual environment editing is unchanged (no regression)
- [ ] HTML response whose request URL uses a variable → images/relative assets load
- [ ] Added e2e specs for the above; TypeScript typecheck passes and unit tests are green

## Scope / follow-ups
This restores the variable APIs available in the current Bruno packages. The collection-variable and some delete APIs (`setCollectionVar`, `deleteCollectionVar`, `deleteGlobalEnvVar`, …) are disabled upstream and will be re-enabled alongside the data-type support work, which lands as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
