### PR TITLE
fix(request) - support file upload in POST API request

### DIFF
--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -8,6 +8,7 @@ import { saveCancelToken, deleteCancelToken, cancelTokens } from '../../utils/ca
 import { cookiesStore } from '../../store/cookies';
 import { getCookieStringForUrl, saveCookies } from '../../utils/cookies';
 import { createFormData, formatMultipartData } from '../../utils/form-data';
+import { readFileBody, getSelectedFileBodyEntry, DEFAULT_FILE_BODY_CONTENT_TYPE } from '../../utils/file-body';
 import { getPreferences } from '../../store/preferences';
 import { getProcessEnvVars } from '../../store/process-env';
 import { getCertsAndProxyConfig } from './cert-utils';
@@ -109,6 +110,7 @@ interface BrunoRequest {
     xml?: string;
     formUrlEncoded?: Array<{ name: string; value: string; enabled?: boolean }>;
     multipartForm?: Array<{ name: string; value: string; type?: string; enabled?: boolean; contentType?: string }>;
+    file?: Array<{ filePath?: string | null; contentType?: string | null; selected?: boolean }>;
     graphql?: {
       query?: string;
       variables?: string;
@@ -348,6 +350,17 @@ const executeRequest = async (
       preparedRequest.headers = { ...preparedRequest.headers, ...formHeaders };
       (preparedRequest as unknown as { _originalMultipartData?: unknown })._originalMultipartData = multipartFields;
       (preparedRequest as unknown as { collectionPath?: string }).collectionPath = context.collectionPath;
+    }
+
+    if (request.body?.mode === 'file') {
+      const fileBody = readFileBody(request.body.file, context.collectionPath);
+      preparedRequest.data = fileBody?.data;
+      if (fileBody) {
+        const contentTypeSet = Object.keys(preparedRequest.headers).some((key) => key.toLowerCase() === 'content-type');
+        if (!contentTypeSet) {
+          preparedRequest.headers['content-type'] = fileBody.contentType;
+        }
+      }
     }
 
     const preferences = getPreferences();
@@ -728,6 +741,15 @@ const prepareItemRequest = (item: unknown, collection: unknown): BrunoRequest =>
       case 'multipartForm':
         headers.push({ name: 'content-type', value: 'multipart/form-data', enabled: true });
         break;
+      case 'file': {
+        const selectedFile = getSelectedFileBodyEntry(body.file);
+        headers.push({
+          name: 'content-type',
+          value: (selectedFile?.contentType || '').trim() || DEFAULT_FILE_BODY_CONTENT_TYPE,
+          enabled: true
+        });
+        break;
+      }
       case 'graphql':
         headers.push({ name: 'content-type', value: 'application/json', enabled: true });
         break;

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -353,7 +353,7 @@ const executeRequest = async (
     }
 
     if (request.body?.mode === 'file') {
-      const fileBody = readFileBody(request.body.file, context.collectionPath);
+      const fileBody = await readFileBody(request.body.file, context.collectionPath);
       preparedRequest.data = fileBody?.data;
       if (fileBody) {
         const contentTypeSet = Object.keys(preparedRequest.headers).some((key) => key.toLowerCase() === 'content-type');

--- a/src/extension/utils/file-body.ts
+++ b/src/extension/utils/file-body.ts
@@ -25,7 +25,10 @@ export const getSelectedFileBodyEntry = (files: FileBodyEntry[] | null | undefin
 /**
  * Reads the selected file as the raw request body.
  */
-export const readFileBody = (files: FileBodyEntry[] | null | undefined, collectionPath: string): FileBody | null => {
+export const readFileBody = async (
+  files: FileBodyEntry[] | null | undefined,
+  collectionPath: string
+): Promise<FileBody | null> => {
   const entry = getSelectedFileBodyEntry(files);
   if (!entry) {
     return null;
@@ -34,12 +37,13 @@ export const readFileBody = (files: FileBodyEntry[] | null | undefined, collecti
   const filePath = (entry.filePath as string).trim();
   const resolvedPath = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(collectionPath, filePath);
 
-  if (!fs.existsSync(resolvedPath) || !fs.statSync(resolvedPath).isFile()) {
+  const stats = await fs.promises.stat(resolvedPath).catch((): null => null);
+  if (!stats?.isFile()) {
     throw new Error(`File not found for request body: ${filePath}`);
   }
 
   return {
-    data: fs.readFileSync(resolvedPath),
+    data: await fs.promises.readFile(resolvedPath),
     contentType: (entry.contentType || '').trim() || DEFAULT_FILE_BODY_CONTENT_TYPE
   };
 };

--- a/src/extension/utils/file-body.ts
+++ b/src/extension/utils/file-body.ts
@@ -14,11 +14,6 @@ export interface FileBody {
 
 export const DEFAULT_FILE_BODY_CONTENT_TYPE = 'application/octet-stream';
 
-/**
- * File / Binary body mode holds a list of files of which exactly one is sent.
- * Falls back to the first file with a path — the radio button in the request pane
- * shows the first row as picked before the user ever clicks it.
- */
 export const getSelectedFileBodyEntry = (files: FileBodyEntry[] | null | undefined): FileBodyEntry | undefined => {
   const candidates = (files || []).filter((file) => typeof file?.filePath === 'string' && file.filePath.trim().length > 0);
   if (!candidates.length) {
@@ -28,8 +23,7 @@ export const getSelectedFileBodyEntry = (files: FileBodyEntry[] | null | undefin
 };
 
 /**
- * Reads the selected file as the raw request body. Paths are stored relative to the
- * collection when the file lives inside it, absolute otherwise.
+ * Reads the selected file as the raw request body.
  */
 export const readFileBody = (files: FileBodyEntry[] | null | undefined, collectionPath: string): FileBody | null => {
   const entry = getSelectedFileBodyEntry(files);

--- a/src/extension/utils/file-body.ts
+++ b/src/extension/utils/file-body.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface FileBodyEntry {
+  filePath?: string | null;
+  contentType?: string | null;
+  selected?: boolean;
+}
+
+export interface FileBody {
+  data: Buffer;
+  contentType: string;
+}
+
+export const DEFAULT_FILE_BODY_CONTENT_TYPE = 'application/octet-stream';
+
+/**
+ * File / Binary body mode holds a list of files of which exactly one is sent.
+ * Falls back to the first file with a path — the radio button in the request pane
+ * shows the first row as picked before the user ever clicks it.
+ */
+export const getSelectedFileBodyEntry = (files: FileBodyEntry[] | null | undefined): FileBodyEntry | undefined => {
+  const candidates = (files || []).filter((file) => typeof file?.filePath === 'string' && file.filePath.trim().length > 0);
+  if (!candidates.length) {
+    return undefined;
+  }
+  return candidates.find((file) => file.selected) || candidates[0];
+};
+
+/**
+ * Reads the selected file as the raw request body. Paths are stored relative to the
+ * collection when the file lives inside it, absolute otherwise.
+ */
+export const readFileBody = (files: FileBodyEntry[] | null | undefined, collectionPath: string): FileBody | null => {
+  const entry = getSelectedFileBodyEntry(files);
+  if (!entry) {
+    return null;
+  }
+
+  const filePath = (entry.filePath as string).trim();
+  const resolvedPath = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(collectionPath, filePath);
+
+  if (!fs.existsSync(resolvedPath) || !fs.statSync(resolvedPath).isFile()) {
+    throw new Error(`File not found for request body: ${filePath}`);
+  }
+
+  return {
+    data: fs.readFileSync(resolvedPath),
+    contentType: (entry.contentType || '').trim() || DEFAULT_FILE_BODY_CONTENT_TYPE
+  };
+};

--- a/src/webview/components/FilePickerEditor/StyledWrapper.ts
+++ b/src/webview/components/FilePickerEditor/StyledWrapper.ts
@@ -70,10 +70,35 @@ const StyledWrapper = styled.div`
       cursor: default;
     }
 
+    /* The selected file is missing on disk — tint the chip so it reads as a warning. */
+    &.has-warning {
+      background-color: var(--vscode-inputValidation-warningBackground, rgba(204, 167, 0, 0.15));
+      border-radius: ${(props) => props.theme.border.radius.sm};
+      font-weight: 500;
+      padding: 4px;
+    }
+
     .file-icon {
       flex-shrink: 0;
       color: ${(props) => props.theme.colors.text.muted};
       margin-right: 4px;
+    }
+
+    .warning-icon {
+      flex-shrink: 0;
+      color: ${(props) => props.theme.status.warning.text};
+      margin-right: 4px;
+    }
+
+    .warning-tooltip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+
+      svg {
+        color: ${(props) => props.theme.status.warning.text};
+        flex-shrink: 0;
+      }
     }
 
     .file-name {

--- a/src/webview/components/FilePickerEditor/index.tsx
+++ b/src/webview/components/FilePickerEditor/index.tsx
@@ -50,8 +50,6 @@ const FilePickerEditor = ({
     .filter((v: any) => v != null && v != '');
   const filenames = filePaths.map((v: any) => v.split(/[/\\]/).pop());
 
-  // A path stored in the request may no longer exist — the file was moved or the
-  // collection was shared without it. Warn instead of failing only on send.
   const { status, missingPaths } = useMissingFileCheck(filePaths, collection?.pathname);
   const hasMissingFiles = status === 'ready' && missingPaths.length > 0;
 
@@ -146,14 +144,6 @@ const FilePickerEditor = ({
               <IconX size={16} />
             </button>
           )}
-          {/* {hasMissingFiles && (
-            <Tooltip id={warningTooltipId} className="tooltip-mod max-w-lg" place="bottom-end">
-              <div className="warning-tooltip" data-testid="file-picker-warning-tooltip">
-                <IconAlertTriangle size={14} strokeWidth={1.5} />
-                <span>The file above is not in the given directory, please upload it again.</span>
-              </div>
-            </Tooltip>
-          )} */}
           {hasMissingFiles && (
             <Tooltip
               id={warningTooltipId}

--- a/src/webview/components/FilePickerEditor/index.tsx
+++ b/src/webview/components/FilePickerEditor/index.tsx
@@ -112,11 +112,12 @@ const FilePickerEditor = ({
       <StyledWrapper>
         <div
           className={`file-picker-selected ${readOnly ? 'read-only' : ''}`}
+          data-testid="file-picker-selected"
           title={title}
           onClick={!readOnly ? browse : undefined}
         >
           <IconFile size={16} className="file-icon" />
-          <span className="file-name">
+          <span className="file-name" data-testid="file-picker-file-name">
             {renderButtonText(filenames)}
           </span>
           {!readOnly && (
@@ -138,6 +139,7 @@ const FilePickerEditor = ({
     <StyledWrapper>
       <button
         className={`file-picker-btn ${readOnly ? 'read-only' : ''} ${displayMode === 'icon' ? 'icon-only' : ''} ${displayMode === 'labelAndIcon' ? 'icon-right' : ''}`}
+        data-testid="file-picker-button"
         onClick={browse}
         disabled={readOnly}
         type="button"

--- a/src/webview/components/FilePickerEditor/index.tsx
+++ b/src/webview/components/FilePickerEditor/index.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useId } from 'react';
 import path from 'utils/common/path';
 import { useDispatch } from 'react-redux';
 import { browseFiles } from 'providers/ReduxStore/slices/collections/actions';
-import { IconX, IconUpload, IconFile } from '@tabler/icons';
+import { IconX, IconUpload, IconFile, IconAlertTriangle } from '@tabler/icons';
+import { Tooltip } from 'react-tooltip';
+import useMissingFileCheck from 'hooks/useMissingFileCheck';
 
 import StyledWrapper from './StyledWrapper';
+import IconAlertTriangleFilled from 'components/Icons/IconAlertTriangleFilled';
 
 interface FilePickerEditorProps {
   value?: unknown;
@@ -41,11 +44,16 @@ const FilePickerEditor = ({
   icon: CustomIcon
 }: any) => {
   const dispatch = useDispatch();
-  const filenames = (isSingleFilePicker ? [value] : value || [])
-    .filter((v: any) => v != null && v != '')
-    .map((v: any) => {
-      return v.split(/[/\\]/).pop();
-    });
+  const warningTooltipId = `file-picker-warning-${useId().replace(/:/g, '')}`;
+
+  const filePaths = (isSingleFilePicker ? [value] : value || [])
+    .filter((v: any) => v != null && v != '');
+  const filenames = filePaths.map((v: any) => v.split(/[/\\]/).pop());
+
+  // A path stored in the request may no longer exist — the file was moved or the
+  // collection was shared without it. Warn instead of failing only on send.
+  const { status, missingPaths } = useMissingFileCheck(filePaths, collection?.pathname);
+  const hasMissingFiles = status === 'ready' && missingPaths.length > 0;
 
   // title is shown when hovering over the button
   const title = filenames.map((v: any) => `- ${v}`).join('\n');
@@ -111,12 +119,20 @@ const FilePickerEditor = ({
     return (
       <StyledWrapper>
         <div
-          className={`file-picker-selected ${readOnly ? 'read-only' : ''}`}
+          className={`file-picker-selected ${readOnly ? 'read-only' : ''} ${hasMissingFiles ? 'has-warning' : ''}`}
           data-testid="file-picker-selected"
           title={title}
           onClick={!readOnly ? browse : undefined}
         >
-          <IconFile size={16} className="file-icon" />
+          {hasMissingFiles ? (
+            <IconAlertTriangleFilled
+              data-tooltip-id={warningTooltipId}
+              className="warning-icon"
+              size={16}
+            />
+          ) : (
+            <IconFile size={16} className="file-icon" />
+          )}
           <span className="file-name" data-testid="file-picker-file-name">
             {renderButtonText(filenames)}
           </span>
@@ -129,6 +145,26 @@ const FilePickerEditor = ({
             >
               <IconX size={16} />
             </button>
+          )}
+          {/* {hasMissingFiles && (
+            <Tooltip id={warningTooltipId} className="tooltip-mod max-w-lg" place="bottom-end">
+              <div className="warning-tooltip" data-testid="file-picker-warning-tooltip">
+                <IconAlertTriangle size={14} strokeWidth={1.5} />
+                <span>The file above is not in the given directory, please upload it again.</span>
+              </div>
+            </Tooltip>
+          )} */}
+          {hasMissingFiles && (
+            <Tooltip
+              id={warningTooltipId}
+              className="tooltip-mod max-w-lg"
+              place="bottom-end"
+            >
+              <div className="warning-tooltip" data-testid="file-picker-warning-tooltip">
+                <IconAlertTriangleFilled size={14} />
+                <span>The file above is not in the given directory, please upload it again.</span>
+              </div>
+            </Tooltip>
           )}
         </div>
       </StyledWrapper>

--- a/src/webview/components/RequestPane/FileBody/index.tsx
+++ b/src/webview/components/RequestPane/FileBody/index.tsx
@@ -160,7 +160,7 @@ const FileBody = ({
         </tbody>
       </table>
       <div>
-        <button className="btn-add-param text-link pr-2 pt-3 select-none" onClick={addFile}>
+        <button className="btn-add-param text-link pr-2 pt-3 select-none" data-testid="body-file-add" onClick={addFile}>
           + Add File
         </button>
       </div>

--- a/src/webview/components/RequestPane/RequestBody/RequestBodyMode/index.tsx
+++ b/src/webview/components/RequestPane/RequestBody/RequestBodyMode/index.tsx
@@ -119,6 +119,7 @@ const RequestBodyMode = ({
           selectedItemId={bodyMode}
           showGroupDividers={false}
           groupStyle="select"
+          data-testid="body-mode"
         >
           <div className="flex items-center justify-center pl-3 py-1 select-none selected-body-mode">
             {humanizeRequestBodyMode(bodyMode)} <IconCaretDown className="caret ml-1" size={14} strokeWidth={2} />

--- a/src/webview/hooks/useMissingFileCheck/index.ts
+++ b/src/webview/hooks/useMissingFileCheck/index.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { getAbsoluteFilePath } from 'utils/common/path';
+import { ipcRenderer } from 'utils/ipc';
+
+export type MissingFileCheckStatus = 'idle' | 'checking' | 'ready' | 'error';
+
+export interface MissingFileCheckState {
+  status: MissingFileCheckStatus;
+  missingPaths: string[];
+}
+
+/**
+ * Checks whether the given file paths (resolved against `basePath`) exist on disk.
+ *
+ * The hook only reports what it observed — callers own the "should I warn" policy.
+ * A sequence counter discards results from superseded runs so rapid input changes
+ * can't leave stale results on screen.
+ *
+ * - `'idle'`     — nothing to check (empty input or no `basePath`)
+ * - `'checking'` — a check is in flight; `missingPaths` is empty
+ * - `'ready'`    — check completed; `missingPaths` lists paths that don't exist
+ * - `'error'`    — the check itself failed (e.g. IPC threw); `missingPaths` is empty
+ */
+const useMissingFileCheck = (paths: string[], basePath?: string): MissingFileCheckState => {
+  const [state, setState] = useState<MissingFileCheckState>({ status: 'idle', missingPaths: [] });
+  const seqRef = useRef(0);
+  const pathsRef = useRef(paths);
+  pathsRef.current = paths;
+
+  // Content-based key so re-renders that pass a fresh array with the same
+  // contents don't retrigger the check.
+  const pathsKey = paths.join('\0');
+
+  useEffect(() => {
+    const currentPaths = pathsRef.current;
+    if (!currentPaths.length || !basePath) {
+      setState({ status: 'idle', missingPaths: [] });
+      return;
+    }
+
+    const seq = ++seqRef.current;
+    setState({ status: 'checking', missingPaths: [] });
+
+    Promise.all(
+      currentPaths.map(async (filePath) => {
+        const exists = await ipcRenderer.invoke<boolean>(
+          'renderer:exists-sync',
+          getAbsoluteFilePath(basePath, filePath)
+        );
+        return { filePath, exists };
+      })
+    ).then(
+      (results) => {
+        if (seq !== seqRef.current) return;
+        setState({
+          status: 'ready',
+          missingPaths: results.filter((r) => !r.exists).map((r) => r.filePath)
+        });
+      },
+      () => {
+        if (seq !== seqRef.current) return;
+        setState({ status: 'error', missingPaths: [] });
+      }
+    );
+  }, [pathsKey, basePath]);
+
+  return state;
+};
+
+export default useMissingFileCheck;

--- a/src/webview/hooks/useMissingFileCheck/index.ts
+++ b/src/webview/hooks/useMissingFileCheck/index.ts
@@ -12,10 +12,6 @@ export interface MissingFileCheckState {
 /**
  * Checks whether the given file paths (resolved against `basePath`) exist on disk.
  *
- * The hook only reports what it observed — callers own the "should I warn" policy.
- * A sequence counter discards results from superseded runs so rapid input changes
- * can't leave stale results on screen.
- *
  * - `'idle'`     — nothing to check (empty input or no `basePath`)
  * - `'checking'` — a check is in flight; `missingPaths` is empty
  * - `'ready'`    — check completed; `missingPaths` lists paths that don't exist
@@ -27,8 +23,6 @@ const useMissingFileCheck = (paths: string[], basePath?: string): MissingFileChe
   const pathsRef = useRef(paths);
   pathsRef.current = paths;
 
-  // Content-based key so re-renders that pass a fresh array with the same
-  // contents don't retrigger the check.
   const pathsKey = paths.join('\0');
 
   useEffect(() => {

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -43,8 +43,7 @@ const grpcPort = Number(process.env.GRPC_PORT) || port + 1;
 
 app.use(cors());
 
-// Records the body as received so tests can assert what the extension actually sent.
-// Must stay above express.json()/urlencoded(), which would consume the stream first.
+// Records the body as received.
 let lastRawBody: { contentType: string | null; body: string } = { contentType: null, body: '' };
 app.post('/raw-body', express.raw({ type: '*/*' }), (req, res) => {
   lastRawBody = {

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -7,6 +7,8 @@
  * Endpoints:
  *   GET  /ping                                    - Health check
  *   GET  /headers                                 - Echo request headers
+ *   POST /raw-body                                - Record the raw request body as received
+ *   GET  /get-raw-body                            - Read back the last recorded raw body
  *   POST /api/echo/json                           - Echo JSON body
  *   *    /api/echo/query                           - Echo query params as a flat object
  *   *    /api/echo/header                          - Echo the `x-prompt-header` header value
@@ -40,6 +42,22 @@ const port = Number(process.env.PORT) || 8081;
 const grpcPort = Number(process.env.GRPC_PORT) || port + 1;
 
 app.use(cors());
+
+// Records the body as received so tests can assert what the extension actually sent.
+// Must stay above express.json()/urlencoded(), which would consume the stream first.
+let lastRawBody: { contentType: string | null; body: string } = { contentType: null, body: '' };
+app.post('/raw-body', express.raw({ type: '*/*' }), (req, res) => {
+  lastRawBody = {
+    contentType: (req.headers['content-type'] as string) ?? null,
+    // A request with no body at all never reaches express.raw, leaving req.body unset
+    body: Buffer.isBuffer(req.body) ? req.body.toString('utf8') : ''
+  };
+  res.json({ ok: true });
+});
+app.get('/get-raw-body', (_req, res) => {
+  res.json(lastRawBody);
+});
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/tests/e2e/specs/file-body.spec.ts
+++ b/tests/e2e/specs/file-body.spec.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openNewRequestPanel,
+  createRequest,
+  openRequest,
+  openRequestPaneTab,
+  sendRequest
+} from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+/**
+ * Switch the body to "File / Binary" mode and attach `filePath` to the first file row.
+ * The picker opens a native dialog, so we intercept its `renderer:browse-files` IPC call.
+ */
+async function attachFileBody(editor: Frame, filePath: string): Promise<void> {
+  const body = buildCommonLocators(editor).requestBody;
+
+  await openRequestPaneTab(editor, 'Body');
+  await body.modeSelector().click();
+  await body.modeOption('file').click();
+  await body.addFile().click();
+
+  await editor.evaluate((selected) => {
+    const ipc = (window as any).ipcRenderer;
+    const originalInvoke = ipc.invoke.bind(ipc);
+    ipc.invoke = async (channel: string, ...args: any[]) => {
+      if (channel === 'renderer:browse-files') {
+        ipc.invoke = originalInvoke; // restore after one use
+        return [selected];
+      }
+      return originalInvoke(channel, ...args);
+    };
+  }, filePath);
+
+  await body.selectFile().click();
+
+  // The row shows the file name once the pick lands in state
+  await expect(body.selectedFileName()).toHaveText(path.basename(filePath), { timeout: 10_000 });
+}
+
+test.describe('Request body: File / Binary', () => {
+  test('the picked file is uploaded as the raw request body', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'File Body';
+    const requestName = 'Upload File';
+    const fileContent = 'first line\nsecond line\n';
+
+    // Outside the collection directory, like a file picked from ~/Downloads — stored as an absolute path
+    const payloadPath = path.join(tmpDir, 'payload.txt');
+    fs.writeFileSync(payloadPath, fileContent, 'utf8');
+
+    await createCollection(page, sidebar, collectionName, tmpDir);
+
+    const newReqPanel = await openNewRequestPanel(page, sidebar, collectionName);
+    await createRequest(page, newReqPanel, sidebar, collectionName, requestName, `${TEST_SERVER}/raw-body`, 'POST');
+
+    const editor = await openRequest(page, sidebar, collectionName, requestName);
+    await attachFileBody(editor, payloadPath);
+    await sendRequest(editor, 200);
+
+    // Ask the server what arrived — a request with no body still comes back 200
+    const res = await fetch(`${TEST_SERVER}/get-raw-body`);
+    const sent = (await res.json()) as { contentType: string | null; body: string };
+
+    expect(sent.body).toBe(fileContent);
+    // Filled in from the file extension when the file is picked
+    expect(sent.contentType).toBe('text/plain; charset=utf-8');
+  });
+});

--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -45,6 +45,29 @@ async function waitForPort(port: number, timeoutMs = 25_000): Promise<void> {
   throw new Error(`Port ${port} never opened within ${timeoutMs}ms`);
 }
 
+/**
+ * @vscode/test-electron hardcodes the macOS binary as `Electron`, but VS Code 1.131
+ * renamed it to `Code`, so spawning the path it hands back fails with ENOENT. Only
+ * macOS is affected — on Windows it returns `Code.exe` and on Linux `code`, both of
+ * which are still current. Rather than hardcode the new name, read it out of the
+ * app bundle so a future rename doesn't break this again.
+ */
+function resolveRenamedBinary(exe: string): string {
+  if (process.platform !== 'darwin') {
+    return exe;
+  }
+  const dir = path.dirname(exe);
+  if (!fs.existsSync(dir)) {
+    return exe;
+  }
+  const entries = fs.readdirSync(dir);
+  if (entries.includes('Code')) {
+    return path.join(dir, 'Code');
+  }
+  // Contents/MacOS holds only the main executable, whatever it is called.
+  return entries.length === 1 ? path.join(dir, entries[0]) : exe;
+}
+
 async function resolveExecutable(): Promise<string> {
   if (process.env.CURSOR_PATH) {
     console.log(`[e2e] Using Cursor: ${process.env.CURSOR_PATH}`);
@@ -56,9 +79,7 @@ async function resolveExecutable(): Promise<string> {
   }
   console.log('[e2e] Downloading stable VS Code…');
   const exe = await downloadAndUnzipVSCode('stable');
-  // VS Code 1.131 renamed the macOS binary from `Electron` to `Code`, but @vscode/test-electron
-  // still points at the old name — spawning it fails with ENOENT. Accept whichever one exists.
-  const resolved = fs.existsSync(exe) ? exe : path.join(path.dirname(exe), 'Code');
+  const resolved = fs.existsSync(exe) ? exe : resolveRenamedBinary(exe);
   if (!fs.existsSync(resolved)) {
     throw new Error(`VS Code executable not found (tried ${exe} and ${resolved})`);
   }

--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -49,8 +49,7 @@ async function waitForPort(port: number, timeoutMs = 25_000): Promise<void> {
  * @vscode/test-electron hardcodes the macOS binary as `Electron`, but VS Code 1.131
  * renamed it to `Code`, so spawning the path it hands back fails with ENOENT. Only
  * macOS is affected — on Windows it returns `Code.exe` and on Linux `code`, both of
- * which are still current. Rather than hardcode the new name, read it out of the
- * app bundle so a future rename doesn't break this again.
+ * which are still current.
  */
 function resolveRenamedBinary(exe: string): string {
   if (process.platform !== 'darwin') {

--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -56,8 +56,14 @@ async function resolveExecutable(): Promise<string> {
   }
   console.log('[e2e] Downloading stable VS Code…');
   const exe = await downloadAndUnzipVSCode('stable');
-  console.log(`[e2e] Using VS Code: ${exe}`);
-  return exe;
+  // VS Code 1.131 renamed the macOS binary from `Electron` to `Code`, but @vscode/test-electron
+  // still points at the old name — spawning it fails with ENOENT. Accept whichever one exists.
+  const resolved = fs.existsSync(exe) ? exe : path.join(path.dirname(exe), 'Code');
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`VS Code executable not found (tried ${exe} and ${resolved})`);
+  }
+  console.log(`[e2e] Using VS Code: ${resolved}`);
+  return resolved;
 }
 
 /** Write VS Code user settings to suppress welcome/trust dialogs and speed up startup */

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -80,8 +80,7 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     modeOption: (name: string) => frame.getByText(name, { exact: true }),
     editor: () => frame.locator('.CodeMirror-wrap')
   },
-  // Body-mode dropdown addressed by test id (`body-mode-<mode>` comes from
-  // MenuDropdown's per-item id), plus the File / Binary row controls.
+  // Body-mode dropdown addressed by test id, plus the File / Binary row controls.
   requestBody: {
     modeSelector: () => frame.getByTestId('body-mode'),
     modeOption: (mode: string) => frame.getByTestId(`body-mode-${mode}`),

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -80,6 +80,15 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     modeOption: (name: string) => frame.getByText(name, { exact: true }),
     editor: () => frame.locator('.CodeMirror-wrap')
   },
+  // Body-mode dropdown addressed by test id (`body-mode-<mode>` comes from
+  // MenuDropdown's per-item id), plus the File / Binary row controls.
+  requestBody: {
+    modeSelector: () => frame.getByTestId('body-mode'),
+    modeOption: (mode: string) => frame.getByTestId(`body-mode-${mode}`),
+    addFile: () => frame.getByTestId('body-file-add'),
+    selectFile: () => frame.getByTestId('file-picker-button').first(),
+    selectedFileName: () => frame.getByTestId('file-picker-file-name').first()
+  },
   oauth2: {
     authModeSelector: () => frame.getByTestId('oauth2-auth-mode-selector'),
     grantTypeSelector: () => frame.getByTestId('oauth2-grant-type-selector'),


### PR DESCRIPTION
**Jira: VSCODE-64**
### Description
Added file/binary body support for POST API request. File/binary body added by the user is now getting sent in API body.
### Problem
When data for file/binary body was added, it was not getting sent along with API call.
### Fix
1. File/binary body getting sent with API request.
2. Showing warning message if uploaded file doesn't exists in the system.
### Screenshots
**Before**
<img width="1585" height="337" alt="Screenshot 2026-08-12 at 11 34 16 AM" src="https://github.com/user-attachments/assets/e56f0656-3eb7-4435-9efa-84a9a9676f69" />
**After**
<img width="802" height="272" alt="Screenshot 2026-08-12 at 11 32 23 AM" src="https://github.com/user-attachments/assets/15529581-5edc-403d-ac89-2dcdb240d7d3" />
<img width="1587" height="610" alt="Screenshot 2026-08-12 at 11 35 27 AM" src="https://github.com/user-attachments/assets/bd7d2427-64fd-4747-a00f-0161bb40c98b" />
