### PR TITLE
feat(runtime-vars): implement runtime variables management

### DIFF
--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -22,6 +22,7 @@ import {
 } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import { defaultWorkspaceManager } from '../store/default-workspace';
+import { getRuntimeVariables } from '../store/runtime-variables';
 import { registerDocument, unregisterDocument } from './dirty-state-manager';
 import { notifyActiveItemToSidebar, clearActiveItemFromSidebar } from '../ipc/collection';
 
@@ -213,6 +214,14 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
 
         viewDataByWebview.set(webviewPanel.webview, viewData);
         stateManager.sendTo(webviewPanel.webview, 'main:set-view', viewData);
+
+        const runtimeVariables = getRuntimeVariables(collectionUid);
+        if (Object.keys(runtimeVariables).length > 0) {
+          stateManager.sendTo(webviewPanel.webview, 'main:runtime-variables-update', {
+            collectionUid,
+            runtimeVariables
+          });
+        }
 
         // Collection/folder settings dashboards need the full request tree (e.g.
         // the Overview shows request counts). The single-request open above only

--- a/src/extension/ipc/network/grpc-event-handlers.ts
+++ b/src/extension/ipc/network/grpc-event-handlers.ts
@@ -8,6 +8,7 @@ import { interpolateVars } from './interpolate-vars';
 import { getEnvVars, getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, mergeAuth } from '../../utils/collection';
 import { getCertsAndProxyConfig } from './cert-utils';
 import { getPreferences } from '../../store/preferences';
+import { getRuntimeVariables } from '../../store/runtime-variables';
 import { setAuthHeaders } from './prepare-request';
 import { interpolateString } from './interpolate-string';
 
@@ -234,7 +235,8 @@ const registerGrpcEventHandlers = (): void => {
       runtimeVariables: Record<string, string>;
     }];
 
-    const { request, collection, environment, runtimeVariables } = params;
+    const { request, collection, environment } = params;
+    const runtimeVariables = getRuntimeVariables(collection.uid) as Record<string, string>;
 
     try {
       const requestCopy = cloneDeep(request);
@@ -378,7 +380,8 @@ const registerGrpcEventHandlers = (): void => {
       runtimeVariables: Record<string, string>;
     }];
 
-    const { request, collection, environment, runtimeVariables } = params;
+    const { request, collection, environment } = params;
+    const runtimeVariables = getRuntimeVariables(collection.uid) as Record<string, string>;
 
     try {
       const requestCopy = cloneDeep(request);
@@ -507,7 +510,8 @@ const registerGrpcEventHandlers = (): void => {
       runtimeVariables: Record<string, string>;
     }];
 
