### PR TITLE
fix: reopen prettified requests after save

### DIFF
--- a/src/extension/editors/dirty-state-manager.ts
+++ b/src/extension/editors/dirty-state-manager.ts
@@ -164,10 +164,8 @@ export async function writeFileViaVSCode(
       // Remove any dirty markers from the new content (shouldn't have any, but just in case)
       const cleanContent = content.replace(new RegExp(DIRTY_MARKER, 'g'), '');
 
-      // Only update if content is different (ignoring dirty markers)
-      const currentClean = currentContent.replace(new RegExp(DIRTY_MARKER, 'g'), '');
-
-      if (currentClean !== cleanContent) {
+      // Always remove dirty markers before saving, even when the actual content is unchanged.
+      if (currentContent !== cleanContent) {
         const edit = new vscode.WorkspaceEdit();
         const fullRange = new vscode.Range(
           document.positionAt(0),

--- a/tests/e2e/specs/request-body-prettify.spec.ts
+++ b/tests/e2e/specs/request-body-prettify.spec.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openNewRequestPanel,
+  createRequest,
+  openRequest,
+  fillJsonBody,
+  openRequestPaneTab,
+  runCommand,
+  findCollectionDir
+} from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+test.describe('Request body formatting', () => {
+  test('reopens a POST request after prettifying and saving its JSON body', async ({ page, tmpDir }) => {
+    const collectionName = 'Prettify Collection';
+    const requestName = 'Create Estimate';
+    const compactJson = '{"customer":{"id":1},"items":[{"sku":"A-1","quantity":2}]}';
+
+    const { sidebar, editor } = await test.step('Create a POST request with compact JSON', async () => {
+      const sidebar = await openBrunoSidebar(page);
+      await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+      const newRequestPanel = await openNewRequestPanel(page, sidebar, collectionName);
+      await createRequest(
+        page,
+        newRequestPanel,
+        sidebar,
+        collectionName,
+        requestName,
+        'https://example.com/estimates',
+        'POST'
+      );
+
+      const editor = await openRequest(page, sidebar, collectionName, requestName);
+      await fillJsonBody(page, editor, compactJson);
+
+      return { sidebar, editor };
+    });
+
+    const requestFile = path.join(findCollectionDir(tmpDir), `${requestName}.bru`);
+
+    await test.step('Prettify and save the request', async () => {
+      const locators = buildCommonLocators(editor);
+
+      await locators.body.prettifyButton().click();
+
+      await expect
+        .poll(() => locators.body.lines().count())
+        .toBeGreaterThan(1);
+
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await page.keyboard.press(`${modifier}+s`);
+
+      await expect(
+        locators.notifications.message('Request saved successfully')
+      ).toBeVisible();
+
+      // Re-enter the save path without changing the formatted body. This used to
+      // persist VS Code's invisible dirty marker and make the request unparseable.
+      await locators.body.prettifyButton().click();
+      await page.waitForTimeout(500);
+      await page.keyboard.press(`${modifier}+s`);
+      await page.waitForTimeout(500);
+    });
+
+    await test.step('Close and reopen the saved request', async () => {
+      await runCommand(page, 'View: Close Editor');
+
+      const reopenedEditor = await openRequest(
+        page,
+        sidebar,
+        collectionName,
+        requestName
+      );
+
+      await openRequestPaneTab(reopenedEditor, 'Body');
+
+      const reopenedLocators = buildCommonLocators(reopenedEditor);
+
+      await expect
+        .poll(() => reopenedLocators.body.lines().count())
+        .toBeGreaterThan(1);
+
+      await expect(reopenedLocators.body.editor()).toContainText('"quantity": 2');
+      expect(fs.readFileSync(requestFile, 'utf8')).not.toContain('\u200B');
+    });
+  });
+});

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -78,7 +78,9 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   body: {
     modeSelector: () => frame.locator('.body-mode-selector'),
     modeOption: (name: string) => frame.getByText(name, { exact: true }),
-    editor: () => frame.locator('.CodeMirror-wrap')
+    editor: () => frame.locator('.CodeMirror-wrap'),
+    prettifyButton: () => frame.getByRole('button', { name: 'Prettify', exact: true }),
+    lines: () => frame.locator('.CodeMirror-wrap .CodeMirror-code > div')
   },
   oauth2: {
     authModeSelector: () => frame.getByTestId('oauth2-auth-mode-selector'),
@@ -115,6 +117,9 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   response: {
     statusCode: () => frame.getByTestId('response-status-code'),
     previewContainer: () => frame.getByTestId('response-preview-container')
+  },
+  notifications: {
+    message: (text: string) => frame.getByText(text, { exact: true })
   },
   // A dropdown menu item, by its visible text.
   dropdownItem: (text: string) => frame.locator('.dropdown-item').filter({ hasText: text }),


### PR DESCRIPTION
### Description

Prevent VS Code's invisible dirty-state marker from being persisted in a request file when saving does not otherwise change its content.

### Problem

Fixes usebruno/bruno#8916.

The custom editor compares the current document after stripping its zero-width dirty marker. When the remaining content already matches the serialized request, it skips the workspace edit and saves the document with the marker still present. That makes the `.bru` file fail to parse when it is reopened, leaving the editor at "Loading request...".

### Fix

- Compare the complete current document with the clean serialized content so a remaining dirty marker always triggers a workspace edit before saving.
- Add an E2E regression that prettifies and saves a POST JSON body, re-enters the unchanged save path, closes the editor, and verifies the request can be reopened.
- Verify the saved `.bru` file does not contain the zero-width dirty marker.

### Screenshots

Not applicable; this fixes file persistence and does not change the UI.

| Before | After |
| --- | --- |
| Request can remain at "Loading request..." after reopening | Prettified request reopens successfully |

### Validation

- `npm run typecheck`
- `npm run build`
- `VSCODE_PATH=... npm run test:e2e -- tests/e2e/specs/request-body-prettify.spec.ts`

#### Contribution Checklist:

- [ ] **I've used AI significantly to create this pull request**
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or gifs to help explain the change if applicable.** (Not applicable: no UI changes.)
- [x] **I have read the [contribution guidelines](https://github.com/usebruno/bruno/blob/main/contributing.md).**
- [x] **Create an issue and link to the pull request.**
- [ ] **I've run the claude code review skill locally.**
