### PR TITLE
feat: data type support cross-scope enhancement, polish & E2E coverage

### DIFF
--- a/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
@@ -100,6 +100,7 @@ const VarsTable = ({
   return (
     <StyledWrapper className="w-full">
       <EditableTable
+        testId={`collection-vars-${varType === 'request' ? 'req' : 'res'}`}
         columns={columns}
         rows={vars}
         onChange={handleVarsChange}

--- a/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
@@ -5,7 +5,7 @@ import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
-import DataTypeSelector from 'components/DataTypeSelector';
+import VarsDataTypeSelector from 'components/DataTypeSelector/VarsDataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
@@ -76,16 +76,7 @@ const VarsTable = ({
               placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
             />
           </div>
-          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
-          {!isLastEmptyRow && varType === 'request' && (
-            <DataTypeSelector
-              variable={row}
-              onChange={(fields) => {
-                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
-                handleVarsChange(updated);
-              }}
-            />
-          )}
+          <VarsDataTypeSelector row={row} vars={vars} isLastEmptyRow={isLastEmptyRow} varType={varType} onVarsChange={handleVarsChange} />
         </div>
       )
     }

--- a/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/CollectionSettings/Vars/VarsTable/index.tsx
@@ -5,10 +5,12 @@ import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
+import DataTypeSelector from 'components/DataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
 import { setCollectionVars } from 'providers/ReduxStore/slices/collections/index';
+import { valueToString } from '@usebruno/common/utils';
 
 interface VarsTableProps {
   collection?: React.ReactNode;
@@ -63,14 +65,28 @@ const VarsTable = ({
         onChange,
         isLastEmptyRow
       }: any) => (
-        <MultiLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={onChange}
-          collection={collection}
-          placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
-        />
+        <div className="flex items-center w-full gap-2">
+          <div className="flex-1 min-w-0">
+            <MultiLineEditor
+              value={valueToString(value)}
+              theme={storedTheme}
+              onSave={onSave}
+              onChange={onChange}
+              collection={collection}
+              placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
+            />
+          </div>
+          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
+          {!isLastEmptyRow && varType === 'request' && (
+            <DataTypeSelector
+              variable={row}
+              onChange={(fields) => {
+                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
+                handleVarsChange(updated);
+              }}
+            />
+          )}
+        </div>
       )
     }
   ];

--- a/src/webview/components/DataTypeSelector/VarsDataTypeSelector.tsx
+++ b/src/webview/components/DataTypeSelector/VarsDataTypeSelector.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { BrunoVariableDataType } from '@bruno-types';
+import DataTypeSelector from './index';
+
+interface Var {
+  uid?: string;
+  name?: string;
+  value?: unknown;
+  dataType?: BrunoVariableDataType;
+}
+
+interface VarsDataTypeSelectorProps {
+  row: Var;
+  vars: Var[] | undefined;
+  isLastEmptyRow?: boolean;
+  varType?: string;
+  onVarsChange: (vars: Var[]) => void;
+}
+
+/**
+ * Data-type selector for a Vars-table row. Updates the matching variable's type and hands the full
+ * array back to the table's change handler. Only request-scoped literal vars get a type — response
+ * vars hold a JS expression, and the trailing empty row has nothing to type.
+ */
+const VarsDataTypeSelector = ({ row, vars, isLastEmptyRow, varType, onVarsChange }: VarsDataTypeSelectorProps) => {
+  if (isLastEmptyRow || varType !== 'request') {
+    return null;
+  }
+  return (
+    <DataTypeSelector
+      variable={row}
+      onChange={(fields) => {
+        onVarsChange((vars || []).map((v) => (v.uid === row.uid ? { ...v, ...fields } : v)));
+      }}
+    />
+  );
+};
+
+export default VarsDataTypeSelector;

--- a/src/webview/components/DataTypeSelector/index.tsx
+++ b/src/webview/components/DataTypeSelector/index.tsx
@@ -7,7 +7,7 @@ import MenuDropdown from 'ui/MenuDropdown';
 import StyledWrapper from './StyledWrapper';
 
 interface DataTypeSelectorProps {
-  variable: { uid?: string; value?: unknown; dataType?: BrunoVariableDataType };
+  variable: { uid?: string; name?: string; value?: unknown; dataType?: BrunoVariableDataType };
   onChange: (fields: { dataType?: BrunoVariableDataType }) => void;
 }
 
@@ -36,6 +36,7 @@ const DataTypeSelector = ({ variable, onChange }: DataTypeSelectorProps) => {
           placement="bottom-end"
           showTickMark={true}
           appendTo={() => document.body}
+          data-testid={`datatype-selector-${variable.name || 'new'}`}
         >
           <div className="flex items-center cursor-pointer select-none">
             <span className="type-label">{selectedType}</span>

--- a/src/webview/components/DataTypeSelector/index.tsx
+++ b/src/webview/components/DataTypeSelector/index.tsx
@@ -30,7 +30,13 @@ const DataTypeSelector = ({ variable, onChange }: DataTypeSelectorProps) => {
   return (
     <StyledWrapper>
       <div className="flex items-center relative">
-        <MenuDropdown items={items} selectedItemId={selectedType} placement="bottom-end" showTickMark={true}>
+        <MenuDropdown
+          items={items}
+          selectedItemId={selectedType}
+          placement="bottom-end"
+          showTickMark={true}
+          appendTo={() => document.body}
+        >
           <div className="flex items-center cursor-pointer select-none">
             <span className="type-label">{selectedType}</span>
             <IconCaretDown className="caret-icon ml-1" size={14} strokeWidth={2} />

--- a/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
@@ -108,6 +108,7 @@ const VarsTable = ({
   return (
     <StyledWrapper className="w-full">
       <EditableTable
+        testId={`folder-vars-${varType === 'request' ? 'req' : 'res'}`}
         columns={columns}
         rows={vars}
         onChange={handleVarsChange}

--- a/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
@@ -5,10 +5,12 @@ import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions'
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
+import DataTypeSelector from 'components/DataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
 import { setFolderVars } from 'providers/ReduxStore/slices/collections/index';
+import { valueToString } from '@usebruno/common/utils';
 
 interface VarsTableProps {
   folder: React.ReactNode;
@@ -70,15 +72,29 @@ const VarsTable = ({
         onChange,
         isLastEmptyRow
       }: any) => (
-        <MultiLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={onChange}
-          collection={collection}
-          item={folder}
-          placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
-        />
+        <div className="flex items-center w-full gap-2">
+          <div className="flex-1 min-w-0">
+            <MultiLineEditor
+              value={valueToString(value)}
+              theme={storedTheme}
+              onSave={onSave}
+              onChange={onChange}
+              collection={collection}
+              item={folder}
+              placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
+            />
+          </div>
+          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
+          {!isLastEmptyRow && varType === 'request' && (
+            <DataTypeSelector
+              variable={row}
+              onChange={(fields) => {
+                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
+                handleVarsChange(updated);
+              }}
+            />
+          )}
+        </div>
       )
     }
   ];

--- a/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
+++ b/src/webview/components/FolderSettings/Vars/VarsTable/index.tsx
@@ -5,7 +5,7 @@ import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions'
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
-import DataTypeSelector from 'components/DataTypeSelector';
+import VarsDataTypeSelector from 'components/DataTypeSelector/VarsDataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
@@ -84,16 +84,7 @@ const VarsTable = ({
               placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
             />
           </div>
-          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
-          {!isLastEmptyRow && varType === 'request' && (
-            <DataTypeSelector
-              variable={row}
-              onChange={(fields) => {
-                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
-                handleVarsChange(updated);
-              }}
-            />
-          )}
+          <VarsDataTypeSelector row={row} vars={vars} isLastEmptyRow={isLastEmptyRow} varType={varType} onVarsChange={handleVarsChange} />
         </div>
       )
     }

--- a/src/webview/components/FolderSettings/index.tsx
+++ b/src/webview/components/FolderSettings/index.tsx
@@ -83,7 +83,7 @@ const FolderSettings = ({
   };
 
   return (
-    <StyledWrapper className="flex flex-col h-full overflow-auto">
+    <StyledWrapper className="flex flex-col h-full overflow-auto" data-testid="folder-settings">
       <div className="flex flex-col h-full relative px-4 py-4">
         <div className="flex flex-wrap items-center tabs" role="tablist">
           <div className={getTabClassname('headers')} role="tab" onClick={() => setTab('headers')}>

--- a/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
+++ b/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
@@ -6,7 +6,7 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
-import DataTypeSelector from 'components/DataTypeSelector';
+import VarsDataTypeSelector from 'components/DataTypeSelector/VarsDataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
@@ -102,16 +102,7 @@ const VarsTable = ({
               placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
             />
           </div>
-          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
-          {!isLastEmptyRow && varType === 'request' && (
-            <DataTypeSelector
-              variable={row}
-              onChange={(fields) => {
-                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
-                handleVarsChange(updated);
-              }}
-            />
-          )}
+          <VarsDataTypeSelector row={row} vars={vars} isLastEmptyRow={isLastEmptyRow} varType={varType} onVarsChange={handleVarsChange} />
         </div>
       )
     }

--- a/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
+++ b/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
@@ -126,6 +126,7 @@ const VarsTable = ({
   return (
     <StyledWrapper className="w-full">
       <EditableTable
+        testId={`request-vars-${varType === 'request' ? 'req' : 'res'}`}
         columns={columns}
         rows={vars || []}
         onChange={handleVarsChange}

--- a/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
+++ b/src/webview/components/RequestPane/Vars/VarsTable/index.tsx
@@ -6,9 +6,11 @@ import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collection
 import MultiLineEditor from 'components/MultiLineEditor';
 import InfoTip from 'components/InfoTip';
 import EditableTable from 'components/EditableTable';
+import DataTypeSelector from 'components/DataTypeSelector';
 import StyledWrapper from './StyledWrapper';
 import toast from 'react-hot-toast';
 import { variableNameRegex } from 'utils/common/regex';
+import { valueToString } from '@usebruno/common/utils';
 
 interface VarsTableProps {
   item: any;
@@ -87,16 +89,30 @@ const VarsTable = ({
         onChange,
         isLastEmptyRow
       }: any) => (
-        <MultiLineEditor
-          value={value || ''}
-          theme={storedTheme}
-          onSave={onSave}
-          onChange={onChange}
-          onRun={handleRun}
-          collection={collection}
-          item={item}
-          placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
-        />
+        <div className="flex items-center w-full gap-2">
+          <div className="flex-1 min-w-0">
+            <MultiLineEditor
+              value={valueToString(value)}
+              theme={storedTheme}
+              onSave={onSave}
+              onChange={onChange}
+              onRun={handleRun}
+              collection={collection}
+              item={item}
+              placeholder={isLastEmptyRow ? (varType === 'request' ? 'Value' : 'Expr') : ''}
+            />
+          </div>
+          {/* Data types apply to literal request-var values, not to the JS expression of a response var. */}
+          {!isLastEmptyRow && varType === 'request' && (
+            <DataTypeSelector
+              variable={row}
+              onChange={(fields) => {
+                const updated = (vars || []).map((v: any) => (v.uid === row.uid ? { ...v, ...fields } : v));
+                handleVarsChange(updated);
+              }}
+            />
+          )}
+        </div>
       )
     }
   ];

--- a/tests/e2e/specs/datatype-settings.spec.ts
+++ b/tests/e2e/specs/datatype-settings.spec.ts
@@ -2,26 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Page, Frame } from '@playwright/test';
 import { test, expect } from '../utils/fixtures';
-import { openBrunoSidebar, createCollection, openRequest, createFolder } from '../utils/page/actions';
+import { openBrunoSidebar, createCollection, openRequest, createFolder, findCollectionDir } from '../utils/page/actions';
 import { buildCommonLocators } from '../utils/page/locators';
-
-function findCollectionDir(root: string): string {
-  const stack = [root];
-  while (stack.length) {
-    const dir = stack.pop() as string;
-    let entries: fs.Dirent[] = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
-    for (const e of entries) {
-      if (e.isDirectory()) stack.push(path.join(dir, e.name));
-    }
-  }
-  throw new Error(`No collection (bruno.json) found under ${root}`);
-}
 
 // Scan the webview frames for the one exposing `marker`, re-acquiring after a panel opens.
 async function frameWith(page: Page, marker: string, timeout = 15_000): Promise<Frame> {
@@ -58,14 +40,14 @@ test.describe('Data types in collection & environment variables', () => {
 
     const table = settings.locator('[data-testid="collection-vars-req"]');
     await expect(table).toBeVisible({ timeout: 15_000 });
-    // AC1/AC6: parsed from disk, object renders as JSON and the collection doesn't break.
+    // Parsed from disk, the object renders as JSON and the collection doesn't break.
     await expect(table).toContainText('{"host":"localhost"}');
     await expect(table).not.toContainText('[object Object]');
-    // AC2: selector reflects the on-disk data type.
+    // The selector reflects the on-disk data type.
     await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
     await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
 
-    // AC3/AC4: change tok -> number and Save; the collection file gains @number, @object survives.
+    // Change tok -> number and Save; the collection file gains @number, @object survives.
     const collectionFile = path.join(collectionDir, 'collection.bru');
     await settings.locator('[data-testid="datatype-selector-tok"]').click();
     await settings.locator('[data-testid="datatype-selector-tok-number"]').click();
@@ -100,7 +82,7 @@ test.describe('Data types in collection & environment variables', () => {
     await editor.locator('#configure-env').click();
 
     const envSettings = await frameWith(page, '[data-testid="save-env"]');
-    // AC1/AC6: the @object env var round-trips from disk and renders as JSON (the env editor
+    // The @object env var round-trips from disk and renders as JSON (the env editor
     // pretty-prints, so assert on format-agnostic substrings rather than the exact JSON string).
     const cfgRow = envSettings.locator('[data-testid="env-var-row-cfg"]');
     await expect(cfgRow).toContainText('"host"');
@@ -108,7 +90,7 @@ test.describe('Data types in collection & environment variables', () => {
     await expect(cfgRow).not.toContainText('[object Object]');
     await expect(envSettings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
 
-    // AC3/AC4: change `tok` to number and save — the env file gains the @number annotation.
+    // Change `tok` to number and save — the env file gains the @number annotation.
     await envSettings.locator('[data-testid="datatype-selector-tok"]').click();
     await envSettings.locator('[data-testid="datatype-selector-tok-number"]').click();
     await expect(envSettings.locator('[data-testid="datatype-selector-tok"]')).toContainText('number');
@@ -135,7 +117,7 @@ test.describe('Data types in collection & environment variables', () => {
     await folderRow.locator('[data-testid="collection-item-menu"]').click();
     await sidebar.locator('[role="menuitem"]').filter({ hasText: 'Settings' }).click();
 
-    const settings = await frameWith(page, '[role="tab"]');
+    const settings = await frameWith(page, '[data-testid="folder-settings"]');
     await settings.locator('[role="tab"]').filter({ hasText: 'Vars' }).first().click();
 
     const table = settings.locator('[data-testid="folder-vars-req"]');
@@ -145,7 +127,7 @@ test.describe('Data types in collection & environment variables', () => {
     await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
     await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
 
-    // AC3/AC4: change tok -> number and Save; the folder file gains @number, @object survives.
+    // Change tok -> number and Save; the folder file gains @number, @object survives.
     const folderFile = path.join(collectionDir, 'sub', 'folder.bru');
     await settings.locator('[data-testid="datatype-selector-tok"]').click();
     await settings.locator('[data-testid="datatype-selector-tok-number"]').click();

--- a/tests/e2e/specs/datatype-settings.spec.ts
+++ b/tests/e2e/specs/datatype-settings.spec.ts
@@ -1,0 +1,139 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Page, Frame } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import { openBrunoSidebar, createCollection, openRequest, createFolder } from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+function findCollectionDir(root: string): string {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+  throw new Error(`No collection (bruno.json) found under ${root}`);
+}
+
+// Scan the webview frames for the one exposing `marker`, re-acquiring after a panel opens.
+async function frameWith(page: Page, marker: string, timeout = 15_000): Promise<Frame> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      if (frame === page.mainFrame()) continue;
+      try {
+        if ((await frame.locator(marker).count()) > 0) return frame;
+      } catch {
+        /* frame detached mid-scan */
+      }
+    }
+    await page.waitForTimeout(400);
+  }
+  throw new Error(`No webview frame with ${marker} within ${timeout}ms`);
+}
+
+test.describe('Data types in collection & environment variables', () => {
+  test('collection Vars: an object value shows as JSON with a type selector reflecting the on-disk type', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Typed Coll';
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'collection.bru'), [
+      'vars:pre-request {', '  @object', '  cfg: {"host":"localhost"}', '  tok: plain', '}', ''
+    ].join('\n'), 'utf8');
+
+    // Open collection settings by clicking the collection name, then the Vars tab.
+    await buildCommonLocators(sidebar).sidebar.collectionName(collectionName).click();
+    const settings = await frameWith(page, '[data-testid="collection-settings"]');
+    await settings.locator('[role="tab"]').filter({ hasText: 'Vars' }).first().click();
+
+    const table = settings.locator('[data-testid="collection-vars-req"]');
+    await expect(table).toBeVisible({ timeout: 15_000 });
+    // AC1/AC6: parsed from disk, object renders as JSON and the collection doesn't break.
+    await expect(table).toContainText('{"host":"localhost"}');
+    await expect(table).not.toContainText('[object Object]');
+    // AC2: selector reflects the on-disk data type.
+    await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
+    await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
+  });
+
+  test('environment Vars: typed values display, and choosing a type persists it to the env file', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Typed Env';
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.mkdirSync(path.join(collectionDir, 'environments'), { recursive: true });
+    const envFile = path.join(collectionDir, 'environments', 'Local.bru');
+    // Environment vars use the `vars { }` block (not `vars:pre-request`).
+    fs.writeFileSync(envFile, ['vars {', '  @object', '  cfg: {"host":"localhost"}', '  tok: plain', '}', ''].join('\n'), 'utf8');
+    // A request is needed so the environment selector renders in the editor toolbar.
+    fs.writeFileSync(path.join(collectionDir, 'Ping.bru'), [
+      'meta {', '  name: Ping', '  type: http', '  seq: 1', '}', '',
+      'get {', '  url: https://usebruno.com', '  body: none', '  auth: inherit', '}', ''
+    ].join('\n'), 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Ping');
+    await editor.locator('[data-testid="environment-selector-trigger"]').click();
+    await editor.locator('.dropdown-item').filter({ hasText: 'Local' }).first().click();
+
+    // Re-open the selector and click "Configure" to open the environment settings panel.
+    await editor.locator('[data-testid="environment-selector-trigger"]').click();
+    await editor.locator('#configure-env').click();
+
+    const envSettings = await frameWith(page, '[data-testid="save-env"]');
+    // AC1/AC6: the @object env var round-trips from disk and renders as JSON (the env editor
+    // pretty-prints, so assert on format-agnostic substrings rather than the exact JSON string).
+    const cfgRow = envSettings.locator('[data-testid="env-var-row-cfg"]');
+    await expect(cfgRow).toContainText('"host"');
+    await expect(cfgRow).toContainText('localhost');
+    await expect(cfgRow).not.toContainText('[object Object]');
+    await expect(envSettings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
+
+    // AC3/AC4: change `tok` to number and save — the env file gains the @number annotation.
+    await envSettings.locator('[data-testid="datatype-selector-tok"]').click();
+    await envSettings.locator('[data-testid="datatype-selector-tok-number"]').click();
+    await expect(envSettings.locator('[data-testid="datatype-selector-tok"]')).toContainText('number');
+    await envSettings.locator('[data-testid="save-env"]').click();
+    await expect.poll(() => fs.readFileSync(envFile, 'utf8'), { timeout: 15_000 }).toContain('@number');
+    // The pre-existing @object annotation survives the save.
+    expect(fs.readFileSync(envFile, 'utf8')).toContain('@object');
+  });
+
+  test('folder Vars: an object value shows as JSON with a type selector reflecting the on-disk type', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Typed Folder';
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+    await createFolder(sidebar, collectionName, 'sub');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'sub', 'folder.bru'), [
+      'vars:pre-request {', '  @object', '  cfg: {"host":"localhost"}', '  tok: plain', '}', ''
+    ].join('\n'), 'utf8');
+
+    // Open folder settings via the folder row's context menu.
+    const folderRow = sidebar.locator('[data-testid="sidebar-collection-item-row"]').filter({ hasText: 'sub' });
+    await folderRow.hover();
+    await folderRow.locator('[data-testid="collection-item-menu"]').click();
+    await sidebar.locator('[role="menuitem"]').filter({ hasText: 'Settings' }).click();
+
+    const settings = await frameWith(page, '[role="tab"]');
+    await settings.locator('[role="tab"]').filter({ hasText: 'Vars' }).first().click();
+
+    const table = settings.locator('[data-testid="folder-vars-req"]');
+    await expect(table).toBeVisible({ timeout: 15_000 });
+    await expect(table).toContainText('{"host":"localhost"}');
+    await expect(table).not.toContainText('[object Object]');
+    await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
+    await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
+  });
+});

--- a/tests/e2e/specs/datatype-settings.spec.ts
+++ b/tests/e2e/specs/datatype-settings.spec.ts
@@ -64,6 +64,15 @@ test.describe('Data types in collection & environment variables', () => {
     // AC2: selector reflects the on-disk data type.
     await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
     await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
+
+    // AC3/AC4: change tok -> number and Save; the collection file gains @number, @object survives.
+    const collectionFile = path.join(collectionDir, 'collection.bru');
+    await settings.locator('[data-testid="datatype-selector-tok"]').click();
+    await settings.locator('[data-testid="datatype-selector-tok-number"]').click();
+    await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('number');
+    await settings.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect.poll(() => fs.readFileSync(collectionFile, 'utf8'), { timeout: 15_000 }).toContain('@number');
+    expect(fs.readFileSync(collectionFile, 'utf8')).toContain('@object');
   });
 
   test('environment Vars: typed values display, and choosing a type persists it to the env file', async ({ page, tmpDir }) => {
@@ -135,5 +144,14 @@ test.describe('Data types in collection & environment variables', () => {
     await expect(table).not.toContainText('[object Object]');
     await expect(settings.locator('[data-testid="datatype-selector-cfg"]')).toContainText('object');
     await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('string');
+
+    // AC3/AC4: change tok -> number and Save; the folder file gains @number, @object survives.
+    const folderFile = path.join(collectionDir, 'sub', 'folder.bru');
+    await settings.locator('[data-testid="datatype-selector-tok"]').click();
+    await settings.locator('[data-testid="datatype-selector-tok-number"]').click();
+    await expect(settings.locator('[data-testid="datatype-selector-tok"]')).toContainText('number');
+    await settings.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect.poll(() => fs.readFileSync(folderFile, 'utf8'), { timeout: 15_000 }).toContain('@number');
+    expect(fs.readFileSync(folderFile, 'utf8')).toContain('@object');
   });
 });

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -1,0 +1,102 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Page, Frame } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import { openBrunoSidebar, createCollection, openRequest } from '../utils/page/actions';
+import { getActiveEditorFrame } from '../utils/page/oauth2-actions';
+
+// Find the collection directory created under tmpDir (the folder containing bruno.json).
+function findCollectionDir(root: string): string {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+  throw new Error(`No collection (bruno.json) found under ${root}`);
+}
+
+// A request with a typed (object) pre-request var, a plain string pre-request var,
+// and a post-response var (which holds a JS expression, so it must NOT get a type).
+const TYPED_REQUEST_BRU = [
+  'meta {', '  name: Typed', '  type: http', '  seq: 1', '}', '',
+  'get {', '  url: https://usebruno.com', '  body: none', '  auth: inherit', '}', '',
+  'vars:pre-request {', '  @object', '  cfg: {"host":"localhost"}', '  token: abc123', '}', '',
+  'vars:post-response {', '  saved: res.body.token', '}', ''
+].join('\n');
+
+async function openTypedVars(page: Page, tmpDir: string): Promise<Frame> {
+  const sidebar = await openBrunoSidebar(page);
+  const collectionName = 'Typed Vars';
+  await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+  const collectionDir = findCollectionDir(tmpDir);
+  fs.writeFileSync(path.join(collectionDir, 'Typed.bru'), TYPED_REQUEST_BRU, 'utf8');
+
+  const opened = await openRequest(page, sidebar, collectionName, 'Typed');
+  // Re-acquire the editor frame (opening can replace the webview) before driving its tabs.
+  const editor = await getActiveEditorFrame(page, opened);
+  await openRequestPaneTab(editor, 'Vars');
+  return editor;
+}
+
+// The request-pane tabs collapse into a ">>" overflow menu when the pane is narrow, so a plain
+// role="tab" match misses tabs like Vars. Click it directly if visible, else via the overflow menu.
+async function openRequestPaneTab(editor: Frame, tabName: string): Promise<void> {
+  const directTab = editor.locator('[role="tab"]').filter({ hasText: tabName }).first();
+  if (await directTab.isVisible().catch(() => false)) {
+    await directTab.click();
+    return;
+  }
+  await editor.locator('.more-tabs').click();
+  await editor.locator(`[data-testid="menu-dropdown-${tabName.toLowerCase()}"]`).click();
+  await expect(editor.locator('[role="tab"]').filter({ hasText: tabName }).first()).toBeVisible({ timeout: 15_000 });
+}
+
+// One VS Code launch, every acceptance criterion checked in sequence — launching a fresh
+// instance per assertion is slow and flaky, so this stays a single test.
+test.describe('Data types in request variables', () => {
+  test('display, per-scope selector, dropdown options and type selection all work', async ({ page, tmpDir }) => {
+    const editor = await openTypedVars(page, tmpDir);
+
+    const reqTable = editor.locator('[data-testid="request-vars-req"]');
+    await expect(reqTable).toBeVisible({ timeout: 15_000 });
+
+    // AC1: the @object var round-trips from disk and renders as JSON, never "[object Object]".
+    await expect(reqTable).toContainText('{"host":"localhost"}');
+    await expect(reqTable).not.toContainText('[object Object]');
+
+    // AC2: the type selector reflects the parsed data type per row.
+    const cfgSelector = editor.locator('[data-testid="datatype-selector-cfg"]');
+    const tokenSelector = editor.locator('[data-testid="datatype-selector-token"]');
+    await expect(cfgSelector).toContainText('object');
+    await expect(tokenSelector).toContainText('string');
+
+    // AC3: post-response vars hold a JS expression, so no data-type selector is offered.
+    const resTable = editor.locator('[data-testid="request-vars-res"]');
+    await expect(resTable).toBeVisible();
+    await expect(resTable.locator('[data-testid^="datatype-selector-"]')).toHaveCount(0);
+
+    // AC5: the dropdown is portaled to the body, so every option is reachable/visible even
+    // though it opens over the last row / table edge (the z-order fix).
+    await tokenSelector.click();
+    for (const type of ['string', 'number', 'boolean', 'object']) {
+      await expect(editor.locator(`[data-testid="datatype-selector-token-${type}"]`)).toBeVisible();
+    }
+
+    // AC4 (UI): choosing a type applies it, and returning to the implicit 'string' default works.
+    await editor.locator('[data-testid="datatype-selector-token-number"]').click();
+    await expect(tokenSelector).toContainText('number');
+    await tokenSelector.click();
+    await editor.locator('[data-testid="datatype-selector-token-string"]').click();
+    await expect(tokenSelector).toContainText('string');
+  });
+});

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -2,27 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Page, Frame } from '@playwright/test';
 import { test, expect } from '../utils/fixtures';
-import { openBrunoSidebar, createCollection, openRequest } from '../utils/page/actions';
+import { openBrunoSidebar, createCollection, openRequest, findCollectionDir } from '../utils/page/actions';
 import { getActiveEditorFrame } from '../utils/page/oauth2-actions';
-
-// Find the collection directory created under tmpDir (the folder containing bruno.json).
-function findCollectionDir(root: string): string {
-  const stack = [root];
-  while (stack.length) {
-    const dir = stack.pop() as string;
-    let entries: fs.Dirent[] = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
-    for (const e of entries) {
-      if (e.isDirectory()) stack.push(path.join(dir, e.name));
-    }
-  }
-  throw new Error(`No collection (bruno.json) found under ${root}`);
-}
 
 // A request with a typed (object) pre-request var, a plain string pre-request var,
 // and a post-response var (which holds a JS expression, so it must NOT get a type).
@@ -70,29 +51,29 @@ test.describe('Data types in request variables', () => {
     const reqTable = editor.locator('[data-testid="request-vars-req"]');
     await expect(reqTable).toBeVisible({ timeout: 15_000 });
 
-    // AC1: the @object var round-trips from disk and renders as JSON, never "[object Object]".
+    // The @object var round-trips from disk and renders as JSON, never "[object Object]".
     await expect(reqTable).toContainText('{"host":"localhost"}');
     await expect(reqTable).not.toContainText('[object Object]');
 
-    // AC2: the type selector reflects the parsed data type per row.
+    // The type selector reflects the parsed data type per row.
     const cfgSelector = editor.locator('[data-testid="datatype-selector-cfg"]');
     const tokenSelector = editor.locator('[data-testid="datatype-selector-token"]');
     await expect(cfgSelector).toContainText('object');
     await expect(tokenSelector).toContainText('string');
 
-    // AC3: post-response vars hold a JS expression, so no data-type selector is offered.
+    // Post-response vars hold a JS expression, so no data-type selector is offered.
     const resTable = editor.locator('[data-testid="request-vars-res"]');
     await expect(resTable).toBeVisible();
     await expect(resTable.locator('[data-testid^="datatype-selector-"]')).toHaveCount(0);
 
-    // AC5: the dropdown is portaled to the body, so every option is reachable/visible even
-    // though it opens over the last row / table edge (the z-order fix).
+    // The dropdown is portaled to the body, so every option is reachable/visible even
+    // though it opens over the last row / table edge.
     await tokenSelector.click();
     for (const type of ['string', 'number', 'boolean', 'object']) {
       await expect(editor.locator(`[data-testid="datatype-selector-token-${type}"]`)).toBeVisible();
     }
 
-    // AC4: choosing a type applies it in the UI and persists to disk on save (Cmd/Ctrl+S).
+    // Choosing a type applies it in the UI and persists to disk on save (Cmd/Ctrl+S).
     const requestFile = path.join(findCollectionDir(tmpDir), 'Typed.bru');
     await editor.locator('[data-testid="datatype-selector-token-number"]').click();
     await expect(tokenSelector).toContainText('number');

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -92,11 +92,20 @@ test.describe('Data types in request variables', () => {
       await expect(editor.locator(`[data-testid="datatype-selector-token-${type}"]`)).toBeVisible();
     }
 
-    // AC4 (UI): choosing a type applies it, and returning to the implicit 'string' default works.
+    // AC4: choosing a type applies it in the UI and persists to disk on save (Cmd/Ctrl+S).
+    const requestFile = path.join(findCollectionDir(tmpDir), 'Typed.bru');
     await editor.locator('[data-testid="datatype-selector-token-number"]').click();
     await expect(tokenSelector).toContainText('number');
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+S' : 'Control+S');
+    await expect.poll(() => fs.readFileSync(requestFile, 'utf8'), { timeout: 15_000 }).toContain('@number');
+
+    // Reverting to the implicit 'string' default drops the annotation on disk.
     await tokenSelector.click();
     await editor.locator('[data-testid="datatype-selector-token-string"]').click();
     await expect(tokenSelector).toContainText('string');
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+S' : 'Control+S');
+    await expect.poll(() => fs.readFileSync(requestFile, 'utf8'), { timeout: 15_000 }).not.toContain('@number');
+    // The object var's annotation is untouched throughout.
+    expect(fs.readFileSync(requestFile, 'utf8')).toContain('@object');
   });
 });

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Page, Frame } from '@playwright/test';
 import { test, expect } from '../utils/fixtures';
-import { openBrunoSidebar, createCollection, openRequest, findCollectionDir } from '../utils/page/actions';
+import { openBrunoSidebar, createCollection, openRequest, openRequestPaneTab, findCollectionDir } from '../utils/page/actions';
 import { getActiveEditorFrame } from '../utils/page/oauth2-actions';
 
 // A request with a typed (object) pre-request var, a plain string pre-request var,
@@ -27,19 +27,6 @@ async function openTypedVars(page: Page, tmpDir: string): Promise<Frame> {
   const editor = await getActiveEditorFrame(page, opened);
   await openRequestPaneTab(editor, 'Vars');
   return editor;
-}
-
-// The request-pane tabs collapse into a ">>" overflow menu when the pane is narrow, so a plain
-// role="tab" match misses tabs like Vars. Click it directly if visible, else via the overflow menu.
-async function openRequestPaneTab(editor: Frame, tabName: string): Promise<void> {
-  const directTab = editor.locator('[role="tab"]').filter({ hasText: tabName }).first();
-  if (await directTab.isVisible().catch(() => false)) {
-    await directTab.click();
-    return;
-  }
-  await editor.locator('.more-tabs').click();
-  await editor.locator(`[data-testid="menu-dropdown-${tabName.toLowerCase()}"]`).click();
-  await expect(editor.locator('[role="tab"]').filter({ hasText: tabName }).first()).toBeVisible({ timeout: 15_000 });
 }
 
 // One VS Code launch, every acceptance criterion checked in sequence — launching a fresh

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -1,5 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { Page, Frame, Locator, expect } from '@playwright/test';
 import { buildCommonLocators } from './locators';
+
+/**
+ * Locate the collection directory (the folder containing bruno.json) created under a test's tmpDir.
+ */
+export function findCollectionDir(root: string): string {
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (entries.some((e) => e.isFile() && e.name === 'bruno.json')) return dir;
+    for (const e of entries) {
+      if (e.isDirectory()) stack.push(path.join(dir, e.name));
+    }
+  }
+  throw new Error(`No collection (bruno.json) found under ${root}`);
+}
 
 /**
  * Find the webview Frame that contains actual Bruno app content.

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -917,11 +917,16 @@ export async function pasteIntoCollection(sidebar: Frame, collectionName: string
  * @param tabName - Visible label of the tab to select
  */
 export async function openRequestPaneTab(editor: Frame, tabName: string): Promise<void> {
-  await editor
-    .locator('[role="tab"]')
-    .filter({ hasText: tabName })
-    .first()
-    .click();
+  // Request-pane tabs collapse into a ">>" overflow menu when the pane is narrow, so click the tab
+  // directly when it's visible, otherwise reach it via the overflow menu.
+  const directTab = editor.locator('[role="tab"]').filter({ hasText: tabName }).first();
+  if (await directTab.isVisible().catch(() => false)) {
+    await directTab.click();
+    return;
+  }
+  await editor.locator('.more-tabs').click();
+  await editor.locator(`[data-testid="menu-dropdown-${tabName.toLowerCase()}"]`).click();
+  await expect(directTab).toBeVisible({ timeout: 15_000 });
 }
 
 /**


### PR DESCRIPTION
## Summary
Extends data-type support (string / number / boolean / object) to the **Collection**, **Folder** and **Request** variable tables, so typed values display correctly and a variable's type can be set from the UI — reaching parity with Bruno desktop and the environment editor. Follow-up to the data-type work in #105.

## Problem

- object values rendered as the literal `[object Object]` in the Collection, Folder and Request Vars tables, and
- there was no way to choose a variable's type from those tables.

The type dropdown also opened clipped inside the table instead of overlaying it.

## Root Cause
Those tables passed the raw variable value straight to the value editor (so objects stringified to `[object Object]`) and offered no type control. The type dropdown mounted inside the table cell, so the table's overflow clipped it.

## Solution
- Render values through the shared data-type formatter, so objects display as JSON.
- Add a per-row type selector for request-scoped vars — response vars hold a JS expression, so they're intentionally excluded — and persist the chosen type to disk through the existing save path.
- Portal the type dropdown to the document body so it overlays the table at the correct z-order, matching desktop.

No new on-disk format or serialization — this builds on the layers merged in #105.

## Test plan
- [ ] Collection / Folder / Request var whose value is an object shows as JSON, not `[object Object]`
- [ ] Set a var's type from the table → persisted to the file with the correct annotation and round-trips on reload
- [ ] Post-response (expression) vars show no type selector
- [ ] The type dropdown opens fully above the table (not clipped)
- [ ] Plain string vars are unchanged on disk
- [x] TypeScript typecheck, unit tests, and Playwright e2e green — new e2e covers display, per-scope selector, the dropdown z-order, and a change-type → save → disk round-trip across request, collection, folder and environment vars