-    const { request, collection, environment, runtimeVariables } = params;
+    const { request, collection, environment } = params;
+    const runtimeVariables = getRuntimeVariables(collection.uid) as Record<string, string>;
 
     try {
       const requestCopy = cloneDeep(request);

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -1,6 +1,6 @@
 
 import { AxiosResponse, AxiosError } from 'axios';
-import { registerHandler, sendToWebview } from '../handlers';
+import { registerHandler, sendToWebview, broadcastToAllWebviews } from '../handlers';
 import { prepareRequest, BrunoRequest as PrepareRequestType } from './prepare-request';
 import { interpolateVars } from './interpolate-vars';
 import { createAxiosInstance, AxiosInstanceOptions } from './axios-instance';
@@ -10,6 +10,7 @@ import { getCookieStringForUrl, saveCookies } from '../../utils/cookies';
 import { createFormData, formatMultipartData } from '../../utils/form-data';
 import { getPreferences } from '../../store/preferences';
 import { getProcessEnvVars } from '../../store/process-env';
+import { getRuntimeVariables, setRuntimeVariables } from '../../store/runtime-variables';
 import { getCertsAndProxyConfig } from './cert-utils';
 import { getEnvVars, getTreePathFromCollectionToItem, mergeVars, mergeHeaders, mergeScripts, mergeAuth, flattenItems, findItemInCollection, findItemInCollectionByPathname, hydrateRequestWithUuid, Item } from '../../utils/collection';
 import { getCollectionFormat } from '../../utils/filesystem';
@@ -30,6 +31,23 @@ import qs from 'qs';
 const brunoUtils = brunoUtilsRaw as {
   buildFormUrlEncodedPayload: (fields: Array<{ name: string; value: string; enabled?: boolean }>) => string;
   encodeUrl: (url: string) => string;
+};
+
+/**
+ * Broadcast the current runtime-variable snapshot to every open webview so all
+ * request tabs on the same collection keep the same Redux state. Uses
+ * broadcast (not the invoking-webview-scoped sendToWebview) precisely because
+ * the goal is to push the update out to the other tabs, not just the one that
+ * ran the request.
+ */
+const broadcastRuntimeVariables = (
+  collectionUid: string,
+  runtimeVariables: Record<string, unknown>
+): void => {
+  broadcastToAllWebviews('main:runtime-variables-update', {
+    collectionUid,
+    runtimeVariables
+  });
 };
 
 const getJsSandboxRuntime = (collection: Record<string, unknown>): string => {
@@ -738,7 +756,7 @@ const prepareItemRequest = (item: unknown, collection: unknown): BrunoRequest =>
 const registerNetworkIpc = (): void => {
   // Main HTTP request handler - called by webview
   registerHandler('send-http-request', async (args) => {
-    const [item, collection, environment, runtimeVariables] = args as [unknown, unknown, unknown, Record<string, string>];
+    const [item, collection, environment] = args as [unknown, unknown, unknown, Record<string, string>];
 
     const _collection = collection as Record<string, unknown>;
     const _item = item as Record<string, unknown>;
@@ -749,8 +767,7 @@ const registerNetworkIpc = (): void => {
     const requestUid = (_item.requestUid as string) || itemUid;
     const cancelTokenUid = uuidv4();
 
-    // Mutable copy of runtime variables for script execution
-    const mutableRuntimeVariables: Record<string, unknown> = { ...(runtimeVariables || {}) };
+    const mutableRuntimeVariables: Record<string, unknown> = { ...getRuntimeVariables(collectionUid) };
 
     try {
       const envVars = getEnvVars(environment as never);
@@ -1136,6 +1153,9 @@ const registerNetworkIpc = (): void => {
       } catch (testError) {
         console.error('Tests error:', testError);
       }
+
+      setRuntimeVariables(collectionUid, mutableRuntimeVariables);
+      broadcastRuntimeVariables(collectionUid, mutableRuntimeVariables);
 
       return {
         status: result.status,
@@ -1592,7 +1612,7 @@ const registerNetworkIpc = (): void => {
   // Run collection folder - executes all requests in a folder sequentially
   // Based on bruno-electron's implementation
   registerHandler('renderer:run-collection-folder', async (args) => {
-    const [folder, collection, environment, runtimeVariables, recursive, delay, tags, selectedRequestUids] = args as [
+    const [folder, collection, environment, , recursive, delay, tags, selectedRequestUids] = args as [
       Record<string, unknown> | null,
       Record<string, unknown>,
       Record<string, unknown> | null,
@@ -1610,8 +1630,7 @@ const registerNetworkIpc = (): void => {
 
     const envVars = getEnvVars(environment as never);
 
-    // Make a mutable copy of runtime variables for script execution
-    const runnerRuntimeVariables: Record<string, unknown> = { ...(runtimeVariables || {}) };
+    const runnerRuntimeVariables: Record<string, unknown> = { ...getRuntimeVariables(collectionUid) };
 
     const abortController = new AbortController();
     saveCancelToken(cancelTokenUid, abortController);
@@ -2207,6 +2226,8 @@ const registerNetworkIpc = (): void => {
       }
 
       deleteCancelToken(cancelTokenUid);
+      setRuntimeVariables(collectionUid, runnerRuntimeVariables);
+      broadcastRuntimeVariables(collectionUid, runnerRuntimeVariables);
       sendToWebview('main:run-folder-event', {
         type: 'testrun-ended',
         collectionUid,
@@ -2216,6 +2237,8 @@ const registerNetworkIpc = (): void => {
 
       } catch (error) {
         deleteCancelToken(cancelTokenUid);
+        setRuntimeVariables(collectionUid, runnerRuntimeVariables);
+        broadcastRuntimeVariables(collectionUid, runnerRuntimeVariables);
         sendToWebview('main:run-folder-event', {
           type: 'testrun-ended',
           collectionUid,

--- a/src/extension/ipc/network/ws-event-handlers.ts
+++ b/src/extension/ipc/network/ws-event-handlers.ts
@@ -6,6 +6,7 @@ import { registerHandler, sendToWebview } from '../handlers';
 import { interpolateVars } from './interpolate-vars';
 import { getEnvVars, getTreePathFromCollectionToItem, mergeHeaders, mergeScripts, mergeVars, mergeAuth } from '../../utils/collection';
 import { getCertsAndProxyConfig } from './cert-utils';
+import { getRuntimeVariables } from '../../store/runtime-variables';
 import { setAuthHeaders } from './prepare-request';
 
 interface WsMessage {
@@ -201,7 +202,8 @@ const registerWsEventHandlers = (): void => {
       options?: WsOptions;
     }];
 
-    const { request, collection, environment, runtimeVariables, settings, options = {} } = params;
+    const { request, collection, environment, settings, options = {} } = params;
+    const runtimeVariables = getRuntimeVariables(collection.uid) as Record<string, string>;
 
     try {
       const requestCopy = cloneDeep(request);
@@ -290,7 +292,8 @@ const registerWsEventHandlers = (): void => {
       messageContent?: string;
     }];
 
-    const { item, collection, environment, runtimeVariables, messageContent } = params;
+    const { item, collection, environment, messageContent } = params;
+    const runtimeVariables = getRuntimeVariables(collection.uid) as Record<string, string>;
 
     try {
       const itemCopy = cloneDeep(item);

--- a/src/extension/panels/runner-panel.ts
+++ b/src/extension/panels/runner-panel.ts
@@ -12,6 +12,7 @@ import { openCollection, loadCollectionMetadata, setMessageSender as setCollecti
 import { setMessageSender as setWatcherMessageSender } from '../app/collection-watcher';
 import collectionWatcher from '../app/collection-watcher';
 import UiStateSnapshot from '../store/ui-state-snapshot';
+import { getRuntimeVariables } from '../store/runtime-variables';
 import { posixifyPath } from '../utils/filesystem';
 
 interface IpcMessage {
@@ -151,6 +152,14 @@ export async function openRunnerPanel(
       }
 
       stateManager.sendTo(panel.webview, 'main:set-view', viewData);
+
+      const runtimeVariables = getRuntimeVariables(collectionUid);
+      if (Object.keys(runtimeVariables).length > 0) {
+        stateManager.sendTo(panel.webview, 'main:runtime-variables-update', {
+          collectionUid,
+          runtimeVariables
+        });
+      }
     } catch (error) {
       console.error('RunnerPanel: Error loading collection metadata:', error);
     }

--- a/src/extension/store/runtime-variables.spec.ts
+++ b/src/extension/store/runtime-variables.spec.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'vitest';
+import {
+  getRuntimeVariables,
+  setRuntimeVariables,
+  mergeRuntimeVariables,
+  clearRuntimeVariables
+} from './runtime-variables';
+
+describe('runtime-variables store', () => {
+  test('returns empty object for unknown collection', () => {
+    expect(getRuntimeVariables('unknown-coll')).toEqual({});
+  });
+
+  test('setRuntimeVariables replaces the stored map', () => {
+    const uid = 'coll-set-1';
+    setRuntimeVariables(uid, { a: '1', b: '2' });
+    expect(getRuntimeVariables(uid)).toEqual({ a: '1', b: '2' });
+
+    // A second set fully replaces — keys not in the new payload are dropped.
+    setRuntimeVariables(uid, { b: '3', c: '4' });
+    expect(getRuntimeVariables(uid)).toEqual({ b: '3', c: '4' });
+  });
+
+  test('mergeRuntimeVariables shallow-merges new keys', () => {
+    const uid = 'coll-merge-1';
+    setRuntimeVariables(uid, { a: '1', b: '2' });
+
+    const merged = mergeRuntimeVariables(uid, { b: '99', c: '3' });
+    expect(merged).toEqual({ a: '1', b: '99', c: '3' });
+    expect(getRuntimeVariables(uid)).toEqual({ a: '1', b: '99', c: '3' });
+  });
+
+  test('clearRuntimeVariables removes the collection entry', () => {
+    const uid = 'coll-clear-1';
+    setRuntimeVariables(uid, { a: '1' });
+    clearRuntimeVariables(uid);
+    expect(getRuntimeVariables(uid)).toEqual({});
+  });
+
+  test('isolates values between collections', () => {
+    setRuntimeVariables('coll-A', { shared: 'from-A' });
+    setRuntimeVariables('coll-B', { shared: 'from-B' });
+
+    expect(getRuntimeVariables('coll-A')).toEqual({ shared: 'from-A' });
+    expect(getRuntimeVariables('coll-B')).toEqual({ shared: 'from-B' });
+  });
+
+  test('setRuntimeVariables copies the input so external mutation does not leak in', () => {
+    const uid = 'coll-copy-1';
+    const source = { token: 'abc' };
+    setRuntimeVariables(uid, source);
+    source.token = 'MUTATED';
+
+    expect(getRuntimeVariables(uid)).toEqual({ token: 'abc' });
+  });
+});

--- a/src/extension/store/runtime-variables.ts
+++ b/src/extension/store/runtime-variables.ts
@@ -1,0 +1,44 @@
+/**
+ * In-memory store for per-collection runtime variables.
+ *
+ * Runtime variables (`bru.setVar` / `bru.getVar`) exist for the lifetime of
+ * the VS Code process. They must survive:
+ *   - closing a request tab
+ *   - opening the same request in a new tab (each tab is its own webview
+ *     with its own Redux store)
+ * and reset when the extension host restarts.
+ *
+ * The extension is the single source of truth. Webviews mirror this into
+ * their local Redux state via `main:runtime-variables-update` broadcasts.
+ */
+
+type RuntimeVariables = Record<string, unknown>;
+
+const runtimeVariablesByCollection: Record<string, RuntimeVariables> = {};
+
+export const getRuntimeVariables = (collectionUid: string): RuntimeVariables => {
+  return runtimeVariablesByCollection[collectionUid] || {};
+};
+
+export const setRuntimeVariables = (
+  collectionUid: string,
+  runtimeVariables: RuntimeVariables
+): void => {
+  runtimeVariablesByCollection[collectionUid] = { ...(runtimeVariables || {}) };
+};
+
+/** Shallow-merge new keys into the stored runtime variables. Returns the
+ *  merged snapshot for callers that want to broadcast without re-reading. */
+export const mergeRuntimeVariables = (
+  collectionUid: string,
+  runtimeVariables: RuntimeVariables
+): RuntimeVariables => {
+  const current = runtimeVariablesByCollection[collectionUid] || {};
+  const next = { ...current, ...(runtimeVariables || {}) };
+  runtimeVariablesByCollection[collectionUid] = next;
+  return next;
+};
+
+export const clearRuntimeVariables = (collectionUid: string): void => {
+  delete runtimeVariablesByCollection[collectionUid];
+};

--- a/src/extension/utils/script-runner.ts
+++ b/src/extension/utils/script-runner.ts
@@ -2,7 +2,8 @@
 import { ScriptRuntime, VarsRuntime, TestRuntime, AssertRuntime, ScriptResult, TestResult, VarsResult } from '@usebruno/js';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
-import { sendToWebview } from '../ipc/handlers';
+import { sendToWebview, broadcastToAllWebviews } from '../ipc/handlers';
+import { setRuntimeVariables } from '../store/runtime-variables';
 import logsStore, { LogLevel } from '../store/logs';
 
 // Strip comments from script (simple implementation)
@@ -63,7 +64,13 @@ const createConsoleLogHandler = (collectionUid: string, requestUid: string) => {
 /** Broadcast a script's variable changes on their webview channels: env + runtime vars for
  *  in-session state, environment vars for the disk write (persist by default, only when the script
  *  actually changed one), and global env vars. `envVarsBefore` is the pre-script snapshot used to
- *  skip needless environment-file writes. */
+ *  skip needless environment-file writes.
+ *
+ *  Runtime variables get a dedicated broadcast (`main:runtime-variables-update`) so *every* open
+ *  request tab in the collection updates its Redux mirror — the desktop app can rely on a single
+ *  window's Redux tree, but here each tab is its own webview and would otherwise miss the update.
+ *  We also persist to the in-memory extension store so a fresh tab (opened after the script ran)
+ *  starts with the current values. */
 const emitScriptVariableUpdates = (
   result: {
     envVariables?: Record<string, unknown>;
@@ -74,13 +81,30 @@ const emitScriptVariableUpdates = (
   context: ScriptContext,
   envVarsBefore?: Record<string, unknown>
 ): void => {
-  sendToWebview('main:script-environment-update', {
+  // Broadcast (not send-to-current-webview): the same script-authored env +
+  // runtime var changes need to land in every open request tab's Redux store,
+  // not just the one that ran the request. The desktop app can rely on one
+  // window's Redux tree, but here each tab is its own webview and would
+  // otherwise miss the update — the exact bug in the ticket.
+  broadcastToAllWebviews('main:script-environment-update', {
     envVariables: result.envVariables,
     runtimeVariables: result.runtimeVariables,
     requestUid: context.requestUid,
     collectionUid: context.collectionUid
   });
 
+  if (result.runtimeVariables && typeof result.runtimeVariables === 'object') {
+    const runtimeVariables = result.runtimeVariables as Record<string, unknown>;
+    setRuntimeVariables(context.collectionUid, runtimeVariables);
+    broadcastToAllWebviews('main:runtime-variables-update', {
+      collectionUid: context.collectionUid,
+      runtimeVariables
+    });
+  }
+
+  // Persistence stays scoped to the invoking webview: the merge-and-write
+  // action runs in Redux + writes to disk, and we only want *one* write per
+  // script run. The file watcher then broadcasts the change to sibling tabs.
   if (result.envVariables && !isEqual(result.envVariables, envVarsBefore)) {
     sendToWebview('main:persistent-env-variables-update', {
       persistentEnvVariables: result.envVariables,
@@ -89,14 +113,14 @@ const emitScriptVariableUpdates = (
   }
 
   if (result.collectionVariables) {
-    sendToWebview('main:collection-variables-update', {
+    broadcastToAllWebviews('main:collection-variables-update', {
       collectionVariables: result.collectionVariables,
       collectionUid: context.collectionUid
     });
   }
 
   if (result.globalEnvironmentVariables) {
-    sendToWebview('main:global-environment-variables-update', {
+    broadcastToAllWebviews('main:global-environment-variables-update', {
       globalEnvironmentVariables: result.globalEnvironmentVariables
     });
   }

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -18,6 +18,7 @@ import {
   requestCancelled,
   runFolderEvent,
   runRequestEvent,
+  runtimeVariablesUpdateEvent,
   scriptEnvironmentUpdateEvent,
   streamDataReceived,
   addTransientRequest,
@@ -303,6 +304,11 @@ const useIpcEvents = () => {
 
     const removeScriptEnvUpdateListener = ipcRenderer.on('main:script-environment-update', (val: unknown) => {
       dispatch(scriptEnvironmentUpdateEvent(val as ScriptEnvironmentUpdateEventPayload));
+    });
+
+    const removeRuntimeVariablesUpdateListener = ipcRenderer.on('main:runtime-variables-update', (val: unknown) => {
+      const payload = val as { collectionUid: string; runtimeVariables: Record<string, unknown> };
+      dispatch(runtimeVariablesUpdateEvent(payload));
     });
 
     const removePersistentEnvVariablesUpdateListener = ipcRenderer.on('main:persistent-env-variables-update', (val: unknown) => {
@@ -656,6 +662,7 @@ const useIpcEvents = () => {
       removeDisplayErrorListener();
       removeToastSuccessListener();
       removeScriptEnvUpdateListener();
+      removeRuntimeVariablesUpdateListener();
       removeGlobalEnvironmentVariablesUpdateListener();
       removeCollectionRenamedListener();
       removeCollectionFolderRenamedListener();

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -2063,6 +2063,17 @@ export const collectionsSlice = createSlice({
       }
     },
 
+    runtimeVariablesUpdateEvent: (
+      state,
+      action: PayloadAction<{ collectionUid: string; runtimeVariables: Record<string, unknown> }>
+    ) => {
+      const { collectionUid, runtimeVariables } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (collection) {
+        collection.runtimeVariables = runtimeVariables || {};
+      }
+    },
+
     clearTimeline: (state, action: PayloadAction<ClearTimelinePayload>) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
       if (collection) {
@@ -3187,6 +3198,7 @@ export const {
   responseReceived,
   responseCleared,
   scriptEnvironmentUpdateEvent,
+  runtimeVariablesUpdateEvent,
   processEnvUpdateEvent,
   clearTimeline,
   clearRequestTimeline,

--- a/src/webview/providers/ReduxStore/slices/collections/runtime-variables.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/runtime-variables.spec.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, vi } from 'vitest';
+
+// Mock vscode
+vi.mock('vscode', () => ({}));
+
+const { default: collectionsReducer, runtimeVariablesUpdateEvent } = await import('./index');
+
+function makeState(runtimeVariables: Record<string, unknown> = {}) {
+  return {
+    collections: [
+      {
+        uid: 'col-1',
+        name: 'Test',
+        pathname: '/test',
+        items: [],
+        environments: [],
+        brunoConfig: {},
+        runtimeVariables
+      }
+    ],
+    collectionSortOrder: 'default',
+    activeConnections: {}
+  } as any;
+}
+
+describe('runtimeVariablesUpdateEvent', () => {
+  test('overwrites the stored map (extension is source of truth)', () => {
+    const state = makeState({ oldKey: 'stale' });
+
+    const result = collectionsReducer(
+      state,
+      runtimeVariablesUpdateEvent({
+        collectionUid: 'col-1',
+        runtimeVariables: { newKey: 'fresh' }
+      } as any)
+    );
+
+    // Assignment, not merge — oldKey is gone so deletions on the extension
+    // side are observable in every mirrored tab.
+    expect(result.collections[0].runtimeVariables).toEqual({ newKey: 'fresh' });
+  });
+
+  test('coerces missing payload to empty object', () => {
+    const state = makeState({ a: '1' });
+    const result = collectionsReducer(
+      state,
+      runtimeVariablesUpdateEvent({ collectionUid: 'col-1', runtimeVariables: null } as any)
+    );
+    expect(result.collections[0].runtimeVariables).toEqual({});
+  });
+
+  test('ignores updates for unknown collections', () => {
+    const state = makeState({ a: '1' });
+    const result = collectionsReducer(
+      state,
+      runtimeVariablesUpdateEvent({
+        collectionUid: 'does-not-exist',
+        runtimeVariables: { x: '9' }
+      } as any)
+    );
+    expect(result.collections[0].runtimeVariables).toEqual({ a: '1' });
+  });
+});


### PR DESCRIPTION
This enhancement improves the scripting capabilities and state management within the extension, aligning with user expectations for variable persistence and accessibility.

- Introduced a new in-memory store for runtime variables, allowing per-collection management.
- Added functions to get, set, merge, and clear runtime variables, ensuring they persist across webview sessions.
- Updated various components to utilize runtime variables, broadcasting updates to all open webviews for consistent state.
- Implemented tests to verify the functionality of runtime variable management, ensuring isolation between collections and proper handling of updates.