### PR TITLE
feat(timeline): implement timeline panel in vscode

### DIFF
--- a/src/bruno-types/app/collection-ext.ts
+++ b/src/bruno-types/app/collection-ext.ts
@@ -6,8 +6,9 @@ import type { ResponseState, TestResult, AssertionResult } from './response';
 export interface RequestSent {
   url?: string;
   method?: string;
-  headers?: KeyValue[];
+  headers?: KeyValue[] | Record<string, string>;
   body?: unknown;
+  data?: unknown;
   timestamp?: number;
   [key: string]: unknown;
 }
@@ -23,7 +24,8 @@ export interface OAuth2CredentialEntry {
 }
 
 export interface TimelineEntry {
-  type: 'request' | 'response' | 'error';
+  id?: string;
+  type: 'request' | 'response' | 'error' | 'oauth2';
   eventType?: string;
   collectionUid: UID;
   folderUid: UID | null;
@@ -33,6 +35,7 @@ export interface TimelineEntry {
     request?: unknown;
     response?: unknown;
     eventData?: unknown;
+    debugInfo?: unknown[];
     timestamp?: number;
   };
 }

--- a/src/bruno-types/app/index.ts
+++ b/src/bruno-types/app/index.ts
@@ -1,6 +1,7 @@
 export type {
   HttpResponse,
   ResponseTimeline,
+  NetworkLogEntry,
   GrpcResponse,
   WebSocketState,
   WebSocketMessageLog,

--- a/src/bruno-types/app/response.ts
+++ b/src/bruno-types/app/response.ts
@@ -14,14 +14,12 @@ export interface HttpResponse {
   responseTime?: number;
 }
 
-export interface ResponseTimeline {
-  startTime?: number;
-  dnsTime?: number;
-  tcpTime?: number;
-  tlsTime?: number;
-  firstByteTime?: number;
-  downloadTime?: number;
-  endTime?: number;
+export type ResponseTimeline = NetworkLogEntry[];
+
+export interface NetworkLogEntry {
+  elapsedMs: number;
+  type: 'info' | 'request' | 'response' | 'error';
+  message: string;
 }
 
 export interface GrpcResponse {

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -24,6 +24,7 @@ import { Readable } from 'stream';
 import { registerWsEventHandlers } from './ws-event-handlers';
 import { registerGrpcEventHandlers } from './grpc-event-handlers';
 import { utils as brunoUtilsRaw } from '@usebruno/common';
+import type { NetworkLogEntry, RequestSent, ResponseTimeline } from '@bruno-types';
 import qs from 'qs';
 
 // Type assertion for @usebruno/common utils (no type definitions available)
@@ -189,9 +190,55 @@ interface RequestResult {
   rawBuffer?: Buffer;
   size: number;
   duration: number;
-  timeline?: Array<{ timestamp: number; event: string }>;
+  timeline?: ResponseTimeline;
+  requestSent?: RequestSent;
   error?: string;
 }
+
+/** Request bodies can be streams (multipart) or buffers, neither of which survives postMessage. */
+const serializeRequestData = (data: unknown, multipartFields?: unknown): unknown => {
+  if (data === null || data === undefined || typeof data === 'string') {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString();
+  }
+  if (typeof (data as { pipe?: unknown }).pipe === 'function') {
+    return multipartFields ?? '[multipart form data]';
+  }
+  try {
+    JSON.stringify(data);
+    return data;
+  } catch {
+    return '[Unserializable body]';
+  }
+};
+
+/** `false` is used to stop axios auto-setting Content-Type; no such header was actually sent. */
+const serializeSentHeaders = (headers: Record<string, unknown>): Record<string, string> => {
+  const sent: Record<string, string> = {};
+  Object.entries(headers || {}).forEach(([key, value]) => {
+    if (value === false || value === null || value === undefined) {
+      return;
+    }
+    sent[key] = String(value);
+  });
+  return sent;
+};
+
+const buildRequestSnapshot = (request: {
+  url?: string;
+  method?: string;
+  headers?: unknown;
+  data?: unknown;
+  _originalMultipartData?: unknown;
+}): RequestSent => ({
+  url: request.url,
+  method: (request.method || 'GET').toUpperCase(),
+  headers: serializeSentHeaders(request.headers as Record<string, unknown>),
+  data: serializeRequestData(request.data, request._originalMultipartData),
+  timestamp: Date.now()
+});
 
 interface RunFolderContext {
   running: boolean;
@@ -206,10 +253,11 @@ const executeRequest = async (
   options: RequestOptions = {}
 ): Promise<RequestResult> => {
   const startTime = Date.now();
-  const timeline: Array<{ timestamp: number; event: string }> = [];
+  const timeline: NetworkLogEntry[] = [];
+  let requestSent: RequestSent | undefined;
 
-  const addTimelineEvent = (event: string) => {
-    timeline.push({ timestamp: Date.now() - startTime, event });
+  const addTimelineEvent = (message: string, type: NetworkLogEntry['type'] = 'info') => {
+    timeline.push({ elapsedMs: Date.now() - startTime, type, message });
   };
 
   addTimelineEvent('Request started');
@@ -389,7 +437,9 @@ const executeRequest = async (
       }
     }
 
-    addTimelineEvent('Sending request');
+    requestSent = buildRequestSnapshot(preparedRequest);
+
+    addTimelineEvent(`${requestSent.method} ${requestSent.url}`, 'request');
     const axiosInstance = createAxiosInstance(axiosOptions);
 
     preparedRequest.signal = abortController.signal;
@@ -399,13 +449,13 @@ const executeRequest = async (
       response = await axiosInstance.request(preparedRequest);
     } catch (error) {
       if ((error as Error).name === 'AbortError' || (error as Error).name === 'CanceledError') {
-        addTimelineEvent('Request cancelled');
+        addTimelineEvent('Request cancelled', 'error');
         throw new Error('Request cancelled');
       }
       throw error;
     }
 
-    addTimelineEvent('Response received');
+    addTimelineEvent(`${response.status} ${response.statusText}`, 'response');
 
     const responseHeaders: Record<string, string> = {};
     Object.entries(response.headers).forEach(([key, value]) => {
@@ -444,7 +494,8 @@ const executeRequest = async (
       rawBuffer: rawBuffer,
       size: responseSize,
       duration: Date.now() - startTime,
-      timeline
+      timeline,
+      requestSent
     };
 
     return result;
@@ -452,7 +503,7 @@ const executeRequest = async (
     const axiosError = error as AxiosError;
     const duration = Date.now() - startTime;
 
-    addTimelineEvent('Request failed: ' + (error as Error).message);
+    addTimelineEvent('Request failed: ' + (error as Error).message, 'error');
 
     // If we have a response (4xx, 5xx), return it as a valid response
     // This matches bruno-electron behavior - error responses are shown as data, not as errors
@@ -495,7 +546,8 @@ const executeRequest = async (
         rawBuffer: errorRawBuffer,
         size: errorSize,
         duration,
-        timeline
+        timeline,
+        requestSent
       };
     }
 
@@ -503,7 +555,8 @@ const executeRequest = async (
     const errorMessage = (error as Error).message || 'Error occurred while executing the request!';
     return {
       status: 0,
-      statusText: errorMessage,
+      // Desktop reports the axios error code here and keeps the readable text in `error`.
+      statusText: axiosError.code || errorMessage,
       headers: {},
       data: null,
       dataBuffer: '',
@@ -511,6 +564,7 @@ const executeRequest = async (
       size: 0,
       duration,
       timeline,
+      requestSent,
       error: errorMessage
     };
   } finally {
@@ -1028,12 +1082,7 @@ const registerNetworkIpc = (): void => {
 
       sendToWebview('main:run-request-event', {
         type: 'request-sent',
-        requestSent: {
-          url: scriptRequest.url,
-          method: scriptRequest.method,
-          headers: scriptRequest.headers,
-          timestamp: Date.now()
-        },
+        requestSent: buildRequestSnapshot(scriptRequest),
         collectionUid,
         itemUid,
         requestUid,
@@ -1043,6 +1092,25 @@ const registerNetworkIpc = (): void => {
       // Use scriptRequest so pre-request script changes are respected
       // scriptRequest will be mutated by interpolateVars inside executeRequest
       const result = await executeRequest(scriptRequest as unknown as BrunoRequest, context);
+
+      const oauth2Credentials = (scriptRequest as { oauth2Credentials?: {
+        credentials?: unknown;
+        url?: string;
+        credentialsId?: string;
+        folderUid?: string;
+        debugInfo?: { data: unknown[] };
+      } }).oauth2Credentials;
+      if (oauth2Credentials?.debugInfo) {
+        sendToWebview('main:credentials-update', {
+          collectionUid,
+          itemUid,
+          folderUid: oauth2Credentials.folderUid ?? null,
+          url: oauth2Credentials.url,
+          credentialsId: oauth2Credentials.credentialsId,
+          credentials: oauth2Credentials.credentials,
+          debugInfo: oauth2Credentials.debugInfo
+        });
+      }
 
       sendToWebview('main:run-request-event', {
         type: 'response-received',
@@ -1073,6 +1141,7 @@ const registerNetworkIpc = (): void => {
           size: result.size,
           duration: result.duration,
           timeline: result.timeline,
+          requestSent: result.requestSent,
           error: result.error
         };
       }
@@ -1146,8 +1215,9 @@ const registerNetworkIpc = (): void => {
         size: result.size,
         duration: result.duration,
         timeline: result.timeline,
+        requestSent: result.requestSent,
         // Interpolated URL actually sent (executeRequest resolves {{vars}} in place). Used as the
-        // <base href> for HTML previews so relative assets resolve; requestSent.url is still raw.
+        // <base href> for HTML previews so relative assets resolve.
         requestUrl: scriptRequest.url,
         error: result.error
       };
@@ -1985,12 +2055,7 @@ const registerNetworkIpc = (): void => {
               .join('&');
           }
 
-          const requestSent = {
-            url: scriptRequest.url,
-            method: scriptRequest.method,
-            headers: scriptRequest.headers,
-            timestamp: Date.now()
-          };
+          const requestSent = buildRequestSnapshot(scriptRequest);
 
           sendToWebview('main:run-folder-event', {
             type: 'request-sent',
@@ -2080,6 +2145,7 @@ const registerNetworkIpc = (): void => {
 
           sendToWebview('main:run-folder-event', {
             type: 'response-received',
+            requestSent: result.requestSent,
             responseReceived: {
               status: result.status,
               statusText: result.statusText,

--- a/src/webview/components/ResponsePane/GrpcResponsePane/index.tsx
+++ b/src/webview/components/ResponsePane/GrpcResponsePane/index.tsx
@@ -13,6 +13,9 @@ import StyledWrapper from './StyledWrapper';
 import ResponseTrailers from './ResponseTrailers';
 import GrpcQueryResult from './GrpcQueryResult';
 import ResponseLayoutToggle from '../ResponseLayoutToggle';
+import Timeline from '../Timeline';
+import ClearTimeline from '../ClearTimeline';
+import { useItemTimeline } from '../timeline-utils';
 import Tab from 'components/Tab';
 
 interface GrpcResponsePaneProps {
@@ -29,6 +32,8 @@ const GrpcResponsePane = ({
   const tabs = useSelector((state) => state.tabs.tabs);
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isLoading = ['queued', 'sending'].includes(item.requestState);
+
+  const requestTimeline = useItemTimeline(collection, item);
 
   const selectTab = (tab: any) => {
     dispatch(
@@ -52,6 +57,9 @@ const GrpcResponsePane = ({
       case 'trailers': {
         return <ResponseTrailers trailers={response.trailers} />;
       }
+      case 'timeline': {
+        return <Timeline item={item} collection={collection} />;
+      }
       default: {
         return <div>404 | Not found</div>;
       }
@@ -66,7 +74,7 @@ const GrpcResponsePane = ({
     );
   }
 
-  if (!item.response) {
+  if (!item.response && !requestTimeline.length) {
     return (
       <StyledWrapper className="flex h-full relative">
         <Placeholder />
@@ -99,6 +107,11 @@ const GrpcResponsePane = ({
       label: 'Trailers',
       count: Array.isArray(response.trailers) ? response.trailers.length : 0
     },
+    {
+      name: 'timeline',
+      label: 'Timeline',
+      count: requestTimeline.length
+    }
   ];
 
   return (
@@ -116,7 +129,12 @@ const GrpcResponsePane = ({
         ))}
         {!isLoading ? (
           <div className="flex flex-grow justify-end items-center">
-            {item?.response ? (
+            {focusedTab.responsePaneTab === 'timeline' ? (
+              <>
+                <ResponseLayoutToggle />
+                <ClearTimeline item={item} collection={collection} />
+              </>
+            ) : item?.response ? (
               <>
                 <ResponseLayoutToggle />
                 <ResponseClear item={item} collection={collection} />
@@ -139,6 +157,8 @@ const GrpcResponsePane = ({
         <div className="flex-1 min-h-0 min-w-0 overflow-auto">
           {item?.response ? (
             <>{getTabPanel(focusedTab.responsePaneTab)}</>
+          ) : focusedTab.responsePaneTab === 'timeline' && requestTimeline.length ? (
+            <Timeline item={item} collection={collection} />
           ) : null}
         </div>
       </section>

--- a/src/webview/components/ResponsePane/Timeline/TimelineItem/Response/index.tsx
+++ b/src/webview/components/ResponsePane/Timeline/TimelineItem/Response/index.tsx
@@ -37,8 +37,8 @@ const Response = ({
     <div>
       <div className="mb-1">
         <Status statusCode={status || statusCode} statusText={statusText} />
-        {response.duration && <span className="timeline-item-metadata">{response.duration}ms</span>}
-        {response.size && <span className="timeline-item-metadata">{response.size}B</span>}
+        {response?.duration ? <span className="timeline-item-metadata">{response.duration}ms</span> : null}
+        {response?.size ? <span className="timeline-item-metadata">{response.size}B</span> : null}
       </div>
 
       <Headers headers={headers} type="response" />

--- a/src/webview/components/ResponsePane/Timeline/TimelineItem/StyledWrapper.ts
+++ b/src/webview/components/ResponsePane/Timeline/TimelineItem/StyledWrapper.ts
@@ -16,6 +16,12 @@ const StyledWrapper = styled.div`
     cursor: pointer;
   }
 
+  .timeline-item-chevron {
+    display: flex;
+    align-items: center;
+    color: ${(props) => props.theme.colors.text.muted};
+  }
+
   .timeline-item-header-content {
     display: flex;
     justify-content: space-between;

--- a/src/webview/components/ResponsePane/Timeline/TimelineItem/index.tsx
+++ b/src/webview/components/ResponsePane/Timeline/TimelineItem/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { IconChevronDown, IconChevronRight } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 import Network from './Network/index';
 import Request from './Request/index';
@@ -28,21 +29,38 @@ const TimelineItem = ({
   hideTimestamp = false
 }: any) => {
   const { theme } = useTheme();
-  const [isCollapsed, _toggleCollapse] = useState(false);
+  const [isExpanded, _toggleExpand] = useState(false);
   const [activeTab, setActiveTab] = useState('request');
-  const toggleCollapse = () => _toggleCollapse((prev) => !prev);
+  const toggleExpand = () => _toggleExpand((prev) => !prev);
+  const handleRowKeyDown = (ev: React.KeyboardEvent) => {
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      ev.preventDefault();
+      toggleExpand();
+    }
+  };
   const { method, status, statusCode, statusText, url = '' } = request || {};
   const { status: responseStatus, statusCode: responseStatusCode, statusText: responseStatusText } = response || {};
-  const showNetworkLogs = response.timeline && response.timeline.length > 0;
+  const showNetworkLogs = response?.timeline?.length > 0;
 
   return (
     <StyledWrapper>
       <div className={`timeline-item ${isOauth2 ? 'timeline-item--oauth2' : ''}`}>
-        <div className="oauth-request-item-header relative cursor-pointer flex items-center justify-between gap-3 min-w-0" onClick={toggleCollapse}>
+        <div
+          className="oauth-request-item-header relative cursor-pointer flex items-center justify-between gap-3 min-w-0"
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
+          onClick={toggleExpand}
+          onKeyDown={handleRowKeyDown}
+          data-testid="timeline-item-header"
+        >
+          <span className="timeline-item-chevron flex-shrink-0" aria-hidden="true">
+            {isExpanded ? <IconChevronDown size={14} strokeWidth={2} /> : <IconChevronRight size={14} strokeWidth={2} />}
+          </span>
           <Status statusCode={responseStatus || responseStatusCode} statusText={responseStatusText} />
           <div className="flex items-center gap-1">
             <Method method={method} />
-            <div className="truncate flex-1 min-w-0">{url}</div>
+            <div className="truncate flex-1 min-w-0" data-testid="timeline-url">{url}</div>
             {isOauth2 && <span className="text-xs flex-shrink-0" style={{ color: theme.colors.text.muted }}>[oauth2.0]</span>}
           </div>
           {!hideTimestamp && (
@@ -51,8 +69,8 @@ const TimelineItem = ({
             </span>
           )}
         </div>
-        {isCollapsed && (
-          <div className="timeline-item-content">
+        {isExpanded && (
+          <div className="timeline-item-content" data-testid="timeline-item-detail">
             <div className="timeline-item-tabs">
               <button
                 className={`timeline-item-tab ${activeTab === 'request' ? 'timeline-item-tab--active' : ''}`}

--- a/src/webview/components/ResponsePane/Timeline/index.tsx
+++ b/src/webview/components/ResponsePane/Timeline/index.tsx
@@ -1,87 +1,34 @@
 import React from 'react';
 import StyledWrapper from './StyledWrapper';
-import { findItemInCollection, findParentItemInCollection } from 'utils/collections/index';
-import { get } from 'lodash';
 import TimelineItem from './TimelineItem/index';
 import GrpcTimelineItem from './GrpcTimelineItem/index';
-
-interface getEffectiveAuthSourceProps {
-  collection?: React.ReactNode;
-  item?: React.ReactNode;
-}
-
-const getEffectiveAuthSource = (collection: any, item: any) => {
-  const authMode = item.draft ? get(item, 'draft.request.auth.mode') : get(item, 'request.auth.mode');
-  if (authMode !== 'inherit') return null;
-
-  const collectionRoot = collection?.draft?.root || collection?.root || {};
-  const collectionAuth = get(collectionRoot, 'request.auth');
-  let effectiveSource = {
-    type: 'collection',
-    uid: collection.uid,
-    auth: collectionAuth
-  };
-
-  let path = [];
-  let currentItem = findItemInCollection(collection, item?.uid);
-  while (currentItem) {
-    path.unshift(currentItem);
-    currentItem = findParentItemInCollection(collection, currentItem?.uid);
-  }
-
-  for (let i of [...path].reverse()) {
-    if (i.type === 'folder') {
-      const folderAuth = get(i, 'root.request.auth');
-      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
-        effectiveSource = {
-          type: 'folder',
-          uid: i.uid,
-          auth: folderAuth
-        };
-        break;
-      }
-    }
-  }
-
-  return effectiveSource;
-};
+import { useItemTimeline } from '../timeline-utils';
 
 const Timeline = ({
   collection,
   item
 }: any) => {
-  const authSource = getEffectiveAuthSource(collection, item);
   const isGrpcRequest = item.type === 'grpc-request' || item.type === 'ws-request';
-
-  const combinedTimeline = ([...(collection?.timeline || [])]).filter((obj) => {
-    // Always show entries for this item
-    if (obj.itemUid === item.uid) return true;
-
-    // For OAuth2 entries, also show if auth is inherited
-    if (obj.type === 'oauth2' && authSource) {
-      if (authSource.type === 'folder' && obj.folderUid === authSource.uid) return true;
-      if (authSource.type === 'collection' && !obj.folderUid) return true;
-    }
-
-    return false;
-  }).sort((a, b) => b.timestamp - a.timestamp);
+  const combinedTimeline = useItemTimeline(collection, item);
 
   return (
     <StyledWrapper
       className="pb-4 w-full flex flex-grow flex-col"
     >
-      {/* Timeline container with scrollbar */}
       <div
         className="timeline-container"
+        data-testid="timeline-container"
       >
         {combinedTimeline.map((event, index) => {
+          // Newest-first: an index key would let a new row inherit the top row's expand state.
+          const key = event.id ?? `${event.type}-${event.itemUid}-${event.timestamp}-${event.eventType ?? ''}-${index}`;
           if (event.type === 'request') {
             const { data, timestamp, eventType } = event;
             const { request, response, eventData = {}, timestamp: eventTimestamp = timestamp } = data;
 
             if (isGrpcRequest) {
               return (
-                <div key={index} className="timeline-event">
+                <div key={key} className="timeline-event" data-testid="timeline-item">
                   <GrpcTimelineItem
                     timestamp={eventTimestamp}
                     request={request}
@@ -96,7 +43,7 @@ const Timeline = ({
             }
 
             return (
-              <div key={index} className="timeline-event">
+              <div key={key} className="timeline-event" data-testid="timeline-item">
                 <TimelineItem
                   timestamp={timestamp}
                   request={request}
@@ -110,7 +57,7 @@ const Timeline = ({
             const { data, timestamp } = event;
             const { debugInfo } = data;
             return (
-              <div key={index} className="timeline-event">
+              <div key={key} className="timeline-event" data-testid="timeline-item">
                 <div className="timeline-event-header cursor-pointer flex items-center">
                   <div className="flex items-center">
                     <span className="font-bold">OAuth2.0 Calls</span>

--- a/src/webview/components/ResponsePane/WsResponsePane/index.tsx
+++ b/src/webview/components/ResponsePane/WsResponsePane/index.tsx
@@ -9,6 +9,9 @@ import ResponseTime from '../ResponseTime/index';
 import ResponseClear from '../ResponseClear';
 import StyledWrapper from './StyledWrapper';
 import ResponseLayoutToggle from '../ResponseLayoutToggle';
+import Timeline from '../Timeline';
+import ClearTimeline from '../ClearTimeline';
+import { useItemTimeline } from '../timeline-utils';
 import Tab from 'components/Tab';
 import WSMessagesList from './WSMessagesList';
 import WSResponseHeaders from './WSResponseHeaders';
@@ -35,6 +38,8 @@ const WSResponsePane = ({
   const activeTabUid = useSelector((state) => state.tabs.activeTabUid);
   const isLoading = ['queued', 'sending'].includes(item.requestState);
 
+  const requestTimeline = useItemTimeline(collection, item);
+
   const selectTab = (tab: any) => {
     dispatch(updateResponsePaneTab({
       uid: item.uid,
@@ -52,6 +57,9 @@ const WSResponsePane = ({
       case 'headers': {
         return <WSResponseHeaders response={response} />;
       }
+      case 'timeline': {
+        return <Timeline item={item} collection={collection} />;
+      }
       default: {
         return <div>404 | Not found</div>;
       }
@@ -66,7 +74,7 @@ const WSResponsePane = ({
     );
   }
 
-  if (!item.response) {
+  if (!item.response && !requestTimeline.length) {
     return (
       <StyledWrapper className="flex h-full relative">
         <Placeholder />
@@ -94,6 +102,11 @@ const WSResponsePane = ({
       label: 'Headers',
       count: response.headers ? Object.keys(response.headers).length : 0
     },
+    {
+      name: 'timeline',
+      label: 'Timeline',
+      count: requestTimeline.length
+    }
   ];
 
   return (
@@ -111,7 +124,12 @@ const WSResponsePane = ({
         ))}
         {!isLoading ? (
           <div className="flex flex-grow justify-end items-center">
-            {item?.response ? (
+            {focusedTab.responsePaneTab === 'timeline' ? (
+              <>
+                <ResponseLayoutToggle />
+                <ClearTimeline item={item} collection={collection} />
+              </>
+            ) : item?.response ? (
               <>
                 <ResponseLayoutToggle />
                 <ResponseClear item={item} collection={collection} />
@@ -134,6 +152,8 @@ const WSResponsePane = ({
         <div className="flex-1 min-h-0 min-w-0 overflow-auto">
           {item?.response ? (
             <>{getTabPanel(focusedTab.responsePaneTab)}</>
+          ) : focusedTab.responsePaneTab === 'timeline' && requestTimeline.length ? (
+            <Timeline item={item} collection={collection} />
           ) : null}
         </div>
       </section>

--- a/src/webview/components/ResponsePane/index.tsx
+++ b/src/webview/components/ResponsePane/index.tsx
@@ -11,6 +11,9 @@ import ResponseTime from './ResponseTime';
 import ResponseSize from './ResponseSize';
 import TestResults from './TestResults';
 import TestResultsLabel from './TestResultsLabel';
+import Timeline from './Timeline';
+import ClearTimeline from './ClearTimeline';
+import { useItemTimeline } from './timeline-utils';
 import ScriptError from './ScriptError';
 import ScriptErrorIcon from './ScriptErrorIcon';
 import StyledWrapper from './StyledWrapper';
@@ -109,6 +112,8 @@ const ResponsePane = ({
 
   const hasScriptError = item?.preRequestScriptErrorMessage || item?.postResponseScriptErrorMessage || item?.testScriptErrorMessage;
 
+  const timelineCount = useItemTimeline(collection, item).length;
+
   const allTabs = useMemo((): Array<{ key: string; label: React.ReactNode; indicator: React.ReactNode }> => {
     return [
       {
@@ -120,6 +125,11 @@ const ResponsePane = ({
         key: 'headers',
         label: 'Headers',
         indicator: responseHeadersCount > 0 ? <sup className="ml-1 font-medium">{responseHeadersCount}</sup> : null
+      },
+      {
+        key: 'timeline',
+        label: 'Timeline',
+        indicator: timelineCount > 0 ? <sup className="ml-1 font-medium">{timelineCount}</sup> : null
       },
       {
         key: 'tests',
@@ -134,7 +144,7 @@ const ResponsePane = ({
         indicator: null
       }
     ];
-  }, [responseHeadersCount, item.testResults, item.assertionResults, item.preRequestTestResults, item.postResponseTestResults]);
+  }, [responseHeadersCount, timelineCount, item.testResults, item.assertionResults, item.preRequestTestResults, item.postResponseTestResults]);
 
   const getTabPanel = (tab: any) => {
     switch (tab) {
@@ -159,6 +169,9 @@ const ResponsePane = ({
       }
       case 'headers': {
         return <ResponseHeaders headers={response.headers} />;
+      }
+      case 'timeline': {
+        return <Timeline item={item} collection={collection} />;
       }
       case 'tests': {
         return (
@@ -193,7 +206,7 @@ const ResponsePane = ({
     );
   }
 
-  if (!item.response) {
+  if (!item.response && !timelineCount) {
     return (
       <HeightBoundContainer>
         <Placeholder />
@@ -236,16 +249,23 @@ const ResponsePane = ({
           </div>
         </>
       ) : null}
+      {/* Stays mounted: ResponsiveTabs measures rightContent's children to lay out the tabs. */}
       <div className="flex items-center response-pane-status">
-        <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
-        {item.response?.stream?.running
-          ? <ResponseStopWatch startMillis={response.duration} />
-          : <ResponseTime duration={response.duration} />}
-        <ResponseSize size={responseSize} />
+        {item?.response ? (
+          <>
+            <StatusCode status={response.status} isStreaming={item.response?.stream?.running} />
+            {item.response?.stream?.running
+              ? <ResponseStopWatch startMillis={response.duration} />
+              : <ResponseTime duration={response.duration} />}
+            <ResponseSize size={responseSize} />
+          </>
+        ) : null}
       </div>
 
       <div className="flex items-center response-pane-actions">
-        {item?.response && !item?.response?.error ? (
+        {focusedTab?.responsePaneTab === 'timeline' ? (
+          <ClearTimeline item={item} collection={collection} />
+        ) : item?.response && !item?.response?.error ? (
           <ResponsePaneActions
             item={item}
             collection={collection}
@@ -262,7 +282,7 @@ const ResponsePane = ({
 
   return (
     <StyledWrapper className="flex flex-col h-full relative">
-      <div className="px-4">
+      <div className="px-4" data-testid="response-pane-tabs">
         <ResponsiveTabs
           tabs={allTabs}
           activeTab={focusedTab.responsePaneTab}
@@ -288,6 +308,8 @@ const ResponsePane = ({
         <div className="flex-1 min-h-0 min-w-0 overflow-auto">
           {item?.response ? (
             <>{getTabPanel(focusedTab.responsePaneTab)}</>
+          ) : focusedTab.responsePaneTab === 'timeline' && timelineCount ? (
+            <Timeline item={item} collection={collection} />
           ) : null}
         </div>
       </section>

--- a/src/webview/components/ResponsePane/timeline-utils.spec.ts
+++ b/src/webview/components/ResponsePane/timeline-utils.spec.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => ({}));
+
+const { getItemTimeline } = await import('./timeline-utils');
+
+const inheritingItem = (uid: string) => ({
+  uid,
+  name: uid,
+  type: 'http-request',
+  request: { url: 'http://example.com', method: 'GET', auth: { mode: 'inherit' } }
+});
+
+const makeCollection = (items: any[], timeline: any[]): any => ({
+  uid: 'col-1',
+  name: 'Test',
+  pathname: '/test',
+  items,
+  timeline,
+  root: { request: { auth: { mode: 'oauth2' } } }
+});
+
+describe('getItemTimeline', () => {
+  test('returns only entries for the given item, newest first', () => {
+    const collection = makeCollection(
+      [inheritingItem('req-1'), inheritingItem('req-2')],
+      [
+        { type: 'request', itemUid: 'req-1', folderUid: null, timestamp: 1, data: {} },
+        { type: 'request', itemUid: 'req-2', folderUid: null, timestamp: 2, data: {} },
+        { type: 'request', itemUid: 'req-1', folderUid: null, timestamp: 3, data: {} }
+      ]
+    );
+
+    const result = getItemTimeline(collection, inheritingItem('req-1') as any);
+
+    expect(result.map((e) => e.timestamp)).toEqual([3, 1]);
+  });
+
+  test('includes a collection-level oauth2 entry recorded against a sibling request', () => {
+    const collection = makeCollection(
+      [inheritingItem('req-1'), inheritingItem('req-2')],
+      [{ type: 'oauth2', itemUid: 'req-1', folderUid: null, timestamp: 1, data: { debugInfo: [] } }]
+    );
+
+    const result = getItemTimeline(collection, inheritingItem('req-2') as any);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('oauth2');
+  });
+
+  test('excludes an oauth2 entry when the item does not inherit auth', () => {
+    const ownAuthItem = {
+      uid: 'req-2',
+      name: 'req-2',
+      type: 'http-request',
+      request: { url: 'http://example.com', method: 'GET', auth: { mode: 'basic' } }
+    };
+    const collection = makeCollection(
+      [inheritingItem('req-1'), ownAuthItem],
+      [{ type: 'oauth2', itemUid: 'req-1', folderUid: null, timestamp: 1, data: { debugInfo: [] } }]
+    );
+
+    const result = getItemTimeline(collection, ownAuthItem as any);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test('returns an empty array when the collection has no timeline', () => {
+    expect(getItemTimeline(undefined, inheritingItem('req-1') as any)).toEqual([]);
+    expect(getItemTimeline({ uid: 'col-1' } as any, inheritingItem('req-1') as any)).toEqual([]);
+  });
+});

--- a/src/webview/components/ResponsePane/timeline-utils.ts
+++ b/src/webview/components/ResponsePane/timeline-utils.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import { get } from 'lodash';
+import { findItemInCollection, findParentItemInCollection } from 'utils/collections/index';
+import type { AppCollection, AppItem } from '@bruno-types';
+
+type ItemTimeline = NonNullable<AppCollection['timeline']>;
+
+const getEffectiveAuthSource = (collection: any, item: any) => {
+  const authMode = item.draft ? get(item, 'draft.request.auth.mode') : get(item, 'request.auth.mode');
+  if (authMode !== 'inherit') return null;
+
+  const collectionRoot = collection?.draft?.root || collection?.root || {};
+  let effectiveSource = {
+    type: 'collection',
+    uid: collection.uid,
+    auth: get(collectionRoot, 'request.auth')
+  };
+
+  const path = [];
+  let currentItem = findItemInCollection(collection, item?.uid);
+  while (currentItem) {
+    path.unshift(currentItem);
+    currentItem = findParentItemInCollection(collection, currentItem?.uid);
+  }
+
+  for (const i of [...path].reverse()) {
+    if (i.type === 'folder') {
+      const folderAuth = get(i, 'root.request.auth');
+      if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
+        effectiveSource = { type: 'folder', uid: i.uid, auth: folderAuth };
+        break;
+      }
+    }
+  }
+
+  return effectiveSource;
+};
+
+/**
+ * Newest first. Includes OAuth2 entries recorded against an ancestor when this item inherits its
+ * auth, so the token calls that produced its credentials are visible. The tab badge and the empty
+ * state must use this too, or an inherited-only timeline renders rows the count says are not there.
+ */
+export const getItemTimeline = (collection: AppCollection | undefined, item: AppItem): ItemTimeline => {
+  if (!collection?.timeline?.length) {
+    return [];
+  }
+
+  const authSource = getEffectiveAuthSource(collection, item);
+
+  return collection.timeline
+    .filter((entry) => {
+      if (entry.itemUid === item.uid) return true;
+
+      if (entry.type === 'oauth2' && authSource) {
+        if (authSource.type === 'folder' && entry.folderUid === authSource.uid) return true;
+        if (authSource.type === 'collection' && !entry.folderUid) return true;
+      }
+
+      return false;
+    })
+    .sort((a, b) => b.timestamp - a.timestamp);
+};
+
+export const useItemTimeline = (collection: AppCollection | undefined, item: AppItem): ItemTimeline =>
+  useMemo(() => getItemTimeline(collection, item), [collection?.timeline, item]);

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -453,7 +453,8 @@ const useIpcEvents = () => {
         folderUid: credData.folderUid || null,
         url: credData.url || '',
         credentialsId: credData.credentialsId || 'credentials',
-        credentials: credData.credentials || {}
+        credentials: credData.credentials || {},
+        debugInfo: credData.debugInfo
       };
       dispatch(collectionAddOauth2CredentialsByUrl(payload));
     });

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -9,7 +9,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import trim from 'lodash/trim';
 import type { RootState, AppDispatch } from 'providers/ReduxStore/index';
-import type { AppCollection, AppItem } from '@bruno-types';
+import type { AppCollection, AppItem, RequestSent } from '@bruno-types';
 import { variableNameRegex } from 'utils/common/regex';
 
 /** Redux thunk action creator type */
@@ -118,13 +118,14 @@ const safeCloneCollection = (collection: any): any => {
   };
 
   try {
-    const { items, ...collectionWithoutItems } = collection;
+    // `timeline` is UI-only and unbounded; the extension host never reads it back.
+    const { items, timeline, ...collectionWithoutItems } = collection;
     const clonedBase = JSON.parse(JSON.stringify(collectionWithoutItems));
     clonedBase.items = cloneItems(items);
     return clonedBase;
   } catch {
     // Fallback: create a shallow copy and clone items separately
-    const cloned = { ...collection };
+    const { timeline, ...cloned } = collection;
     cloned.items = cloneItems(collection.items);
     return cloned;
   }
@@ -780,23 +781,12 @@ export const sendRequest = (item: AppItem, collectionUid: string): ThunkAction<P
     } else {
       sendNetworkRequest(itemCopy, collectionCopy, environment, collectionCopy.runtimeVariables)
         .then((response: Record<string, unknown>) => {
-          interface TimelineEntry {
-            timestamp: Date | number;
-            [key: string]: unknown;
-          }
-          const serializedResponse = {
-            ...response,
-            timeline: (response.timeline as TimelineEntry[] | undefined)?.map((entry) => ({
-              ...entry,
-              timestamp: entry.timestamp instanceof Date ? entry.timestamp.getTime() : entry.timestamp
-            }))
-          };
-
           dispatch(
             responseReceived({
               itemUid,
               collectionUid,
-              response: serializedResponse
+              response,
+              requestSent: response.requestSent as RequestSent | undefined
             })
           );
         })

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -22,7 +22,7 @@ import { splitOnFirst, parsePathParams } from 'utils/url';
 import { parseQueryParams, getDataTypeFromValue } from '@usebruno/common/utils';
 // @ts-expect-error - @usebruno/common/utils may not export buildQueryString in types
 import { buildQueryString as stringifyQueryParams } from '@usebruno/common/utils';
-import type { AppCollection, AppItem, UID, KeyValue, DraftRequestBody, HttpRequestParam, ResponseState, AuthMode, OAuth2CredentialEntry } from '@bruno-types';
+import type { AppCollection, AppItem, UID, KeyValue, DraftRequestBody, HttpRequestParam, ResponseState, AuthMode, OAuth2CredentialEntry, TimelineEntry } from '@bruno-types';
 import type {
   CollectionUidPayload,
   ItemUidPayload,
@@ -178,6 +178,36 @@ const initialState: CollectionsState = {
 
 const getRequestFromItem = (item: AppItem) => {
   return item.draft?.request || item.request;
+};
+
+const pushTimelineEntry = (collection: AppCollection, entry: Omit<TimelineEntry, 'id' | 'collectionUid'>) => {
+  if (!collection.timeline) {
+    collection.timeline = [];
+  }
+  collection.timeline.push({ id: uuid(), collectionUid: collection.uid, ...entry });
+};
+
+const pushStreamingTimelineEntry = (
+  collection: AppCollection,
+  item: AppItem,
+  eventType: string,
+  response: unknown,
+  eventData: unknown
+) => {
+  const timestamp = Date.now();
+  pushTimelineEntry(collection, {
+    type: 'request',
+    eventType,
+    folderUid: null,
+    itemUid: item.uid,
+    timestamp,
+    data: {
+      request: item.requestSent || item.request,
+      response,
+      eventData,
+      timestamp
+    }
+  });
 };
 
 const ensureDraft = (item: AppItem) => {
@@ -1980,16 +2010,44 @@ export const collectionsSlice = createSlice({
     },
 
     responseReceived: (state, action: PayloadAction<ResponseReceivedPayload>) => {
-      const { collectionUid, itemUid, response } = action.payload;
+      const { collectionUid, itemUid, response, requestSent } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection) {
-        const item = findItemInCollection(collection, itemUid);
-        if (item) {
-          item.response = response;
-          item.requestState = 'received';
-          item.loading = false;
-        }
+      if (!collection) {
+        return;
       }
+
+      const item = findItemInCollection(collection, itemUid);
+      if (!item) {
+        return;
+      }
+
+      item.response = response;
+      item.requestState = 'received';
+      item.loading = false;
+
+      if (requestSent) {
+        item.requestSent = requestSent;
+      }
+
+      // A cancelled request resolves with a null response, so there is nothing to record.
+      if (!response) {
+        return;
+      }
+
+      const timelineRequest = requestSent || item.requestSent || item.request;
+      const timestamp = (timelineRequest as { timestamp?: number } | null)?.timestamp || Date.now();
+
+      pushTimelineEntry(collection, {
+        type: 'request',
+        folderUid: null,
+        itemUid: item.uid,
+        timestamp,
+        data: {
+          request: timelineRequest,
+          response,
+          timestamp
+        }
+      });
     },
 
     responseCleared: (state, action: PayloadAction<ResponseClearedPayload>) => {
@@ -2073,10 +2131,8 @@ export const collectionsSlice = createSlice({
     clearRequestTimeline: (state, action: PayloadAction<ClearRequestTimelinePayload>) => {
       const { collectionUid, itemUid } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
-      if (collection && itemUid) {
-        const item = findItemInCollection(collection, itemUid);
-        if (item) {
-        }
+      if (collection && itemUid && collection.timeline) {
+        collection.timeline = collection.timeline.filter((entry) => entry?.itemUid !== itemUid);
       }
     },
 
@@ -2139,6 +2195,10 @@ export const collectionsSlice = createSlice({
           if (item) {
             item.status = 'completed';
             item.responseReceived = action.payload.responseReceived;
+            // The request-sent event fires before interpolation; this one carries what was actually sent.
+            if (action.payload.requestSent) {
+              item.requestSent = action.payload.requestSent;
+            }
           }
         }
 
@@ -2306,6 +2366,8 @@ export const collectionsSlice = createSlice({
           timestamp: Date.now()
         } as any;
       }
+
+      pushStreamingTimelineEntry(collection, item, eventType, item.response, eventData);
     },
 
     grpcResponseReceived: (state, action: PayloadAction<GrpcResponseReceivedPayload>) => {
@@ -2384,6 +2446,8 @@ export const collectionsSlice = createSlice({
       }
 
       item.response = updatedResponse;
+
+      pushStreamingTimelineEntry(collection, item, eventType, updatedResponse, eventData);
     },
 
     runWsRequestEvent: (state, action: PayloadAction<RunGrpcRequestEventPayload>) => {
@@ -2414,6 +2478,8 @@ export const collectionsSlice = createSlice({
           trailers: []
         } as any;
       }
+
+      pushStreamingTimelineEntry(collection, item, eventType, item.response, eventData);
     },
 
     wsResponseReceived: (state, action: PayloadAction<WsResponseReceivedPayload>) => {
@@ -2537,6 +2603,20 @@ export const collectionsSlice = createSlice({
       // Add the new credential
       filtered.push({ collectionUid, folderUid: folderUid || null, itemUid: itemUid || null, url, credentials, credentialsId, debugInfo });
       collection.oauth2Credentials = filtered;
+
+      if (!debugInfo?.data?.length) {
+        return;
+      }
+
+      pushTimelineEntry(collection, {
+        type: 'oauth2',
+        folderUid: folderUid || null,
+        itemUid: itemUid || '',
+        timestamp: Date.now(),
+        data: {
+          debugInfo: debugInfo.data
+        }
+      });
     },
 
     collectionClearOauth2CredentialsByUrl: (state, action: PayloadAction<CollectionClearOauth2CredentialsByUrlPayload>) => {

--- a/src/webview/providers/ReduxStore/slices/collections/timeline.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/timeline.spec.ts
@@ -1,0 +1,261 @@
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('vscode', () => ({}));
+
+const {
+  default: collectionsReducer,
+  responseReceived,
+  clearRequestTimeline,
+  clearTimeline,
+  collectionAddOauth2CredentialsByUrl,
+  runGrpcRequestEvent,
+  grpcResponseReceived,
+  runWsRequestEvent
+} = await import('./index');
+
+function makeState(items: any[], timeline?: any[]): any {
+  return {
+    collections: [{
+      uid: 'col-1',
+      name: 'Test',
+      pathname: '/test',
+      items,
+      environments: [],
+      brunoConfig: {},
+      ...(timeline ? { timeline } : {})
+    }],
+    collectionSortOrder: 'default',
+    activeConnections: {}
+  };
+}
+
+const makeItem = (uid: string) => ({
+  uid,
+  name: uid,
+  type: 'http-request',
+  request: { url: 'http://example.com', method: 'GET' }
+});
+
+const response = { status: 200, statusText: 'OK', headers: {}, data: { ok: true }, duration: 12, size: 9 };
+
+describe('responseReceived', () => {
+  test('appends a request entry to the collection timeline', () => {
+    const state = makeState([makeItem('req-1')]);
+    const requestSent = { url: 'http://example.com', method: 'GET', headers: {}, timestamp: 1000 };
+
+    const result = collectionsReducer(state, responseReceived({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      response,
+      requestSent
+    }));
+
+    const timeline = result.collections[0].timeline;
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]).toMatchObject({
+      type: 'request',
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      timestamp: 1000,
+      data: { request: requestSent, response, timestamp: 1000 }
+    });
+    expect(result.collections[0].items[0].requestSent).toEqual(requestSent);
+  });
+
+  test('falls back to the item request when no requestSent is supplied', () => {
+    const state = makeState([makeItem('req-1')]);
+
+    const result = collectionsReducer(state, responseReceived({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      response
+    }));
+
+    expect(result.collections[0].timeline[0].data.request).toEqual({
+      url: 'http://example.com',
+      method: 'GET'
+    });
+  });
+
+  test('accumulates entries across repeated sends', () => {
+    let state: any = makeState([makeItem('req-1')]);
+
+    state = collectionsReducer(state, responseReceived({ collectionUid: 'col-1', itemUid: 'req-1', response }));
+    state = collectionsReducer(state, responseReceived({ collectionUid: 'col-1', itemUid: 'req-1', response }));
+
+    expect(state.collections[0].timeline).toHaveLength(2);
+  });
+
+  test('does not add an entry for a cancelled request', () => {
+    const state = makeState([makeItem('req-1')]);
+
+    const result = collectionsReducer(state, responseReceived({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      response: null
+    }));
+
+    expect(result.collections[0].timeline ?? []).toHaveLength(0);
+    expect(result.collections[0].items[0].response).toBeNull();
+  });
+});
+
+describe('clearRequestTimeline', () => {
+  test('removes only the entries belonging to the given item', () => {
+    const state = makeState(
+      [makeItem('req-1'), makeItem('req-2')],
+      [
+        { type: 'request', itemUid: 'req-1', timestamp: 1, data: {} },
+        { type: 'request', itemUid: 'req-2', timestamp: 2, data: {} },
+        { type: 'oauth2', itemUid: 'req-1', timestamp: 3, data: {} }
+      ]
+    );
+
+    const result = collectionsReducer(state, clearRequestTimeline({
+      collectionUid: 'col-1',
+      itemUid: 'req-1'
+    }));
+
+    expect(result.collections[0].timeline).toHaveLength(1);
+    expect(result.collections[0].timeline[0].itemUid).toBe('req-2');
+  });
+});
+
+describe('clearTimeline', () => {
+  test('empties the whole collection timeline', () => {
+    const state = makeState([makeItem('req-1')], [{ type: 'request', itemUid: 'req-1', timestamp: 1, data: {} }]);
+
+    const result = collectionsReducer(state, clearTimeline({ collectionUid: 'col-1' }));
+
+    expect(result.collections[0].timeline).toEqual([]);
+  });
+});
+
+describe('streaming timelines', () => {
+  const makeStreamingItem = (uid: string, type: string) => ({
+    uid,
+    name: uid,
+    type,
+    request: { url: 'grpc://localhost:50051', method: 'SayHello', methodType: 'server-streaming' }
+  });
+
+  test('gRPC records one entry per protocol event, tagged with the event type', () => {
+    let state: any = makeState([makeStreamingItem('grpc-1', 'grpc-request')]);
+    const payload = { collectionUid: 'col-1', itemUid: 'grpc-1' };
+
+    state = collectionsReducer(state, runGrpcRequestEvent({
+      ...payload,
+      eventType: 'request',
+      eventData: { url: 'grpc://localhost:50051', method: 'SayHello' }
+    }));
+    state = collectionsReducer(state, grpcResponseReceived({
+      ...payload,
+      eventType: 'metadata',
+      eventData: { metadata: [{ name: 'x-trace', value: 'abc' }] }
+    }));
+    state = collectionsReducer(state, grpcResponseReceived({
+      ...payload,
+      eventType: 'response',
+      eventData: { res: { greeting: 'hello' } }
+    }));
+    state = collectionsReducer(state, grpcResponseReceived({
+      ...payload,
+      eventType: 'status',
+      eventData: { status: { code: 0 } }
+    }));
+
+    const timeline = state.collections[0].timeline;
+    expect(timeline.map((e: any) => e.eventType)).toEqual(['request', 'metadata', 'response', 'status']);
+    expect(timeline.every((e: any) => e.type === 'request' && e.itemUid === 'grpc-1')).toBe(true);
+    expect(timeline[1].data.eventData).toEqual({ metadata: [{ name: 'x-trace', value: 'abc' }] });
+  });
+
+  test('each gRPC stream message adds its own entry rather than replacing the previous one', () => {
+    let state: any = makeState([makeStreamingItem('grpc-1', 'grpc-request')]);
+
+    for (const greeting of ['one', 'two', 'three']) {
+      state = collectionsReducer(state, grpcResponseReceived({
+        collectionUid: 'col-1',
+        itemUid: 'grpc-1',
+        eventType: 'response',
+        eventData: { res: { greeting } }
+      }));
+    }
+
+    expect(state.collections[0].timeline).toHaveLength(3);
+    expect(state.collections[0].items[0].response.responses).toHaveLength(3);
+  });
+
+  test('WebSocket records the outbound connect event', () => {
+    const state = makeState([makeStreamingItem('ws-1', 'ws-request')]);
+
+    const result = collectionsReducer(state, runWsRequestEvent({
+      collectionUid: 'col-1',
+      itemUid: 'ws-1',
+      eventType: 'request',
+      eventData: { url: 'ws://localhost:8080' }
+    }));
+
+    expect(result.collections[0].timeline).toHaveLength(1);
+    expect(result.collections[0].timeline[0]).toMatchObject({ type: 'request', eventType: 'request', itemUid: 'ws-1' });
+  });
+
+  test('clearing a streaming request drops all of its event entries', () => {
+    let state: any = makeState([makeStreamingItem('grpc-1', 'grpc-request'), makeStreamingItem('grpc-2', 'grpc-request')]);
+
+    state = collectionsReducer(state, runGrpcRequestEvent({
+      collectionUid: 'col-1', itemUid: 'grpc-1', eventType: 'request', eventData: {}
+    }));
+    state = collectionsReducer(state, grpcResponseReceived({
+      collectionUid: 'col-1', itemUid: 'grpc-1', eventType: 'status', eventData: { status: { code: 0 } }
+    }));
+    state = collectionsReducer(state, runGrpcRequestEvent({
+      collectionUid: 'col-1', itemUid: 'grpc-2', eventType: 'request', eventData: {}
+    }));
+
+    const result = collectionsReducer(state, clearRequestTimeline({ collectionUid: 'col-1', itemUid: 'grpc-1' }));
+
+    expect(result.collections[0].timeline).toHaveLength(1);
+    expect(result.collections[0].timeline[0].itemUid).toBe('grpc-2');
+  });
+});
+
+describe('collectionAddOauth2CredentialsByUrl', () => {
+  test('adds an oauth2 entry when debug info is present', () => {
+    const state = makeState([makeItem('req-1')]);
+    const debugInfo = { data: [{ request: { url: 'http://token' }, response: { status: 200 } }] };
+
+    const result = collectionsReducer(state, collectionAddOauth2CredentialsByUrl({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      folderUid: null,
+      url: 'http://token',
+      credentialsId: 'default',
+      credentials: { access_token: 'abc' },
+      debugInfo
+    }));
+
+    expect(result.collections[0].timeline).toHaveLength(1);
+    expect(result.collections[0].timeline[0]).toMatchObject({
+      type: 'oauth2',
+      itemUid: 'req-1',
+      data: { debugInfo: debugInfo.data }
+    });
+  });
+
+  test('adds no entry when there is no debug info', () => {
+    const state = makeState([makeItem('req-1')]);
+
+    const result = collectionsReducer(state, collectionAddOauth2CredentialsByUrl({
+      collectionUid: 'col-1',
+      itemUid: 'req-1',
+      folderUid: null,
+      url: 'http://token',
+      credentialsId: 'default',
+      credentials: { access_token: 'abc' }
+    }));
+
+    expect(result.collections[0].timeline ?? []).toHaveLength(0);
+    expect(result.collections[0].oauth2Credentials).toHaveLength(1);
+  });
+});

--- a/src/webview/providers/ReduxStore/slices/collections/types.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/types.ts
@@ -2,7 +2,7 @@
  * Payload types for collection slice reducers
  */
 import type { UID, KeyValue, AuthMode, BrunoVariableDataType } from '@bruno-types';
-import type { AppCollection, AppItem, SecurityConfig } from '@bruno-types';
+import type { AppCollection, AppItem, RequestSent, SecurityConfig } from '@bruno-types';
 
 export interface CollectionUidPayload {
   collectionUid: UID;
@@ -107,7 +107,8 @@ export interface ProcessEnvUpdateEventPayload extends CollectionUidPayload {
 export interface RequestCancelledPayload extends ItemUidPayload {}
 
 export interface ResponseReceivedPayload extends ItemUidPayload {
-  response: Record<string, unknown>;
+  response: Record<string, unknown> | null;
+  requestSent?: RequestSent;
 }
 
 export interface RunGrpcRequestEventPayload extends ItemUidPayload {
@@ -551,7 +552,7 @@ export interface RunFolderEventPayload extends CollectionUidPayload {
   isRecursive?: boolean;
   cancelTokenUid?: UID;
   error?: string;
-  requestSent?: Record<string, unknown>;
+  requestSent?: RequestSent;
   responseReceived?: Record<string, unknown>;
   testResults?: unknown[];
   preRequestTestResults?: unknown[];

--- a/src/webview/ui/ResponsiveTabs/index.tsx
+++ b/src/webview/ui/ResponsiveTabs/index.tsx
@@ -202,6 +202,7 @@ const ResponsiveTabs = ({
         key={tab.key}
         role="tab"
         aria-selected={isActive}
+        data-testid={`responsive-tab-${tab.key}`}
         className={classnames('tab select-none', tab.key, { active: isActive })}
         onClick={() => handleTabSelect(tab.key)}
       >

--- a/src/webview/utils/network/index.tsx
+++ b/src/webview/utils/network/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { resolvePath } from 'utils/filesystem';
+import type { RequestSent, ResponseTimeline } from '@bruno-types';
 
-// Response types for network operations
 interface HttpResponse {
   error?: string | Error;
   data?: string;
@@ -12,7 +12,8 @@ interface HttpResponse {
   status?: number;
   statusText?: string;
   duration?: number;
-  timeline?: unknown[];
+  timeline?: ResponseTimeline;
+  requestSent?: RequestSent;
   stream?: unknown;
 }
 
@@ -55,6 +56,7 @@ export const sendNetworkRequest = async (item: any, collection: any, environment
             statusText: response.statusText,
             duration: response.duration,
             timeline: response.timeline,
+            requestSent: response.requestSent,
             stream: response.stream,
             // Interpolated URL that was sent, used as the HTML-preview <base href>
             requestUrl: (response as { requestUrl?: string }).requestUrl

--- a/tests/e2e/specs/timeline.spec.ts
+++ b/tests/e2e/specs/timeline.spec.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import { openBrunoSidebar, createCollection, openRequest, sendRequest, findCollectionDir } from '../utils/page/actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+// The Timeline tab sits inline or in the overflow menu depending on pane width, and is briefly in
+// neither while the pane re-measures. Each step is bounded so a stale attempt can't eat the retries.
+async function openTimelineTab(editor: Frame): Promise<void> {
+  const responseTabs = editor.locator('[data-testid="response-pane-tabs"]');
+  const tab = responseTabs.locator('[data-testid="responsive-tab-timeline"]');
+
+  await expect(async () => {
+    if (await tab.count() > 0) {
+      await tab.click({ timeout: 2_000 });
+    } else {
+      await responseTabs.locator('.more-tabs').click({ timeout: 2_000 });
+      await editor.locator('[role="menuitem"]').filter({ hasText: 'Timeline' }).first().click({ timeout: 2_000 });
+    }
+    await expect(editor.locator('[data-testid="timeline-container"]')).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 20_000 });
+}
+
+// Response actions collapse into a "More actions" dropdown when the pane is too narrow.
+async function clearResponse(editor: Frame): Promise<void> {
+  const inlineButton = editor.locator('[data-testid="response-clear-btn"]');
+  const menuTrigger = editor.locator('[data-testid="response-actions-menu"]');
+
+  await expect(async () => {
+    if (await inlineButton.isVisible()) {
+      await inlineButton.click({ timeout: 2_000 });
+    } else {
+      await menuTrigger.click({ timeout: 2_000 });
+      await editor.locator('[data-testid="response-actions-menu-clear-response"]').click({ timeout: 2_000 });
+    }
+    await expect(editor.locator('[data-testid="response-status-code"]')).toHaveCount(0, { timeout: 2_000 });
+  }).toPass({ timeout: 20_000 });
+}
+
+async function writeRequest(collectionDir: string, name: string, url: string): Promise<void> {
+  fs.writeFileSync(path.join(collectionDir, `${name}.bru`), [
+    'meta {', `  name: ${name}`, '  type: http', '  seq: 1', '}', '',
+    'get {', `  url: ${url}`, '  body: none', '  auth: none', '}', ''
+  ].join('\n'), 'utf8');
+}
+
+async function setupCollection(page: any, name: string, tmpDir: string): Promise<{ sidebar: Frame; collectionDir: string }> {
+  const sidebar = await openBrunoSidebar(page);
+  await createCollection(page, sidebar, name, tmpDir, 'bru');
+  return { sidebar, collectionDir: findCollectionDir(tmpDir) };
+}
+
+test.describe('Response timeline', () => {
+  test('records each send and can be cleared', async ({ page, tmpDir }) => {
+    const collectionName = 'Timeline Collection';
+    const { sidebar, collectionDir } = await setupCollection(page, collectionName, tmpDir);
+
+    fs.mkdirSync(path.join(collectionDir, 'environments'), { recursive: true });
+    fs.writeFileSync(path.join(collectionDir, 'environments', 'Local.bru'), `vars {\n  host: ${TEST_SERVER}\n}\n`, 'utf8');
+    await writeRequest(collectionDir, 'Ping', '{{host}}/ping');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Ping');
+
+    await editor.locator('[data-testid="environment-selector-trigger"]').click();
+    await editor.locator('.dropdown-item').filter({ hasText: 'Local' }).first().click();
+
+    await sendRequest(editor, 200);
+    await openTimelineTab(editor);
+
+    const entries = editor.locator('[data-testid="timeline-item"]');
+    const url = editor.locator('[data-testid="timeline-url"]').first();
+    const header = editor.locator('[data-testid="timeline-item-header"]').first();
+    const detail = editor.locator('[data-testid="timeline-item-detail"]').first();
+
+    await expect(entries).toHaveCount(1, { timeout: 10_000 });
+    await expect(url).toHaveText(`${TEST_SERVER}/ping`, { timeout: 10_000 });
+
+    await header.click();
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+
+    await sendRequest(editor, 200);
+    await openTimelineTab(editor);
+    await expect(entries).toHaveCount(2, { timeout: 10_000 });
+
+    await editor.getByTitle('Clear Timeline').click();
+    await expect(entries).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  test('clearing the response keeps the timeline', async ({ page, tmpDir }) => {
+    const collectionName = 'Timeline Survives Clear';
+    const { sidebar, collectionDir } = await setupCollection(page, collectionName, tmpDir);
+
+    await writeRequest(collectionDir, 'Ping', `${TEST_SERVER}/ping`);
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Ping');
+
+    await sendRequest(editor, 200);
+
+    // The Timeline tab swaps these actions out for Clear Timeline, so clear from the Response tab.
+    await clearResponse(editor);
+
+    await openTimelineTab(editor);
+    await expect(editor.locator('[data-testid="timeline-item"]')).toHaveCount(1, { timeout: 10_000 });
+  });
+
+  test('a failed request shows the axios error code as its status', async ({ page, tmpDir }) => {
+    const collectionName = 'Timeline Errors';
+    const { sidebar, collectionDir } = await setupCollection(page, collectionName, tmpDir);
+
+    // Malformed scheme: fails inside axios before any response. Loopback host so a change in
+    // axios' URL parsing can never send this to the public internet.
+    await writeRequest(collectionDir, 'Bad', 'gethttps://127.0.0.1:8081/sample.mp4');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Bad');
+    await editor.locator('#send-request').click();
+
+    await openTimelineTab(editor);
+
+    // Desktop shows the error code here, not the raw axios message.
+    await expect(editor.locator('[data-testid="timeline-item"]').first())
+      .toContainText('ERR_BAD_REQUEST', { timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Description

**Jira:** VSCODE-11
The VS Code app is missing timeline in the response panel. There is no way to view previous requests, inspect the exact request that was sent (with variables resolved and auth/cookie headers applied), or see any token requests triggered during authentication.

## Root cause
The response was not captured after the request was resolved.

## Solution

The extension now captures the resolved request along with the response and keeps each send as a separate Timeline entry, including network, gRPC, WebSocket, and OAuth2 events. A Timeline tab with a count and Clear Timeline action has also been added to all response panes.

## Recordings / Screenshots

**Before**

<img width="1414" height="769" alt="Screenshot 2026-08-05 at 3 45 39 PM" src="https://github.com/user-attachments/assets/4f3858b6-1069-4af4-9a86-2fcfc5d780a1" />

**After**

<img width="1465" height="598" alt="Screenshot 2026-07-31 at 1 38 52 PM" src="https://github.com/user-attachments/assets/27207dc4-04f1-4b5a-a354-7ee326818a6e" />
