### PR TITLE
fix(transient-request) - inherit collection settings, environments and presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@vitest/coverage-v8": "^4.1.2",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "autoprefixer": "^10.4.20",
         "cors": "^2.8.6",
         "esbuild": "^0.20.0",
@@ -7055,9 +7055,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7068,7 +7068,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-electron/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -441,7 +441,7 @@
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/coverage-v8": "^4.1.2",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "autoprefixer": "^10.4.20",
     "cors": "^2.8.6",
     "esbuild": "^0.20.0",

--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -1571,7 +1571,6 @@ class CollectionWatcher {
         await this.handleFileAddWithSender(filePath, collectionUid, collectionPath, sender);
       }
 
-      // Load the environments
       await this.loadEnvironments(collectionPath, collectionUid, sender);
 
       // If no .env file, still send process.env variables

--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -1571,6 +1571,9 @@ class CollectionWatcher {
         await this.handleFileAddWithSender(filePath, collectionUid, collectionPath, sender);
       }
 
+      // Load the environments
+      await this.loadEnvironments(collectionPath, collectionUid, sender);
+
       // If no .env file, still send process.env variables
       if (!hasDotEnv && sender) {
         sender('main:process-env-update', {

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { WebviewHelper } from '../webview/helper';
 import { showSaveRequestPicker } from '../utils/folder-picker';
+import { posixifyPath } from '../utils/filesystem';
 import { stateManager } from '../webview/state-manager';
 import {
   setCurrentWebview,
@@ -166,8 +167,10 @@ export async function openTransientRequestPanel(
     // 3) Stream the whole collection into THIS webview's store.
     try {
       // Register watcher if not already present.
-      if (!collectionWatcher.hasWatcher(collectionPath)) {
-        collectionWatcher.setupWatchersOnly(collectionPath, uid);
+      const nativePath = path.normalize(collectionPath);
+      const posixPath = posixifyPath(collectionPath);
+      if (!collectionWatcher.hasWatcher(nativePath) && !collectionWatcher.hasWatcher(posixPath)) {
+        collectionWatcher.setupWatchersOnly(nativePath, uid);
       }
       await collectionWatcher.loadFullCollection(collectionPath, uid, webviewSender);
     } catch (error) {

--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -18,9 +18,8 @@ import {
   handleInvoke,
   hasHandler
 } from '../ipc/handlers';
-import { openCollection, loadCollectionMetadata, setMessageSender as setCollectionsMessageSender } from '../app/collections';
+import { loadCollectionMetadata } from '../app/collections';
 import { notifyActiveItemToSidebar, clearActiveItemFromSidebar } from '../ipc/collection';
-import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import { AppItem } from '@bruno-types';
 
@@ -130,24 +129,21 @@ export async function openTransientRequestPanel(
     stateManager.sendTo(panel.webview, channel, ...args);
   };
 
-  const originalBroadcastSender = (channel: string, ...args: unknown[]) => {
-    stateManager.broadcast(channel, ...args);
-  };
-
   let collectionLoaded = false;
 
   // Render the transient request as soon as the webview is ready. We send the
   // collection metadata + the transient item + the view type in a single
   // burst so the UI shows the request immediately. The full collection tree
-  // (environments, siblings, watchers) is populated in the background via
-  // openCollection so scripts/vars eventually resolve, but the user does not
-  // wait for a full scan to see the request pane.
+  // (environments, siblings, watchers) is populated in the background so
+  // scripts/vars eventually resolve, but the user does not wait for a full
+  // scan to see the request pane.
   const loadCollection = async () => {
     if (collectionLoaded) return;
     collectionLoaded = true;
 
     // 1) Seed collection metadata and the transient item in Redux immediately.
-    await loadCollectionMetadata(collectionPath, webviewSender);
+    const loadedUid = await loadCollectionMetadata(collectionPath, webviewSender);
+    const uid = loadedUid || collectionUid;
 
     const item = transientItems.get(itemUid);
     if (item) {
@@ -167,16 +163,15 @@ export async function openTransientRequestPanel(
       });
     }
 
-    // 3) Kick off the full collection load in the background for env/tree.
-    setCollectionsMessageSender(webviewSender);
-    setWatcherMessageSender(webviewSender);
+    // 3) Stream the whole collection into THIS webview's store.
     try {
-      await openCollection(collectionWatcher, collectionPath);
+      // Register watcher if not already present.
+      if (!collectionWatcher.hasWatcher(collectionPath)) {
+        collectionWatcher.setupWatchersOnly(collectionPath, uid);
+      }
+      await collectionWatcher.loadFullCollection(collectionPath, uid, webviewSender);
     } catch (error) {
-      console.error('TransientRequestPanel: Error opening collection:', error);
-    } finally {
-      setCollectionsMessageSender(originalBroadcastSender);
-      setWatcherMessageSender(originalBroadcastSender);
+      console.error('TransientRequestPanel: Error loading collection:', error);
     }
   };
 

--- a/src/webview/components/Environments/EnvironmentSelector/EnvironmentListContent/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSelector/EnvironmentListContent/index.tsx
@@ -26,8 +26,12 @@ const EnvironmentListContent = ({
     <div>
       {environments && environments.length > 0 ? (
         <>
-          <div className="environment-list">
-            <div className="dropdown-item no-environment" onClick={() => onEnvironmentSelect(null)}>
+          <div className="environment-list" data-testid="environment-list">
+            <div
+              className="dropdown-item no-environment"
+              onClick={() => onEnvironmentSelect(null)}
+              data-testid="environment-list-no-environment"
+            >
               <span>No Environment</span>
             </div>
             <ToolHint
@@ -47,13 +51,14 @@ const EnvironmentListContent = ({
                   onClick={() => onEnvironmentSelect(env)}
                   data-tooltip-content={env.name}
                   data-tooltip-hidden={env.name?.length < 90}
+                  data-testid="environment-list-item"
                 >
                   <span className="max-w-100% truncate no-wrap">{env.name}</span>
                 </div>)}
               </div>
             </ToolHint>
             <div className="dropdown-item configure-button">
-              <button onClick={onSettingsClick} id="configure-env">
+              <button onClick={onSettingsClick} id="configure-env" data-testid="environment-list-configure">
                 <IconSettings size={16} strokeWidth={1.5} />
                 <span>Configure</span>
               </button>
@@ -61,7 +66,7 @@ const EnvironmentListContent = ({
           </div>
         </>
       ) : (
-        <div className="empty-state">
+        <div className="empty-state" data-testid="environment-list-empty-state">
           <h3>Ready to get started?</h3>
           <p>{description}</p>
           <div className="space-y-2">

--- a/src/webview/components/Environments/EnvironmentSelector/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSelector/index.tsx
@@ -136,7 +136,12 @@ const EnvironmentSelector = ({
                 delayShow={1000}
                 hidden={activeCollectionEnvironment.name?.length < 7}
               >
-                <span className="env-text max-w-24 truncate overflow-hidden">{activeCollectionEnvironment.name}</span>
+                <span
+                  className="env-text max-w-24 truncate overflow-hidden"
+                  data-testid="active-collection-environment"
+                >
+                  {activeCollectionEnvironment.name}
+                </span>
               </ToolHint>
             </div>
             {activeGlobalEnvironment && <span className="env-separator">|</span>}
@@ -152,13 +157,20 @@ const EnvironmentSelector = ({
               delayShow={1000}
               hidden={activeGlobalEnvironment.name?.length < 7}
             >
-              <span className="env-text max-w-24 truncate overflow-hidden">{activeGlobalEnvironment.name}</span>
+              <span
+                className="env-text max-w-24 truncate overflow-hidden"
+                data-testid="active-global-environment"
+              >
+                {activeGlobalEnvironment.name}
+              </span>
             </ToolHint>
           </div>
         )}
       </>
     ) : (
-      <span className="env-text-inactive max-w-36 truncate no-wrap">No Environment</span>
+      <span className="env-text-inactive max-w-36 truncate no-wrap" data-testid="no-active-environment">
+        No Environment
+      </span>
     );
 
     return (

--- a/src/webview/utils/transient-manager.spec.ts
+++ b/src/webview/utils/transient-manager.spec.ts
@@ -239,3 +239,50 @@ describe('createWebSocketRequest', () => {
     expect(item.settings).toEqual({ timeout: 0, keepAliveInterval: 0 });
   });
 });
+
+// ─── Collection-level inheritance ───────────────────────────────────────────
+
+describe('collection presets', () => {
+  const withPresets: CollectionInfo = {
+    uid: 'col-5',
+    pathname: '/Users/test/preset-collection',
+    format: 'bru',
+    brunoConfig: { presets: { requestType: 'http', requestUrl: 'https://api.example.com' } }
+  };
+
+  const withDraftPresets: CollectionInfo = {
+    ...withPresets,
+    uid: 'col-6',
+    draft: { brunoConfig: { presets: { requestUrl: 'https://draft.example.com' } } }
+  };
+
+  beforeEach(() => {
+    transientManager.resetCounter(withPresets.uid);
+    transientManager.resetCounter(withDraftPresets.uid);
+  });
+
+  test('base URL preset seeds the url of every request type', () => {
+    expect(transientManager.createHttpRequest(withPresets).request.url).toBe('https://api.example.com');
+    expect(transientManager.createGraphQLRequest(withPresets).request.url).toBe('https://api.example.com');
+    expect(transientManager.createGrpcRequest(withPresets).request.url).toBe('https://api.example.com');
+    expect(transientManager.createWebSocketRequest(withPresets).request.url).toBe('https://api.example.com');
+  });
+
+  test('unsaved preset edits on the draft win over the saved config', () => {
+    const item = transientManager.createHttpRequest(withDraftPresets);
+    expect(item.request.url).toBe('https://draft.example.com');
+  });
+
+  test('collections without presets still produce an empty url', () => {
+    expect(transientManager.createHttpRequest(bruCollection).request.url).toBe('');
+  });
+
+  test('the requestType preset does not override the type picked from the menu', () => {
+    const graphqlPreset: CollectionInfo = {
+      uid: 'col-7',
+      pathname: '/Users/test/graphql-preset',
+      brunoConfig: { presets: { requestType: 'graphql' } }
+    };
+    expect(transientManager.createHttpRequest(graphqlPreset).type).toBe('http-request');
+  });
+});

--- a/src/webview/utils/transient-manager.ts
+++ b/src/webview/utils/transient-manager.ts
@@ -25,10 +25,17 @@ interface TransientItem {
   settings: Record<string, unknown>;
 }
 
+interface CollectionPresets {
+  requestType?: string;
+  requestUrl?: string;
+}
+
 interface CollectionInfo {
   uid: string;
   pathname: string;
   format?: string; // 'bru' or 'yml'
+  brunoConfig?: { presets?: CollectionPresets };
+  draft?: { brunoConfig?: { presets?: CollectionPresets } } | null;
   items?: any[]; // saved requests + open transients
 }
 
@@ -59,9 +66,18 @@ function generateItemMeta(collection: CollectionInfo): { name: string; filename:
   return { name, filename, pathname };
 }
 
-function createBaseRequest(): Record<string, unknown> {
+// Collection presets. 
+function getPresets(collection: CollectionInfo): CollectionPresets {
+  return collection?.draft?.brunoConfig?.presets || collection?.brunoConfig?.presets || {};
+}
+
+function getPresetUrl(collection: CollectionInfo): string {
+  return getPresets(collection).requestUrl || '';
+}
+
+function createBaseRequest(url = ''): Record<string, unknown> {
   return {
-    url: '',
+    url,
     method: 'GET',
     headers: [],
     params: [],
@@ -87,7 +103,7 @@ const transientManager = {
       draft: null,
       filename,
       pathname,
-      request: createBaseRequest(),
+      request: createBaseRequest(getPresetUrl(collection)),
       settings: { encodeUrl: true }
     };
   },
@@ -104,7 +120,7 @@ const transientManager = {
       filename,
       pathname,
       request: {
-        ...createBaseRequest(),
+        ...createBaseRequest(getPresetUrl(collection)),
         method: 'POST',
         body: {
           mode: 'graphql',
@@ -127,7 +143,7 @@ const transientManager = {
       filename,
       pathname,
       request: {
-        url: '',
+        url: getPresetUrl(collection),
         method: '',
         methodType: '',
         headers: [],
@@ -158,7 +174,7 @@ const transientManager = {
       filename,
       pathname,
       request: {
-        url: '',
+        url: getPresetUrl(collection),
         method: 'GET',
         headers: [],
         params: [],

--- a/tests/e2e/transient-request/fixtures/transient-inheritance-collection.json
+++ b/tests/e2e/transient-request/fixtures/transient-inheritance-collection.json
@@ -1,0 +1,90 @@
+{
+  "name": "Transient Inheritance",
+  "version": "1",
+  "items": [
+    {
+      "type": "http",
+      "name": "Saved Request",
+      "filename": "saved-request.bru",
+      "seq": 1,
+      "settings": { "encodeUrl": true },
+      "tags": [],
+      "request": {
+        "url": "http://127.0.0.1:8081/ping",
+        "method": "GET",
+        "headers": [],
+        "params": [],
+        "body": { "mode": "none", "formUrlEncoded": [], "multipartForm": [], "file": [] },
+        "script": {},
+        "vars": {},
+        "assertions": [],
+        "tests": "",
+        "docs": "",
+        "auth": { "mode": "inherit" }
+      }
+    }
+  ],
+  "environments": [
+    {
+      "name": "Local",
+      "variables": [
+        {
+          "name": "envHost",
+          "value": "local-env-value",
+          "type": "text",
+          "enabled": true,
+          "secret": false
+        }
+      ]
+    },
+    {
+      "name": "Staging",
+      "variables": [
+        {
+          "name": "envHost",
+          "value": "staging-env-value",
+          "type": "text",
+          "enabled": true,
+          "secret": false
+        }
+      ]
+    }
+  ],
+  "root": {
+    "meta": { "name": "Transient Inheritance" },
+    "request": {
+      "headers": [
+        {
+          "uid": "collectionHeader1xxxx",
+          "name": "x-prompt-header",
+          "value": "from-collection-root",
+          "enabled": true
+        }
+      ],
+      "auth": { "mode": "bearer", "bearer": { "token": "collection-root-token" } },
+      "vars": {
+        "req": [
+          {
+            "uid": "collectionVar1xxxxxxx",
+            "name": "collectionVar",
+            "value": "from-collection-vars",
+            "enabled": true
+          }
+        ],
+        "res": []
+      },
+      "script": { "req": "", "res": "" },
+      "tests": ""
+    }
+  },
+  "brunoConfig": {
+    "version": "1",
+    "name": "Transient Inheritance",
+    "type": "collection",
+    "ignore": ["node_modules", ".git"],
+    "presets": {
+      "requestType": "http",
+      "requestUrl": "http://127.0.0.1:8081/api/echo/query?collVar={{collectionVar}}&envVar={{envHost}}"
+    }
+  }
+}

--- a/tests/e2e/transient-request/transient-request-inheritance.spec.ts
+++ b/tests/e2e/transient-request/transient-request-inheritance.spec.ts
@@ -1,0 +1,84 @@
+import * as path from 'path';
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  importCollection,
+  openTransientRequest,
+  selectEnvironment,
+  setCodeMirrorValue,
+  sendRequest
+} from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+/**
+ * A transient request is created from the collection's "+" menu and never touches
+ * disk, so everything it inherits has to be pushed into its own panel: the collection
+ * root (headers / vars / auth), the environments, and the presets.
+ */
+
+const SERVER = 'http://127.0.0.1:8081';
+const FIXTURE = path.resolve(__dirname, 'fixtures/transient-inheritance-collection.json');
+const COLLECTION = 'Transient Inheritance';
+
+test.describe('Transient request inherits collection-level settings', () => {
+  test('inherits presets, environments, vars, headers and auth', async ({ page, tmpDir }) => {
+    // One launch + an import + four sends does not fit the default per-test budget.
+    test.slow();
+
+    const panel = await test.step('create a transient request in the collection', async () => {
+      const sidebar = await openBrunoSidebar(page);
+      await importCollection(page, sidebar, FIXTURE, tmpDir, COLLECTION);
+      return openTransientRequest(page, sidebar, COLLECTION);
+    });
+
+    const locators = buildCommonLocators(panel);
+    const env = locators.environment;
+    const url = locators.requestUrl.editor().locator('.CodeMirror');
+    const response = locators.response.previewContainer();
+
+    await test.step('seeds the URL from the collection base-URL preset', async () => {
+      await expect(locators.requestUrl.editor()).toContainText('/api/echo/query');
+      await expect(locators.requestUrl.editor()).toContainText('{{collectionVar}}');
+      await expect(locators.requestUrl.editor()).toContainText('{{envHost}}');
+    });
+
+    await test.step('lists the collection environments in the picker', async () => {
+      await expect(env.inactiveLabel()).toBeVisible();
+      await env.trigger().click();
+
+      await expect(env.item('Local')).toBeVisible();
+      await expect(env.item('Staging')).toBeVisible();
+      await expect(env.items()).toHaveCount(2);
+      await expect(env.emptyState()).toHaveCount(0);
+
+      // Close it again so the next step opens from a known state.
+      await env.trigger().click();
+      await expect(env.items()).toHaveCount(0);
+    });
+
+    await test.step('sends with the collection var and the selected environment', async () => {
+      await selectEnvironment(panel, 'Local');
+      await sendRequest(panel, 200);
+      await expect(response).toContainText('from-collection-vars');
+      await expect(response).toContainText('local-env-value');
+    });
+
+    await test.step('re-interpolates after switching environment', async () => {
+      await selectEnvironment(panel, 'Staging');
+      await sendRequest(panel, 200);
+      await expect(response).toContainText('staging-env-value');
+    });
+
+    await test.step('attaches the collection-level header', async () => {
+      await setCodeMirrorValue(page, url, `${SERVER}/api/echo/header`);
+      await sendRequest(panel, 200);
+      await expect(response).toContainText('from-collection-root');
+    });
+
+    await test.step('applies collection-level auth through inherit mode', async () => {
+      await setCodeMirrorValue(page, url, `${SERVER}/api/echo/auth`);
+      await sendRequest(panel, 200);
+      await expect(response).toContainText('Bearer collection-root-token');
+    });
+  });
+});

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -259,6 +259,50 @@ export async function openNewRequestPanel(
 }
 
 /**
+ * Create a transient request from the collection row's "+" menu
+ * and return its panel Frame.
+ */
+export async function openTransientRequest(
+  page: Page,
+  sidebar: Frame,
+  collectionName: string,
+  type: 'HTTP' | 'GraphQL' | 'gRPC' | 'WebSocket' = 'HTTP'
+): Promise<Frame> {
+  const menuItemId = { HTTP: 'new-http', GraphQL: 'new-graphql', gRPC: 'new-grpc', WebSocket: 'new-ws' }[type];
+  const marker = type === 'WebSocket'
+    ? '[data-testid="ws-connect-button"]'
+    : type === 'gRPC'
+      ? '[data-testid="grpc-query-url-container"]'
+      : '#request-url';
+
+  // The "+" only renders on hover; MenuDropdown puts its own testid on the trigger.
+  const collectionRow = buildCommonLocators(sidebar).sidebar.collectionName(collectionName);
+  await collectionRow.hover();
+  await sidebar.getByTestId('collection-new-request').click();
+  await sidebar.getByTestId(`collection-new-request-${menuItemId}`).click();
+
+  return waitForFrameWithMarker(page, sidebar, marker);
+}
+
+/**
+ * Pick an environment from the collection toolbar's environment selector.
+ */
+export async function selectEnvironment(frame: Frame, name: string | null): Promise<void> {
+  const env = buildCommonLocators(frame).environment;
+  await env.trigger().click();
+
+  const option = name ? env.item(name) : env.noEnvironmentOption();
+  await expect(option).toBeVisible();
+  await option.click();
+
+  if (name) {
+    await expect(env.activeName()).toHaveText(name);
+  } else {
+    await expect(env.inactiveLabel()).toBeVisible();
+  }
+}
+
+/**
  * Fill the new request form and submit it.
  *
  * @param page - Playwright Page
@@ -654,14 +698,22 @@ async function openRequestByMarker(
   // Click the request to open it in the editor
   await requestRow.click();
 
-  // Wait for the request editor frame — identified by the marker selector.
-  const timeout = 20_000;
+  return waitForFrameWithMarker(page, sidebar, markerSelector);
+}
+
+// Wait for the request editor frame — identified by the marker selector.
+async function waitForFrameWithMarker(
+  page: Page,
+  excludeFrame: Frame,
+  markerSelector: string,
+  timeout = 20_000
+): Promise<Frame> {
   const deadline = Date.now() + timeout;
   let editor: Frame | undefined;
 
   while (Date.now() < deadline) {
     for (const frame of page.frames()) {
-      if (frame === sidebar || frame === page.mainFrame()) continue;
+      if (frame === excludeFrame || frame === page.mainFrame()) continue;
       try {
         const has = await frame.locator(markerSelector).count();
         if (has > 0) { editor = frame; break; }

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -21,14 +21,11 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     requestsInfo: () => frame.getByTestId('collection-requests-count'),
     requestsNotLoaded: () => frame.getByTestId('collection-requests-not-loaded')
   },
-  // Environment picker in the collection toolbar .
   environment: {
     trigger: () => frame.getByTestId('environment-selector-trigger'),
-    // Names shown on the trigger; absent while nothing is selected.
     activeName: () => frame.getByTestId('active-collection-environment'),
     activeGlobalName: () => frame.getByTestId('active-global-environment'),
     inactiveLabel: () => frame.getByTestId('no-active-environment'),
-    // Rows of the open dropdown's collection tab — one per environment.
     item: (name: string) => frame.getByTestId('environment-list-item').filter({ hasText: name }),
     items: () => frame.getByTestId('environment-list-item'),
     noEnvironmentOption: () => frame.getByTestId('environment-list-no-environment'),

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -21,6 +21,19 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     requestsInfo: () => frame.getByTestId('collection-requests-count'),
     requestsNotLoaded: () => frame.getByTestId('collection-requests-not-loaded')
   },
+  // Environment picker in the collection toolbar .
+  environment: {
+    trigger: () => frame.getByTestId('environment-selector-trigger'),
+    // Names shown on the trigger; absent while nothing is selected.
+    activeName: () => frame.getByTestId('active-collection-environment'),
+    activeGlobalName: () => frame.getByTestId('active-global-environment'),
+    inactiveLabel: () => frame.getByTestId('no-active-environment'),
+    // Rows of the open dropdown's collection tab — one per environment.
+    item: (name: string) => frame.getByTestId('environment-list-item').filter({ hasText: name }),
+    items: () => frame.getByTestId('environment-list-item'),
+    noEnvironmentOption: () => frame.getByTestId('environment-list-no-environment'),
+    emptyState: () => frame.getByTestId('environment-list-empty-state')
+  },
   requestUrl: {
     editor: () => frame.locator('#request-url'),
     highlightedToken: (name: string) =>


### PR DESCRIPTION
**Jira: VSCODE-85**
### Description
On creating transient request it loads/inherits collection settings, presets and environments related to the collection.
### Problem
Opening a transient request is not inheriting collection settings, presets and environments.
### Fix
Environment and full collection is loaded so that newly created transient request inherits collection settings, presets, environments.

**Before**

https://github.com/user-attachments/assets/ad9d1f7c-2bd8-400b-baaa-948358e31c37

**After**

https://github.com/user-attachments/assets/09d9df4f-c3af-4844-a525-067481d5af0a

