### PR TITLE
fix : add support for VS code Bruno not supporting Multiline Header Value Entry Error Display

### DIFF
--- a/src/webview/components/EditableTable/StyledWrapper.ts
+++ b/src/webview/components/EditableTable/StyledWrapper.ts
@@ -65,6 +65,8 @@ const StyledWrapper = styled.div`
 
   tbody {
     tr {
+      height: 35px;
+      max-height: 35px;
       transition: background 0.1s ease;
 
       &:last-child td {
@@ -72,16 +74,77 @@ const StyledWrapper = styled.div`
       }
 
       td {
+        height: 35px;
+        max-height: 35px;
         padding: 1px 10px !important;
         border-top: none !important;
         border-left: none !important;
         border-bottom: solid 1px ${(props) => props.theme.border.border0};
         border-right: solid 1px ${(props) => props.theme.border.border0};
         vertical-align: middle;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        box-sizing: border-box;
 
         &:last-child {
           border-right: none;
         }
+
+        > div:not(.drag-handle) {
+          height: 33px;
+          max-height: 33px;
+          overflow: hidden;
+        }
+
+        /* Single-line editors must clip to one row; a value with newlines
+           surfaces a validation warning rather than expanding the cell. */
+        .single-line-editor .CodeMirror {
+          max-width: 100%;
+          height: 33px !important;
+          max-height: 33px !important;
+
+          .CodeMirror-scroll {
+            overflow: hidden !important;
+            max-height: 33px;
+          }
+
+          .CodeMirror-vscrollbar,
+          .CodeMirror-hscrollbar,
+          .CodeMirror-scrollbar-filler {
+            display: none;
+          }
+
+          .CodeMirror-lines {
+            max-width: 100%;
+          }
+
+          .CodeMirror-line {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+        }
+
+        &:has(.multi-line-editor) {
+          height: auto;
+          max-height: none;
+          overflow: visible;
+          white-space: normal;
+          text-overflow: clip;
+
+          > div:not(.drag-handle) {
+            height: auto;
+            max-height: none;
+            overflow: visible;
+          }
+        }
+      }
+
+      &:has(.multi-line-editor) {
+        height: auto;
+        max-height: calc(35px * 3);
+        overflow: auto;
       }
     }
   }
@@ -92,6 +155,7 @@ const StyledWrapper = styled.div`
     text-align: center;
     vertical-align: middle;
     line-height: 1;
+    text-overflow: clip;
 
     input[type='checkbox'] {
       vertical-align: baseline;

--- a/src/webview/components/HeaderEditor/index.tsx
+++ b/src/webview/components/HeaderEditor/index.tsx
@@ -63,7 +63,7 @@ const HeaderEditor = ({
 
   return (
     <div className="flex items-center w-full">
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <SingleLineEditor
           value={value || ''}
           theme={theme}
@@ -77,7 +77,7 @@ const HeaderEditor = ({
         />
       </div>
       {error && !isLastEmptyRow && (
-        <span className="ml-1">
+        <span className="ml-1 shrink-0">
           <IconAlertCircle
             data-tooltip-id={`error-${rowUid}-${type}`}
             className="text-red-600 cursor-pointer"


### PR DESCRIPTION
## Summary
Keeps the request Headers editor at a fixed single-row height when a header value contains newlines. Invalid values are clipped to one line, with the warning icon still visible.


## Problem
Entering a multiline header value was correctly marked as invalid, but the row expanded to fit the value, breaking the Headers layout. 

JIRA: VSCODE-48

## Root Cause
The extension's headers table was missing row and cell height constraints, causing multiline values to expand the row instead of staying on a single line.

## Solution
Clamp table rows and single-line editor cells to a single row, clipping overflowing content (including newlines) while allowing multi-line editor cells to grow as before, and keep the validation warning icon visible within the fixed-height cell.


## Screenshot
Before
<img width="1913" height="898" alt="image" src="https://github.com/user-attachments/assets/7cfd36be-b7c5-43b3-8f40-9084247ac78c" />
After
<img width="2178" height="672" alt="image" src="https://github.com/user-attachments/assets/8b172706-b713-4bb3-b490-e277b3f02153" />

