### PR TITLE
fix(nested-collection)- Show proper location of nested collection in overview

### DIFF
--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -103,6 +103,21 @@ export const isCollectionRootFile = (pathname: string, collectionPath: string): 
   return basename === 'collection.bru' || basename === 'opencollection.yml';
 };
 
+/**
+ * A collection root file (opencollection.yml / collection.bru) that lives BELOW
+ * the collection root — i.e. it belongs to a nested collection. Not a real
+ * request, so we flag it as errored: the overview lists it under "requests not
+ * loaded" and clicking it shows RequestNotLoaded, not a broken request. (The
+ * collection's own root file is handled separately and never reaches here.)
+ */
+const isNestedCollectionRootFile = (pathname: string, collectionPath: string): boolean => {
+  const basename = path.basename(pathname);
+  if (basename !== 'collection.bru' && basename !== 'opencollection.yml') {
+    return false;
+  }
+  return path.normalize(path.dirname(pathname)) !== path.normalize(collectionPath);
+};
+
 interface EnvironmentVariable {
   name: string;
   value: string | number | boolean | Record<string, unknown> | null;
@@ -633,6 +648,21 @@ class CollectionWatcher {
         return;
       }
 
+      // A nested collection's root config file is not a request — surface it as
+      // "not loaded" rather than parsing it as one.
+      if (isNestedCollectionRootFile(pathname, collectionPath)) {
+        file.data = { name: path.basename(pathname), type: 'http-request' };
+        file.error = { message: 'This is a nested collection, not a request.' };
+        file.partial = true;
+        file.loading = false;
+        file.size = sizeInMB(fileStats?.size);
+        hydrateRequestWithUuid(file.data, pathname);
+        if (sender) {
+          sender('main:collection-tree-updated', 'addFile', file);
+        }
+        return;
+      }
+
       const format = getCollectionFormat(collectionPath);
 
       file.data = await parseRequest(content, { format });
@@ -1158,6 +1188,18 @@ class CollectionWatcher {
         return null;
       }
 
+      // A nested collection's root config file is not a request — surface it as
+      // "not loaded" rather than parsing it as one.
+      if (isNestedCollectionRootFile(pathname, collectionPath)) {
+        file.data = { name: path.basename(pathname), type: 'http-request' };
+        file.error = { message: 'This is a nested collection, not a request.' };
+        file.partial = true;
+        file.loading = false;
+        file.size = sizeInMB(fileStats?.size);
+        hydrateRequestWithUuid(file.data, pathname);
+        return file;
+      }
+
       const format = getCollectionFormat(collectionPath);
       const metaData = parseFileMeta(content, format);
       if (!metaData) {
@@ -1207,6 +1249,21 @@ class CollectionWatcher {
       if (!content.trim()) {
         console.log('[Watcher] Skipping empty file:', pathname);
         this.markFileAsProcessed(collectionUid, pathname);
+        return;
+      }
+
+      // A nested collection's root config file is not a request — surface it as
+      // "not loaded" rather than parsing it as one.
+      if (isNestedCollectionRootFile(pathname, collectionPath)) {
+        file.data = { name: path.basename(pathname), type: 'http-request' };
+        file.error = { message: 'This is a nested collection, not a request.' };
+        file.partial = true;
+        file.loading = false;
+        file.size = sizeInMB(fileStats?.size);
+        hydrateRequestWithUuid(file.data, pathname);
+        if (messageSender) {
+          messageSender('main:collection-tree-updated', 'addFile', file);
+        }
         return;
       }
 

--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -118,6 +118,21 @@ const isNestedCollectionRootFile = (pathname: string, collectionPath: string): b
   return path.normalize(path.dirname(pathname)) !== path.normalize(collectionPath);
 };
 
+/**
+ * Fill `file` in as the "not loaded" tree entry for a nested collection's root
+ * config file: placeholder request data plus an error, so the overview lists it
+ * under "requests not loaded" instead of rendering a broken request. Callers
+ * emit or return `file` themselves.
+ */
+const markAsNestedCollectionFile = (file: FileData, pathname: string, size: number): void => {
+  file.data = { name: path.basename(pathname), type: 'http-request' };
+  file.error = { message: 'This is a nested collection, not a request.' };
+  file.partial = true;
+  file.loading = false;
+  file.size = sizeInMB(size);
+  hydrateRequestWithUuid(file.data, pathname);
+};
+
 interface EnvironmentVariable {
   name: string;
   value: string | number | boolean | Record<string, unknown> | null;
@@ -651,12 +666,7 @@ class CollectionWatcher {
       // A nested collection's root config file is not a request — surface it as
       // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
-        file.data = { name: path.basename(pathname), type: 'http-request' };
-        file.error = { message: 'This is a nested collection, not a request.' };
-        file.partial = true;
-        file.loading = false;
-        file.size = sizeInMB(fileStats?.size);
-        hydrateRequestWithUuid(file.data, pathname);
+        markAsNestedCollectionFile(file, pathname, fileStats?.size);
         if (sender) {
           sender('main:collection-tree-updated', 'addFile', file);
         }
@@ -1191,12 +1201,7 @@ class CollectionWatcher {
       // A nested collection's root config file is not a request — surface it as
       // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
-        file.data = { name: path.basename(pathname), type: 'http-request' };
-        file.error = { message: 'This is a nested collection, not a request.' };
-        file.partial = true;
-        file.loading = false;
-        file.size = sizeInMB(fileStats?.size);
-        hydrateRequestWithUuid(file.data, pathname);
+        markAsNestedCollectionFile(file, pathname, fileStats?.size);
         return file;
       }
 
@@ -1255,12 +1260,7 @@ class CollectionWatcher {
       // A nested collection's root config file is not a request — surface it as
       // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
-        file.data = { name: path.basename(pathname), type: 'http-request' };
-        file.error = { message: 'This is a nested collection, not a request.' };
-        file.partial = true;
-        file.loading = false;
-        file.size = sizeInMB(fileStats?.size);
-        hydrateRequestWithUuid(file.data, pathname);
+        markAsNestedCollectionFile(file, pathname, fileStats?.size);
         if (messageSender) {
           messageSender('main:collection-tree-updated', 'addFile', file);
         }

--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -103,13 +103,6 @@ export const isCollectionRootFile = (pathname: string, collectionPath: string): 
   return basename === 'collection.bru' || basename === 'opencollection.yml';
 };
 
-/**
- * A collection root file (opencollection.yml / collection.bru) that lives BELOW
- * the collection root — i.e. it belongs to a nested collection. Not a real
- * request, so we flag it as errored: the overview lists it under "requests not
- * loaded" and clicking it shows RequestNotLoaded, not a broken request. (The
- * collection's own root file is handled separately and never reaches here.)
- */
 const isNestedCollectionRootFile = (pathname: string, collectionPath: string): boolean => {
   const basename = path.basename(pathname);
   if (basename !== 'collection.bru' && basename !== 'opencollection.yml') {
@@ -118,12 +111,6 @@ const isNestedCollectionRootFile = (pathname: string, collectionPath: string): b
   return path.normalize(path.dirname(pathname)) !== path.normalize(collectionPath);
 };
 
-/**
- * Fill `file` in as the "not loaded" tree entry for a nested collection's root
- * config file: placeholder request data plus an error, so the overview lists it
- * under "requests not loaded" instead of rendering a broken request. Callers
- * emit or return `file` themselves.
- */
 const markAsNestedCollectionFile = (file: FileData, pathname: string, size: number): void => {
   file.data = { name: path.basename(pathname), type: 'http-request' };
   file.error = { message: 'This is a nested collection, not a request.' };
@@ -663,8 +650,6 @@ class CollectionWatcher {
         return;
       }
 
-      // A nested collection's root config file is not a request — surface it as
-      // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
         markAsNestedCollectionFile(file, pathname, fileStats?.size);
         if (sender) {
@@ -1198,8 +1183,6 @@ class CollectionWatcher {
         return null;
       }
 
-      // A nested collection's root config file is not a request — surface it as
-      // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
         markAsNestedCollectionFile(file, pathname, fileStats?.size);
         return file;
@@ -1257,8 +1240,6 @@ class CollectionWatcher {
         return;
       }
 
-      // A nested collection's root config file is not a request — surface it as
-      // "not loaded" rather than parsing it as one.
       if (isNestedCollectionRootFile(pathname, collectionPath)) {
         markAsNestedCollectionFile(file, pathname, fileStats?.size);
         if (messageSender) {

--- a/src/extension/commands/main-commands.ts
+++ b/src/extension/commands/main-commands.ts
@@ -127,8 +127,6 @@ export function registerMainCommands(
       const collectionRoot = resolveCollectionRoot(fsPath) || fsPath;
       const collectionRootFile = await ensureCollectionRootFile(collectionRoot);
 
-      // The same opencollection.yml may already be open as the parent's "not
-      // loaded" item; force a fresh render as the collection itself.
       await ensureBrunoEditorIntent(collectionRootFile, 'default');
 
       await vscode.commands.executeCommand(

--- a/src/extension/commands/main-commands.ts
+++ b/src/extension/commands/main-commands.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { BrunoEditorProvider, setPendingVariablesMode } from '../editors/bruno-editor-provider';
+import { BrunoEditorProvider, setPendingVariablesMode, ensureBrunoEditorIntent } from '../editors/bruno-editor-provider';
 import { SidebarViewProvider } from '../views/SidebarViewProvider';
-import { findCollectionRoot, isCollectionRoot } from '../utils/path';
+import { resolveCollectionRoot } from '../utils/path';
 import { openRunnerPanel } from '../panels/runner-panel';
 import { openGlobalEnvironmentsPanel } from '../panels/global-environments-panel';
 import { openEnvironmentSettingsPanel } from '../panels/environment-settings-panel';
@@ -105,11 +105,7 @@ export function registerMainCommands(
         targetPath = path.dirname(fsPath);
       }
 
-      let collectionRoot = findCollectionRoot(targetPath);
-
-      if (!collectionRoot && isCollectionRoot(targetPath)) {
-        collectionRoot = targetPath;
-      }
+      const collectionRoot = resolveCollectionRoot(targetPath);
 
       if (!collectionRoot) {
         vscode.window.showWarningMessage('No Bruno collection found in this folder');
@@ -128,8 +124,12 @@ export function registerMainCommands(
       }
 
       const fsPath = uri.fsPath;
-      const collectionRoot = findCollectionRoot(fsPath) || fsPath;
+      const collectionRoot = resolveCollectionRoot(fsPath) || fsPath;
       const collectionRootFile = await ensureCollectionRootFile(collectionRoot);
+
+      // The same opencollection.yml may already be open as the parent's "not
+      // loaded" item; force a fresh render as the collection itself.
+      await ensureBrunoEditorIntent(collectionRootFile, 'default');
 
       await vscode.commands.executeCommand(
         'vscode.openWith',
@@ -147,9 +147,10 @@ export function registerMainCommands(
       }
 
       const fsPath = uri.fsPath;
-      const collectionRoot = findCollectionRoot(fsPath) || fsPath;
+      const collectionRoot = resolveCollectionRoot(fsPath) || fsPath;
       const collectionRootFile = await ensureCollectionRootFile(collectionRoot);
 
+      await ensureBrunoEditorIntent(collectionRootFile, 'default');
       setPendingVariablesMode(collectionRootFile, collectionRoot);
 
       await vscode.commands.executeCommand(
@@ -221,11 +222,7 @@ export function registerMainCommands(
       }
 
       const fsPath = uri.fsPath;
-      let collectionRoot = findCollectionRoot(fsPath);
-
-      if (!collectionRoot && isCollectionRoot(fsPath)) {
-        collectionRoot = fsPath;
-      }
+      const collectionRoot = resolveCollectionRoot(fsPath);
 
       if (!collectionRoot) {
         vscode.window.showWarningMessage('No Bruno collection found');

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -36,15 +36,54 @@ interface CollectionLoadParams {
   filePath: string;
   collectionRoot: string;
   isVariablesMode: boolean;
+  notLoadedParentRoot: string | null;
   webviewPanel: vscode.WebviewPanel;
 }
 
 const pendingVariablesModeRequests = new Map<string, { collectionRoot: string }>();
+// Nested-collection config files opened via the parent's "requests not loaded"
+// item. Maps file path → the parent collection root it belongs to.
+const pendingNotLoadedRequests = new Map<string, { parentCollectionRoot: string }>();
 // Stores view data per webview so renderer:ready can re-send as fallback
 const viewDataByWebview = new Map<vscode.Webview, Record<string, unknown>>();
 
 export function setPendingVariablesMode(filePath: string, collectionRoot: string): void {
   pendingVariablesModeRequests.set(filePath, { collectionRoot });
+}
+
+export function setPendingNotLoadedRequest(filePath: string, parentCollectionRoot: string): void {
+  pendingNotLoadedRequests.set(filePath, { parentCollectionRoot });
+}
+
+// Intent the file's open Bruno editor tab is currently showing. A nested
+// collection's opencollection.yml is one file with two views ('default' = the
+// collection, 'not-loaded' = the parent's item), but VS Code reuses one tab per
+// URI — so we track intent to force a fresh render when it changes.
+const currentIntentByFilePath = new Map<string, string>();
+
+/**
+ * Ensure the Bruno editor for `filePath` renders with `intent`. If a tab is open
+ * for this file with a DIFFERENT intent, close it so the next open re-renders
+ * fresh (last action wins). No-op when there's no tab or the intent matches.
+ */
+export async function ensureBrunoEditorIntent(filePath: string, intent: string): Promise<void> {
+  const key = vscode.Uri.file(filePath).fsPath;
+  const current = currentIntentByFilePath.get(key);
+  if (current === undefined || current === intent) {
+    return;
+  }
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (input && typeof input === 'object' && 'uri' in input) {
+        const uri = (input as { uri: vscode.Uri }).uri;
+        if (uri.fsPath === key) {
+          await vscode.window.tabGroups.close(tab);
+        }
+      }
+    }
+  }
+  currentIntentByFilePath.delete(key);
 }
 
 export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
@@ -110,6 +149,7 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       stateManager.removeWebview(webviewPanel.webview);
       unregisterDocument(document.uri.fsPath);
       viewDataByWebview.delete(webviewPanel.webview);
+      currentIntentByFilePath.delete(document.uri.fsPath);
     });
 
     const pendingVariables = pendingVariablesModeRequests.get(filePath);
@@ -117,6 +157,14 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       pendingVariablesModeRequests.delete(filePath);
     }
     const isVariablesMode = !!pendingVariables;
+
+    const pendingNotLoaded = pendingNotLoadedRequests.get(filePath);
+    if (pendingNotLoaded) {
+      pendingNotLoadedRequests.delete(filePath);
+    }
+    const notLoadedParentRoot = pendingNotLoaded?.parentCollectionRoot ?? null;
+
+    currentIntentByFilePath.set(filePath, notLoadedParentRoot ? 'not-loaded' : 'default');
 
     webviewPanel.webview.onDidReceiveMessage((message: IpcMessage) => {
       this._handleMessage(webviewPanel.webview, document, message);
@@ -128,13 +176,37 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
         filePath,
         collectionRoot,
         isVariablesMode,
+        notLoadedParentRoot,
         webviewPanel
       });
     }
   }
 
   private async _loadCollection(pending: CollectionLoadParams): Promise<void> {
-    const { filePath, collectionRoot, isVariablesMode, webviewPanel } = pending;
+    const { filePath, collectionRoot, isVariablesMode, notLoadedParentRoot, webviewPanel } = pending;
+
+    const fileName = path.basename(filePath);
+    const isCollectionFile = fileName === 'collection.bru' || fileName === 'opencollection.yml';
+    const isFolderFile = fileName === 'folder.bru' || fileName === 'folder.yml';
+
+    // A nested collection's config file opened via the parent's "requests not
+    // loaded" item — not a real request. Render it as the parent's not-loaded
+    // request (RequestNotLoaded), not the nested collection's settings. Only the
+    // item-click path sets this, so opening the nested collection shows its own view.
+    const isNestedCollectionConfig = !isVariablesMode && !!notLoadedParentRoot;
+
+    // A folder's containing collection is the root ABOVE its own directory.
+    // findCollectionRoot(filePath) returns the folder's own dir when the folder is
+    // itself a nested collection, scoping folder-settings wrong ("Folder not
+    // found") — so resolve from the folder's parent instead.
+    let effectiveRoot: string;
+    if (isNestedCollectionConfig) {
+      effectiveRoot = notLoadedParentRoot as string;
+    } else if (isFolderFile && !isVariablesMode) {
+      effectiveRoot = findCollectionRoot(path.dirname(filePath)) || collectionRoot;
+    } else {
+      effectiveRoot = collectionRoot;
+    }
 
     const webviewSender = (channel: string, ...args: unknown[]) => {
       stateManager.sendTo(webviewPanel.webview, channel, ...args);
@@ -160,7 +232,7 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       } else {
         collectionUid = await openCollectionForSingleRequest(
           collectionWatcher,
-          collectionRoot,
+          effectiveRoot,
           filePath,
           {},
           webviewSender
@@ -168,11 +240,7 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       }
 
       if (collectionUid) {
-        await defaultWorkspaceManager.addCollectionToWorkspace(collectionRoot);
-
-        const fileName = path.basename(filePath);
-        const isCollectionFile = fileName === 'collection.bru' || fileName === 'opencollection.yml';
-        const isFolderFile = fileName === 'folder.bru' || fileName === 'folder.yml';
+        await defaultWorkspaceManager.addCollectionToWorkspace(effectiveRoot);
 
         let viewData: {
           viewType: string;
@@ -186,27 +254,35 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
           viewData = {
             viewType: 'variables',
             collectionUid,
-            collectionPath: collectionRoot
+            collectionPath: effectiveRoot
+          };
+        } else if (isNestedCollectionConfig) {
+          // Nested collection config file → not-loaded request of the parent.
+          viewData = {
+            viewType: 'request',
+            collectionUid,
+            collectionPath: effectiveRoot,
+            itemUid: generateUidBasedOnHash(filePath)
           };
         } else if (isCollectionFile) {
           viewData = {
             viewType: 'collection-settings',
             collectionUid,
-            collectionPath: collectionRoot
+            collectionPath: effectiveRoot
           };
         } else if (isFolderFile) {
           const folderPath = path.dirname(filePath);
           viewData = {
             viewType: 'folder-settings',
             collectionUid,
-            collectionPath: collectionRoot,
+            collectionPath: effectiveRoot,
             folderUid: generateUidBasedOnHash(folderPath)
           };
         } else {
           viewData = {
             viewType: 'request',
             collectionUid,
-            collectionPath: collectionRoot,
+            collectionPath: effectiveRoot,
             itemUid: generateUidBasedOnHash(filePath)
           };
         }
@@ -220,8 +296,10 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
         // would show "0 requests". Stream the rest of the tree to this webview.
         // Unlike the shared watcher scan, loadFullCollection targets this webview
         // and has no already-scanned guard, so it works regardless of prior opens.
-        if (!isVariablesMode && (isCollectionFile || isFolderFile)) {
-          await collectionWatcher.loadFullCollection(collectionRoot, collectionUid, webviewSender);
+        // (A nested collection config file opens a single request view and doesn't
+        // need the parent's full tree.)
+        if (!isVariablesMode && !isNestedCollectionConfig && (isCollectionFile || isFolderFile)) {
+          await collectionWatcher.loadFullCollection(effectiveRoot, collectionUid, webviewSender);
         }
       }
     } catch (error) {

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -41,8 +41,6 @@ interface CollectionLoadParams {
 }
 
 const pendingVariablesModeRequests = new Map<string, { collectionRoot: string }>();
-// Nested-collection config files opened via the parent's "requests not loaded"
-// item. Maps file path → the parent collection root it belongs to.
 const pendingNotLoadedRequests = new Map<string, { parentCollectionRoot: string }>();
 // Stores view data per webview so renderer:ready can re-send as fallback
 const viewDataByWebview = new Map<vscode.Webview, Record<string, unknown>>();
@@ -55,17 +53,8 @@ export function setPendingNotLoadedRequest(filePath: string, parentCollectionRoo
   pendingNotLoadedRequests.set(filePath, { parentCollectionRoot });
 }
 
-// Intent the file's open Bruno editor tab is currently showing. A nested
-// collection's opencollection.yml is one file with two views ('default' = the
-// collection, 'not-loaded' = the parent's item), but VS Code reuses one tab per
-// URI — so we track intent to force a fresh render when it changes.
 const currentIntentByFilePath = new Map<string, string>();
 
-/**
- * Ensure the Bruno editor for `filePath` renders with `intent`. If a tab is open
- * for this file with a DIFFERENT intent, close it so the next open re-renders
- * fresh (last action wins). No-op when there's no tab or the intent matches.
- */
 export async function ensureBrunoEditorIntent(filePath: string, intent: string): Promise<void> {
   const key = vscode.Uri.file(filePath).fsPath;
   const current = currentIntentByFilePath.get(key);
@@ -189,16 +178,8 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
     const isCollectionFile = fileName === 'collection.bru' || fileName === 'opencollection.yml';
     const isFolderFile = fileName === 'folder.bru' || fileName === 'folder.yml';
 
-    // A nested collection's config file opened via the parent's "requests not
-    // loaded" item — not a real request. Render it as the parent's not-loaded
-    // request (RequestNotLoaded), not the nested collection's settings. Only the
-    // item-click path sets this, so opening the nested collection shows its own view.
     const isNestedCollectionConfig = !isVariablesMode && !!notLoadedParentRoot;
 
-    // A folder's containing collection is the root ABOVE its own directory.
-    // findCollectionRoot(filePath) returns the folder's own dir when the folder is
-    // itself a nested collection, scoping folder-settings wrong ("Folder not
-    // found") — so resolve from the folder's parent instead.
     let effectiveRoot: string;
     if (isNestedCollectionConfig) {
       effectiveRoot = notLoadedParentRoot as string;
@@ -296,8 +277,6 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
         // would show "0 requests". Stream the rest of the tree to this webview.
         // Unlike the shared watcher scan, loadFullCollection targets this webview
         // and has no already-scanned guard, so it works regardless of prior opens.
-        // (A nested collection config file opens a single request view and doesn't
-        // need the parent's full tree.)
         if (!isVariablesMode && !isNestedCollectionConfig && (isCollectionFile || isFolderFile)) {
           await collectionWatcher.loadFullCollection(effectiveRoot, collectionUid, webviewSender);
         }

--- a/src/extension/utils/path.ts
+++ b/src/extension/utils/path.ts
@@ -27,10 +27,7 @@ export function isCollectionRoot(dirPath: string): boolean {
 
 /**
  * Resolve the collection root for a path that may be a collection-root directory,
- * a file inside a collection, or a subfolder. Unlike findCollectionRoot() — which
- * only walks UP and so returns the PARENT when given a nested collection's own
- * root dir — this checks the path itself first, so a nested collection resolves
- * to itself, not its parent.
+ * a file inside a collection, or a subfolder. 
  */
 export function resolveCollectionRoot(targetPath: string): string | null {
   if (isCollectionRoot(targetPath)) {

--- a/src/extension/utils/path.ts
+++ b/src/extension/utils/path.ts
@@ -25,6 +25,20 @@ export function isCollectionRoot(dirPath: string): boolean {
   return fs.existsSync(brunoJsonPath) || fs.existsSync(ocYmlPath);
 }
 
+/**
+ * Resolve the collection root for a path that may be a collection-root directory,
+ * a file inside a collection, or a subfolder. Unlike findCollectionRoot() — which
+ * only walks UP and so returns the PARENT when given a nested collection's own
+ * root dir — this checks the path itself first, so a nested collection resolves
+ * to itself, not its parent.
+ */
+export function resolveCollectionRoot(targetPath: string): string | null {
+  if (isCollectionRoot(targetPath)) {
+    return targetPath;
+  }
+  return findCollectionRoot(targetPath);
+}
+
 export function getCollectionName(collectionRoot: string): string {
   try {
     const brunoJsonPath = path.join(collectionRoot, 'bruno.json');

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -261,16 +261,11 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
       case 'sidebar:open-request':
         if (typeof args[0] === 'string') {
           const requestPath = vscode.Uri.file(args[0]).fsPath;
-          // A nested collection's config file surfaced as a "not loaded" request
-          // item. Flag it so the editor opens the RequestNotLoaded panel scoped to
-          // the PARENT collection instead of the nested collection's settings.
           const basename = path.basename(requestPath);
           if (basename === 'opencollection.yml' || basename === 'collection.bru') {
             const rootOfFile = findCollectionRoot(requestPath);
             const parentRoot = rootOfFile ? findCollectionRoot(rootOfFile) : null;
             if (parentRoot) {
-              // Same file may already be open as the nested collection itself;
-              // force a fresh render as the "not loaded" request of the parent.
               await ensureBrunoEditorIntent(requestPath, 'not-loaded');
               setPendingNotLoadedRequest(requestPath, parentRoot);
             }

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -9,6 +9,8 @@ import {
 } from '../ipc/handlers';
 import { storeTransientItem }  from '../panels/transient-request-panel';
 import { WebviewHelper } from '../webview/helper';
+import { findCollectionRoot } from '../utils/path';
+import { setPendingNotLoadedRequest, ensureBrunoEditorIntent } from '../editors/bruno-editor-provider';
 
 interface IpcMessage {
   type: 'invoke' | 'send';
@@ -258,9 +260,24 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
     switch (channel) {
       case 'sidebar:open-request':
         if (typeof args[0] === 'string') {
+          const requestPath = args[0];
+          // A nested collection's config file surfaced as a "not loaded" request
+          // item. Flag it so the editor opens the RequestNotLoaded panel scoped to
+          // the PARENT collection instead of the nested collection's settings.
+          const basename = path.basename(requestPath);
+          if (basename === 'opencollection.yml' || basename === 'collection.bru') {
+            const rootOfFile = findCollectionRoot(requestPath);
+            const parentRoot = rootOfFile ? findCollectionRoot(rootOfFile) : null;
+            if (parentRoot) {
+              // Same file may already be open as the nested collection itself;
+              // force a fresh render as the "not loaded" request of the parent.
+              await ensureBrunoEditorIntent(requestPath, 'not-loaded');
+              setPendingNotLoadedRequest(requestPath, parentRoot);
+            }
+          }
           await vscode.commands.executeCommand(
             'vscode.openWith',
-            vscode.Uri.file(args[0]),
+            vscode.Uri.file(requestPath),
             'bruno.requestEditor'
           );
         }

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -260,7 +260,7 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
     switch (channel) {
       case 'sidebar:open-request':
         if (typeof args[0] === 'string') {
-          const requestPath = args[0];
+          const requestPath = vscode.Uri.file(args[0]).fsPath;
           // A nested collection's config file surfaced as a "not loaded" request
           // item. Flag it so the editor opens the RequestNotLoaded panel scoped to
           // the PARENT collection instead of the nested collection's settings.

--- a/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
+++ b/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
@@ -7,6 +7,7 @@ import { isItemARequest, itemIsOpenedInTabs } from 'utils/tabs/index';
 import { getDefaultRequestPaneTab } from 'utils/collections/index';
 import { addTab, focusTab } from 'providers/ReduxStore/slices/tabs';
 import { RootState } from 'providers/ReduxStore';
+import { isSidebarMode, openRequestInVSCodeEditor } from 'utils/webviewMode';
 
 interface RequestsNotLoadedProps {
   collection: React.ReactNode;
@@ -28,24 +29,33 @@ const RequestsNotLoaded = ({
 
   const handleRequestClick = (item: any) => (e: any) => {
     e.preventDefault();
-    if (isItemARequest(item)) {
-      if (itemIsOpenedInTabs(item, tabs as any)) {
-        dispatch(
-          focusTab({
-            uid: item.uid
-          })
-        );
-        return;
-      }
+    if (!isItemARequest(item)) {
+      return;
+    }
+
+    // In the VS Code sidebar, open the file through the custom editor (same path
+    // the sidebar tree uses) so nested collection config files route to the
+    // RequestNotLoaded panel instead of the nested collection's settings.
+    if (isSidebarMode()) {
+      openRequestInVSCodeEditor(item.pathname);
+      return;
+    }
+
+    if (itemIsOpenedInTabs(item, tabs as any)) {
       dispatch(
-        addTab({
-          uid: item.uid,
-          collectionUid: collection.uid,
-          requestPaneTab: getDefaultRequestPaneTab(item)
+        focusTab({
+          uid: item.uid
         })
       );
       return;
     }
+    dispatch(
+      addTab({
+        uid: item.uid,
+        collectionUid: collection.uid,
+        requestPaneTab: getDefaultRequestPaneTab(item)
+      })
+    );
   };
 
   return (

--- a/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
+++ b/src/webview/components/CollectionSettings/Overview/RequestsNotLoaded/index.tsx
@@ -33,9 +33,6 @@ const RequestsNotLoaded = ({
       return;
     }
 
-    // In the VS Code sidebar, open the file through the custom editor (same path
-    // the sidebar tree uses) so nested collection config files route to the
-    // RequestNotLoaded panel instead of the nested collection's settings.
     if (isSidebarMode()) {
       openRequestInVSCodeEditor(item.pathname);
       return;

--- a/src/webview/components/RequestTabPanel/RequestNotLoaded.tsx
+++ b/src/webview/components/RequestTabPanel/RequestNotLoaded.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { loadRequest } from 'providers/ReduxStore/slices/collections/actions';
+import StyledWrapper from './StyledWrapper';
+import { IconFile, IconLoader2 } from '@tabler/icons';
 
 interface RequestNotLoadedProps {
   item: any;
@@ -19,9 +21,44 @@ const RequestNotLoaded: React.FC<RequestNotLoadedProps> = ({ item, collection })
   }, [item?.pathname, collection?.uid, dispatch]);
 
   return (
-    <div className="flex flex-col items-center justify-center h-full p-8 text-center">
-      <div className="text-sm text-gray-500">Loading request...</div>
-    </div>
+    <StyledWrapper>
+      <div className="flex flex-col p-4">
+        <div className="card shadow-sm rounded-md p-4 w-[685px]">
+          <div>
+            <div className="font-medium flex items-center gap-2 pb-4">
+              <IconFile size={16} strokeWidth={1.5} className="text-gray-400" />
+              File Info
+            </div>
+            <div className="hr" />
+
+            <div className="flex items-center mt-2">
+              <span className="w-12 mr-2 text-muted">Name:</span>
+              <div>{item?.name}</div>
+            </div>
+
+            <div className="flex items-center mt-1">
+              <span className="w-12 mr-2 text-muted">Path:</span>
+              <div className="break-all">{item?.pathname}</div>
+            </div>
+
+            <div className="flex items-center mt-1 pb-4">
+              <span className="w-12 mr-2 text-muted">Size:</span>
+              <div>{item?.size?.toFixed?.(2)} MB</div>
+            </div>
+
+            {item?.loading && (
+              <>
+                <div className="hr mt-4" />
+                <div className="flex items-center gap-2 mt-4">
+                  <IconLoader2 className="animate-spin" size={16} strokeWidth={2} />
+                  <span>Loading request...</span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </StyledWrapper>
   );
 };
 


### PR DESCRIPTION
**Jira: VSCODE-65**
### Description
On creating collection inside another collection, proper location of nested collection is shown in nested collection's overview. Parent collection's request count is not shown in nested collection's overview.
### Issue
On creating nested collection, it is showing parent collection's location and parent collection's request count in nested collection's overview.
### Fix
1. On creating nested collection, it adds as a collection in sidebar. Also inside the parent collection, it is treated as folder.
2. Display the proper location of the nested collection in overview. Also display the request count in nested collection and not include request count of parent collection.
3. In parent collection's overview, show openCollection.yml as not loaded properly as nested collection is treated as folder inside parent collection.