### PR TITLE
feat: add support for 'app' item type

### DIFF
--- a/src/bruno-types/collection/item.ts
+++ b/src/bruno-types/collection/item.ts
@@ -9,7 +9,8 @@ export type ItemType =
   | 'folder'
   | 'js'
   | 'grpc-request'
-  | 'ws-request';
+  | 'ws-request'
+  | 'app';
 
 export interface HttpItemSettings {
   encodeUrl?: boolean | null;

--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import { WebviewHelper } from '../webview/helper';
 import { stateManager } from '../webview/state-manager';
 import { findCollectionRoot } from '../utils/path';
@@ -21,6 +22,8 @@ import {
   isFolderRootFile
 } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
+import { parseFileMeta } from '../utils/collection';
+import { getCollectionFormat } from '../utils/filesystem';
 import { defaultWorkspaceManager } from '../store/default-workspace';
 import { registerDocument, unregisterDocument } from './dirty-state-manager';
 import { notifyActiveItemToSidebar, clearActiveItemFromSidebar } from '../ipc/collection';
@@ -174,6 +177,20 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
         const isCollectionFile = fileName === 'collection.bru' || fileName === 'opencollection.yml';
         const isFolderFile = fileName === 'folder.bru' || fileName === 'folder.yml';
 
+        let isAppFile = false;
+        if (!isCollectionFile && !isFolderFile && !isVariablesMode) {
+          try {
+            const format = getCollectionFormat(collectionRoot);
+            const fileContent = await fs.promises.readFile(filePath, 'utf8');
+            const meta = parseFileMeta(fileContent, format);
+            if (meta && meta.type === 'app') {
+              isAppFile = true;
+            }
+          } catch (err) {
+            // If we can't read/parse, fall through to the default request view.
+          }
+        }
+
         let viewData: {
           viewType: string;
           collectionUid: string;
@@ -201,6 +218,13 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
             collectionUid,
             collectionPath: collectionRoot,
             folderUid: generateUidBasedOnHash(folderPath)
+          };
+        } else if (isAppFile) {
+          viewData = {
+            viewType: 'app-unsupported',
+            collectionUid,
+            collectionPath: collectionRoot,
+            itemUid: generateUidBasedOnHash(filePath)
           };
         } else {
           viewData = {

--- a/src/extension/utils/collection.ts
+++ b/src/extension/utils/collection.ts
@@ -476,6 +476,7 @@ const parseBruFileMeta = (data: string): Record<string, unknown> | null => {
       });
 
       let requestType = metaJson.type as string;
+      const isApp = requestType === 'app';
       if (requestType === 'http') {
         requestType = 'http-request';
       } else if (requestType === 'graphql') {
@@ -484,8 +485,23 @@ const parseBruFileMeta = (data: string): Record<string, unknown> | null => {
         requestType = 'grpc-request';
       } else if (requestType === 'ws' || requestType === 'websocket') {
         requestType = 'ws-request';
+      } else if (isApp) {
+        requestType = 'app';
       } else {
         requestType = 'http-request';
+      }
+
+      const sequence = metaJson.seq as number;
+      if (isApp) {
+        return {
+          type: 'app',
+          name: metaJson.name,
+          seq: !isNaN(sequence) ? Number(sequence) : 1,
+          settings: {},
+          tags: Array.isArray(metaJson.tags) ? metaJson.tags : [],
+          request: null,
+          app: { code: '' }
+        };
       }
 
       // Extract HTTP method via regex so the sidebar can render the method
@@ -496,7 +512,6 @@ const parseBruFileMeta = (data: string): Record<string, unknown> | null => {
         method = methodMatch[1].toLowerCase();
       }
 
-      const sequence = metaJson.seq as number;
       return {
         type: requestType,
         name: metaJson.name,
@@ -544,11 +559,26 @@ const parseYmlFileMeta = (data: string): Record<string, unknown> | null => {
     });
 
     let requestType = infoJson.type;
+    const isApp = requestType === 'app';
     if (requestType === 'http') requestType = 'http-request';
     else if (requestType === 'graphql') requestType = 'graphql-request';
     else if (requestType === 'grpc') requestType = 'grpc-request';
     else if (requestType === 'ws' || requestType === 'websocket') requestType = 'ws-request';
+    else if (isApp) requestType = 'app';
     else requestType = 'http-request';
+
+    const seq = Number(infoJson.seq);
+    if (isApp) {
+      return {
+        type: 'app',
+        name: infoJson.name,
+        seq: !isNaN(seq) ? seq : 1,
+        settings: {},
+        tags: [],
+        request: null,
+        app: { code: '' }
+      };
+    }
 
     // Find the first top-level method block (http:, graphql:, ...) and
     // pull its `method:` field if present.
@@ -564,7 +594,6 @@ const parseYmlFileMeta = (data: string): Record<string, unknown> | null => {
       }
     }
 
-    const seq = Number(infoJson.seq);
     return {
       type: requestType,
       name: infoJson.name,

--- a/src/extension/views/SidebarViewProvider.ts
+++ b/src/extension/views/SidebarViewProvider.ts
@@ -266,6 +266,16 @@ export class SidebarViewProvider implements vscode.WebviewViewProvider {
         }
         break;
 
+      case 'sidebar:open-app':
+        if (typeof args[0] === 'string') {
+          await vscode.commands.executeCommand(
+            'vscode.openWith',
+            vscode.Uri.file(args[0]),
+            'bruno.requestEditor'
+          );
+        }
+        break;
+
       case 'sidebar:open-folder':
         if (typeof args[0] === 'string') {
           await vscode.commands.executeCommand(

--- a/src/webview/components/RequestTabPanel/AppUnsupported.tsx
+++ b/src/webview/components/RequestTabPanel/AppUnsupported.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { IconAppWindow } from '@tabler/icons';
+
+const AppUnsupported: React.FC = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full p-8 text-center">
+      <IconAppWindow size={40} strokeWidth={1.5} className="mb-4 opacity-70" />
+      <div className="text-lg font-semibold mb-2">Apps are not supported in VS Code</div>
+      <div className="text-sm opacity-70 max-w-md">
+        To use this feature, please open this collection in the Bruno desktop application.
+      </div>
+    </div>
+  );
+};
+
+export default AppUnsupported;

--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemIcon/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/CollectionItemIcon/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import RequestMethod from '../RequestMethod';
-import { IconLoader2, IconAlertTriangle, IconAlertCircle } from '@tabler/icons';
+import { IconLoader2, IconAlertTriangle, IconAlertCircle, IconAppWindow } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
 
 interface CollectionItemIconProps {
@@ -17,6 +17,10 @@ const CollectionItemIcon = ({
 
   if (item?.loading) {
     return <IconLoader2 className="animate-spin w-fit mr-2" size={18} strokeWidth={1.5} />;
+  }
+
+  if (item?.type === 'app') {
+    return <IconAppWindow className="w-fit mr-2" size={16} strokeWidth={1.5} />;
   }
 
   // When we have a request type (from the lightweight meta parse), render

--- a/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/CollectionItem/index.tsx
@@ -31,7 +31,7 @@ import {
 } from 'providers/ReduxStore/slices/collections/actions';
 import { toggleCollectionItem } from 'providers/ReduxStore/slices/collections';
 import { copyRequest } from 'providers/ReduxStore/slices/app';
-import { isItemARequest, isItemAFolder } from 'utils/tabs';
+import { isItemARequest, isItemAFolder, isItemAnApp } from 'utils/tabs';
 import { doesRequestMatchSearchText, doesFolderHaveItemsMatchSearchText } from 'utils/collections/search';
 import { getDefaultRequestPaneTab } from 'utils/collections';
 import toast from 'react-hot-toast';
@@ -48,7 +48,7 @@ import ActionIcon from 'ui/ActionIcon';
 import MenuDropdown from 'ui/MenuDropdown';
 import { useSidebarAccordion } from 'components/Sidebar/SidebarAccordionContext';
 import useSearchCollapse from 'hooks/useSearchCollapse';
-import { isSidebarMode, openRequestInVSCodeEditor } from 'utils/webviewMode';
+import { isSidebarMode, openRequestInVSCodeEditor, openAppInVSCodeEditor } from 'utils/webviewMode';
 import { ipcRenderer } from 'utils/ipc';
 
 interface CollectionItemProps {
@@ -208,13 +208,19 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
     if (event && event.detail !== 1) return;
     setTimeout(scrollToTheActiveTab, 50);
     const isRequest = isItemARequest(item);
+    const isApp = isItemAnApp(item);
 
     if (isSidebarMode() && isRequest) {
       openRequestInVSCodeEditor(item.pathname);
       return;
     }
 
-    if (isRequest) {
+    if (isSidebarMode() && isApp) {
+      openAppInVSCodeEditor(item.pathname);
+      return;
+    }
+
+    if (isRequest || isApp) {
       if (isTabForItemPresent) {
         dispatch(focusTab({ uid: item.uid }));
         return;
@@ -223,8 +229,8 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
         addTab({
           uid: item.uid,
           collectionUid: collectionUid,
-          requestPaneTab: getDefaultRequestPaneTab(item),
-          type: 'request'
+          ...(isRequest ? { requestPaneTab: getDefaultRequestPaneTab(item) } : {}),
+          type: isApp ? 'app' : 'request'
         })
       );
     } else {
@@ -543,17 +549,18 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
     'is-sidebar-dragging': isSidebarDragging
   });
 
-  const { folderItems, requestItems } = useMemo(() => {
+  const { folderItems, appItems, requestItems } = useMemo(() => {
     const children = item.items || [];
     const folders = sortByNameThenSequence(filter(children, (i: any) => isItemAFolder(i)));
+    const apps = filter(children, (i: any) => isItemAnApp(i)).sort((a: any, b: any) => a.seq - b.seq);
     const requests = filter(children, (i: any) => isItemARequest(i)).sort((a: any, b: any) => a.seq - b.seq);
-    return { folderItems: folders, requestItems: requests };
+    return { folderItems: folders, appItems: apps, requestItems: requests };
   }, [item.items]);
   const indents = useMemo(() => range(item.depth), [item.depth]);
-  const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !requestItems?.length;
+  const showEmptyFolderMessage = isFolder && !hasSearchText && !folderItems?.length && !appItems?.length && !requestItems?.length;
 
   if (searchText && searchText.length) {
-    if (isItemARequest(item)) {
+    if (isItemARequest(item) || isItemAnApp(item)) {
       if (!doesRequestMatchSearchText(item, searchText)) {
         return null;
       }
@@ -640,6 +647,11 @@ const CollectionItem = ({ item, collectionUid, collectionPathname, searchText }:
         <div>
           {folderItems && folderItems.length
             ? folderItems.map((i: any) => {
+                return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} />;
+              })
+            : null}
+          {appItems && appItems.length
+            ? appItems.map((i: any) => {
                 return <CollectionItem key={i.uid} item={i} collectionUid={collectionUid} collectionPathname={collectionPathname} searchText={searchText} />;
               })
             : null}

--- a/src/webview/components/Sidebar/Collections/Collection/index.tsx
+++ b/src/webview/components/Sidebar/Collections/Collection/index.tsx
@@ -38,7 +38,7 @@ import { makeTabPermanent } from 'providers/ReduxStore/slices/tabs';
 import toast from 'react-hot-toast';
 import CollectionItem from './CollectionItem';
 import { doesCollectionHaveItemsMatchingSearchText } from 'utils/collections/search';
-import { isItemAFolder, isItemARequest } from 'utils/collections';
+import { isItemAFolder, isItemARequest, isItemAnApp } from 'utils/collections';
 import { isTabForItemActive } from 'selectors/tab';
 import StyledWrapper from './StyledWrapper';
 import { areItemsLoading } from 'utils/collections';
@@ -302,11 +302,12 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
     'collection-keyboard-focused': isKeyboardFocused
   });
 
-  const { folderItems, requestItems } = useMemo(() => {
+  const { folderItems, appItems, requestItems } = useMemo(() => {
     const items = collection.items || [];
     const folders = sortByNameThenSequence(filter(items, (i: any) => isItemAFolder(i)));
+    const apps = sortByNameThenSequence(filter(items, (i: any) => isItemAnApp(i) && !i.isTransient));
     const requests = sortByNameThenSequence(filter(items, (i: any) => isItemARequest(i) && !i.isTransient));
-    return { folderItems: folders, requestItems: requests };
+    return { folderItems: folders, appItems: apps, requestItems: requests };
   }, [collection.items]);
 
   const newRequestMenuRef = useRef<any>(null);
@@ -495,6 +496,9 @@ const Collection = ({ collection, searchText }: CollectionProps) => {
         {!collectionIsCollapsed ? (
           <div>
             {folderItems?.map?.((i: any) => {
+              return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} />;
+            })}
+            {appItems?.map?.((i: any) => {
               return <CollectionItem key={i.uid} item={i} collectionUid={collection.uid} collectionPathname={collection.pathname} searchText={searchText} />;
             })}
             {requestItems?.map?.((i: any) => {

--- a/src/webview/utils/collections/index.tsx
+++ b/src/webview/utils/collections/index.tsx
@@ -858,6 +858,11 @@ export const isItemAFolder = (item: AppItem): boolean => {
   return !('request' in item) && item.type === 'folder';
 };
 
+export const isItemAnApp = (item: AppItem): boolean => {
+  if (!item) return false;
+  return item.type === 'app';
+};
+
 export const humanizeRequestBodyMode = (mode: string | null | undefined): string => {
   let label = 'No Body';
   switch (mode) {

--- a/src/webview/utils/tabs/index.ts
+++ b/src/webview/utils/tabs/index.ts
@@ -11,6 +11,11 @@ export const isItemAFolder = (item: AppItem): boolean => {
   return !('request' in item) && item.type === 'folder';
 };
 
+export const isItemAnApp = (item: AppItem): boolean => {
+  if (!item) return false;
+  return item.type === 'app';
+};
+
 export const itemIsOpenedInTabs = (item: AppItem, tabs: Tab[]): Tab | undefined => {
   return find(tabs, (t) => t.uid === item.uid);
 };

--- a/src/webview/utils/webviewMode.ts
+++ b/src/webview/utils/webviewMode.ts
@@ -14,6 +14,12 @@ export const openRequestInVSCodeEditor = (requestPath: string): void => {
   }
 };
 
+export const openAppInVSCodeEditor = (appPath: string): void => {
+  if (isSidebarMode() && window.ipcRenderer) {
+    window.ipcRenderer.send('sidebar:open-app', appPath);
+  }
+};
+
 export const openFolderInVSCodeRunner = (folderPath: string): void => {
   if (isSidebarMode() && window.ipcRenderer) {
     window.ipcRenderer.send('sidebar:open-folder', folderPath);

--- a/src/webview/views/ViewContainer.tsx
+++ b/src/webview/views/ViewContainer.tsx
@@ -40,6 +40,7 @@ import RequestNotFound from 'components/RequestTabPanel/RequestNotFound';
 import RequestNotLoaded from 'components/RequestTabPanel/RequestNotLoaded';
 import RequestIsLoading from 'components/RequestTabPanel/RequestIsLoading';
 import FolderNotFound from 'components/RequestTabPanel/FolderNotFound';
+import AppUnsupported from 'components/RequestTabPanel/AppUnsupported';
 
 import { findItemInCollection, findCollectionByUid } from 'utils/collections';
 import { getGlobalEnvironmentVariables, getGlobalEnvironmentVariablesMasked } from 'utils/collections/index';
@@ -251,6 +252,10 @@ const ViewContainer: React.FC<ViewContainerProps> = ({ viewData }) => {
 
   if (viewType === 'empty') {
     return <EmptyView />;
+  }
+
+  if (viewType === 'app-unsupported') {
+    return <AppUnsupported />;
   }
 
   if (viewType === 'global-environments') {

--- a/src/webview/views/types.ts
+++ b/src/webview/views/types.ts
@@ -19,6 +19,7 @@ export type Folder = any;
  */
 export type ViewType =
   | 'request'              // HTTP, GraphQL, gRPC, WebSocket requests
+  | 'app-unsupported'      // App item — desktop-only, placeholder in VS Code
   | 'collection-settings'  // Collection configuration
   | 'folder-settings'      // Folder configuration
   | 'collection-runner'    // Runner results view
@@ -72,6 +73,10 @@ export const VIEW_CONFIGS: Record<ViewType, ViewConfig> = {
     viewType: 'request',
     requiresCollection: true,
     requiresItem: true,
+  },
+  'app-unsupported': {
+    viewType: 'app-unsupported',
+    requiresCollection: false,
   },
   'collection-settings': {
     viewType: 'collection-settings',


### PR DESCRIPTION
## Description

- Introduced 'app' as a new item type in the collection.
- Updated the BrunoEditorProvider to handle app files and display an unsupported view when necessary.
- Enhanced the sidebar to open app items in the appropriate editor.
- Implemented utility functions to identify app items and updated the UI components to render them correctly.
- Added handling for app items in the collection view and ensured they are displayed alongside folders and requests.

## Screenshot
<img width="1490" height="927" alt="Screenshot 2026-08-05 at 2 10 29 PM" src="https://github.com/user-attachments/assets/7acebb94-b87c-40cd-9e62-408b3ebb379e" />