### PR TITLE
feat(environments): implement .env files from environment settings

### DIFF
--- a/src/bruno-types/app/collection-ext.ts
+++ b/src/bruno-types/app/collection-ext.ts
@@ -40,6 +40,20 @@ export interface TimelineEntry {
   };
 }
 
+export interface DotEnvVariable {
+  uid?: UID;
+  name: string;
+  value: string;
+  enabled?: boolean;
+  secret?: boolean;
+}
+
+export interface DotEnvFile {
+  filename: string;
+  variables: DotEnvVariable[];
+  content: string;
+}
+
 export interface RunnerConfiguration {
   recursive?: boolean;
   delay?: number;
@@ -128,6 +142,7 @@ export interface AppCollection extends Omit<Collection, 'items'> {
   isLoading?: boolean;
   securityConfig?: SecurityConfig;
   processEnvVariables?: Record<string, unknown>;
+  dotEnvFiles?: DotEnvFile[];
   timeline?: TimelineEntry[];
   draft?: CollectionDraft | null;
   environmentsDraft?: EnvironmentsDraft | null;

--- a/src/bruno-types/app/index.ts
+++ b/src/bruno-types/app/index.ts
@@ -36,6 +36,8 @@ export type {
   ActiveConnection,
   RequestSent,
   TimelineEntry,
+  DotEnvFile,
+  DotEnvVariable,
   RunnerConfiguration,
   RunnerResultItem,
   RunnerResult,

--- a/src/extension/app/collection-watcher.ts
+++ b/src/extension/app/collection-watcher.ts
@@ -6,7 +6,9 @@ import {
   hasRequestExtension,
   sizeInMB,
   getCollectionFormat,
-  posixifyPath
+  posixifyPath,
+  isDotEnvFile,
+  isDotEnvFilename
 } from '../utils/filesystem';
 
 const {
@@ -22,7 +24,7 @@ import { uuid } from '../utils/common';
 import { getRequestUid } from '../cache/requestUids';
 import { decryptStringSafe } from '../utils/encryption';
 import { parseValueByDataType, BrunoVariableDataType } from '@usebruno/common/utils';
-import { setDotEnvVars, getProcessEnvVars } from '../store/process-env';
+import { setDotEnvVars, clearDotEnvVars, getProcessEnvVars } from '../store/process-env';
 import { setBrunoConfig } from '../store/bruno-config';
 import EnvironmentSecretsStore from '../store/env-secrets';
 import UiStateSnapshot from '../store/ui-state-snapshot';
@@ -63,10 +65,13 @@ const parseDotEnv = (content: string): Record<string, string> => {
   return dotenvToJson(content);
 };
 
-const isDotEnvFile = (pathname: string, collectionPath: string): boolean => {
-  const dirname = path.dirname(pathname);
-  const basename = path.basename(pathname);
-  return path.normalize(dirname) === path.normalize(collectionPath) && basename === '.env';
+const dotEnvVariablesToArray = (envObject: Record<string, string>) => {
+  return Object.entries(envObject).map(([name, value]) => ({
+    name,
+    value,
+    enabled: true,
+    secret: false
+  }));
 };
 
 const isBrunoConfigFile = (pathname: string, collectionPath: string): boolean => {
@@ -416,20 +421,81 @@ class CollectionWatcher {
   }
 
   private async handleDotEnvChangeWithSender(pathname: string, collectionUid: string, sender: MessageSender | null): Promise<void> {
+    const filename = path.basename(pathname);
+
     try {
       const content = fs.readFileSync(pathname, 'utf8');
       const jsonData = parseDotEnv(content);
 
-      setDotEnvVars(collectionUid, jsonData);
+      if (filename === '.env') {
+        setDotEnvVars(collectionUid, jsonData);
+      }
 
       if (sender) {
-        sender('main:process-env-update', {
+        sender('main:dotenv-file-update', {
           collectionUid,
-          processEnvVariables: getProcessEnvVars(collectionUid)
+          filename,
+          variables: dotEnvVariablesToArray(jsonData),
+          content,
+          exists: true
         });
+        this.sendProcessEnvUpdate(collectionUid, sender, filename);
       }
     } catch (err) {
       console.error('Error handling .env change:', err);
+    }
+  }
+
+  private handleDotEnvUnlinkWithSender(pathname: string, collectionUid: string, sender: MessageSender | null): void {
+    const filename = path.basename(pathname);
+
+    if (filename === '.env') {
+      clearDotEnvVars(collectionUid);
+    }
+
+    if (sender) {
+      sender('main:dotenv-file-update', {
+        collectionUid,
+        filename,
+        variables: [],
+        content: '',
+        exists: false
+      });
+      this.sendProcessEnvUpdate(collectionUid, sender, filename);
+    }
+  }
+
+  private sendProcessEnvUpdate(collectionUid: string, sender: MessageSender, filename?: string): void {
+    if (filename && filename !== '.env') return;
+
+    sender('main:process-env-update', {
+      collectionUid,
+      processEnvVariables: getProcessEnvVars(collectionUid)
+    });
+  }
+
+  /**
+   * Dotenv files are not picked up by the recursive scan (it only collects request files),
+   * so they are read explicitly whenever a collection is loaded.
+   */
+  private async loadDotEnvFiles(collectionPath: string, collectionUid: string, sender: MessageSender | null): Promise<void> {
+    let filenames: string[] = [];
+
+    try {
+      filenames = fs
+        .readdirSync(collectionPath, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && isDotEnvFilename(entry.name))
+        .map((entry) => entry.name);
+    } catch (err) {
+      console.error('[Watcher] Error reading dotenv files:', err);
+    }
+
+    for (const filename of filenames) {
+      await this.handleDotEnvChangeWithSender(path.join(collectionPath, filename), collectionUid, sender);
+    }
+
+    if (sender && !filenames.includes('.env')) {
+      this.sendProcessEnvUpdate(collectionUid, sender);
     }
   }
 
@@ -709,44 +775,7 @@ class CollectionWatcher {
     this.initializeLoadingState(collectionUid);
     this.startCollectionDiscovery(collectionUid);
 
-    const format = getCollectionFormat(watchPath);
-    const watchers: vscode.FileSystemWatcher[] = [];
-
-    const requestPattern = format === 'yml'
-      ? new vscode.RelativePattern(watchPath, '**/*.yml')
-      : new vscode.RelativePattern(watchPath, '**/*.bru');
-
-    const envExt = format === 'yml' ? 'yml' : 'bru';
-    const envPattern = new vscode.RelativePattern(watchPath, `environments/*.${envExt}`);
-    const configPattern = new vscode.RelativePattern(watchPath, 'bruno.json');
-    const ocYmlPattern = new vscode.RelativePattern(watchPath, 'opencollection.yml');
-    const dotEnvPattern = new vscode.RelativePattern(watchPath, '.env');
-
-    const requestWatcher = vscode.workspace.createFileSystemWatcher(requestPattern);
-    requestWatcher.onDidCreate(uri => this.handleFileAdd(uri.fsPath, collectionUid, watchPath));
-    requestWatcher.onDidChange(uri => this.handleFileChange(uri.fsPath, collectionUid, watchPath));
-    requestWatcher.onDidDelete(uri => this.handleFileUnlink(uri.fsPath, collectionUid, watchPath));
-    watchers.push(requestWatcher);
-
-    const envWatcher = vscode.workspace.createFileSystemWatcher(envPattern);
-    envWatcher.onDidCreate(uri => addEnvironmentFile(uri.fsPath, collectionUid, watchPath));
-    envWatcher.onDidChange(uri => changeEnvironmentFile(uri.fsPath, collectionUid, watchPath));
-    envWatcher.onDidDelete(uri => unlinkEnvironmentFile(uri.fsPath, collectionUid));
-    watchers.push(envWatcher);
-
-    const configWatcher = vscode.workspace.createFileSystemWatcher(configPattern);
-    configWatcher.onDidChange(uri => this.handleBrunoConfigChange(uri.fsPath, collectionUid, watchPath));
-    watchers.push(configWatcher);
-
-    // Watch for opencollection.yml (YML format config changes are handled via collection root file handler)
-    const ocYmlWatcher = vscode.workspace.createFileSystemWatcher(ocYmlPattern);
-    ocYmlWatcher.onDidChange(uri => this.handleFileChange(uri.fsPath, collectionUid, watchPath));
-    watchers.push(ocYmlWatcher);
-
-    const dotEnvWatcher = vscode.workspace.createFileSystemWatcher(dotEnvPattern);
-    dotEnvWatcher.onDidCreate(uri => this.handleDotEnvChange(uri.fsPath, collectionUid));
-    dotEnvWatcher.onDidChange(uri => this.handleDotEnvChange(uri.fsPath, collectionUid));
-    watchers.push(dotEnvWatcher);
+    const watchers = this.createWatchers(watchPath, collectionUid);
 
     this.watchers.set(watchPath, watchers);
     this.pathToCollectionUid.set(watchPath, collectionUid);
@@ -778,8 +807,11 @@ class CollectionWatcher {
       const requestFiles: string[] = [];
 
       for (const filePath of files) {
+        if (isDotEnvFile(filePath, watchPath)) {
+          continue;
+        }
+
         if (isBrunoConfigFile(filePath, watchPath) ||
-            isDotEnvFile(filePath, watchPath) ||
             isEnvironmentsFolder(filePath, watchPath) ||
             isCollectionRootFile(filePath, watchPath) ||
             isFolderRootFile(filePath, watchPath)) {
@@ -790,19 +822,11 @@ class CollectionWatcher {
       }
 
       // Process config/env/root files first (sequential - sets up collection state)
-      const hasDotEnv = priorityFiles.some(f => isDotEnvFile(f, watchPath));
       for (const filePath of priorityFiles) {
         await this.handleFileAdd(filePath, collectionUid, watchPath);
       }
 
-      // If no .env file was found, still send system process.env variables
-      // so {{process.env.VAR}} highlights correctly in the editor
-      if (!hasDotEnv && messageSender) {
-        messageSender('main:process-env-update', {
-          collectionUid,
-          processEnvVariables: getProcessEnvVars(collectionUid)
-        });
-      }
+      await this.loadDotEnvFiles(watchPath, collectionUid, messageSender);
 
       // Parse request files in parallel but emit them to the webview in
       // larger batches via a single 'addFiles' event. Thousands of individual
@@ -1005,6 +1029,11 @@ class CollectionWatcher {
     collectionUid: string,
     collectionPath: string
   ): void {
+    if (isDotEnvFile(pathname, collectionPath)) {
+      this.handleDotEnvUnlink(pathname, collectionUid);
+      return;
+    }
+
     if (isEnvironmentsFolder(pathname, collectionPath)) {
       unlinkEnvironmentFile(pathname, collectionUid);
       return;
@@ -1054,21 +1083,11 @@ class CollectionWatcher {
   }
 
   private async handleDotEnvChange(pathname: string, collectionUid: string): Promise<void> {
-    try {
-      const content = fs.readFileSync(pathname, 'utf8');
-      const jsonData = parseDotEnv(content);
+    await this.handleDotEnvChangeWithSender(pathname, collectionUid, messageSender);
+  }
 
-      setDotEnvVars(collectionUid, jsonData);
-
-      if (messageSender) {
-        messageSender('main:process-env-update', {
-          collectionUid,
-          processEnvVariables: getProcessEnvVars(collectionUid)
-        });
-      }
-    } catch (err) {
-      console.error('Error handling .env change:', err);
-    }
+  private handleDotEnvUnlink(pathname: string, collectionUid: string): void {
+    this.handleDotEnvUnlinkWithSender(pathname, collectionUid, messageSender);
   }
 
   private async handleCollectionRootFile(
@@ -1411,17 +1430,7 @@ class CollectionWatcher {
       }
     }
 
-    const dotEnvPath = path.join(collectionPath, '.env');
-    if (fs.existsSync(dotEnvPath)) {
-      await this.handleDotEnvChangeWithSender(dotEnvPath, collectionUid, sender);
-    } else if (sender) {
-      // Even without a .env file, send system process.env variables
-      // so {{process.env.VAR}} highlights correctly in the editor
-      sender('main:process-env-update', {
-        collectionUid,
-        processEnvVariables: getProcessEnvVars(collectionUid)
-      });
-    }
+    await this.loadDotEnvFiles(collectionPath, collectionUid, sender);
 
     const brunoJsonPath = path.join(collectionPath, 'bruno.json');
     if (fs.existsSync(brunoJsonPath)) {
@@ -1476,16 +1485,19 @@ class CollectionWatcher {
     targetSender: MessageSender
   ): Promise<void> {
     const envDirPath = path.join(collectionPath, 'environments');
-    if (!fs.existsSync(envDirPath)) return;
 
-    const format = getCollectionFormat(collectionPath);
-    const ext = format === 'yml' ? '.yml' : '.bru';
-    const files = fs.readdirSync(envDirPath).filter(f => f.endsWith(ext));
+    if (fs.existsSync(envDirPath)) {
+      const format = getCollectionFormat(collectionPath);
+      const ext = format === 'yml' ? '.yml' : '.bru';
+      const files = fs.readdirSync(envDirPath).filter(f => f.endsWith(ext));
 
-    for (const file of files) {
-      const filePath = path.join(envDirPath, file);
-      await this.addEnvironmentFileWithSender(filePath, collectionUid, collectionPath, targetSender);
+      for (const file of files) {
+        const filePath = path.join(envDirPath, file);
+        await this.addEnvironmentFileWithSender(filePath, collectionUid, collectionPath, targetSender);
+      }
     }
+
+    await this.loadDotEnvFiles(collectionPath, collectionUid, targetSender);
   }
 
   /**
@@ -1501,45 +1513,52 @@ class CollectionWatcher {
       existingWatchers.forEach(w => w.dispose());
     }
 
+    this.watchers.set(watchPath, this.createWatchers(watchPath, collectionUid));
+  }
+
+  private createWatchers(watchPath: string, collectionUid: string): vscode.FileSystemWatcher[] {
     const format = getCollectionFormat(watchPath);
-    const watchers: vscode.FileSystemWatcher[] = [];
-
-    const requestPattern = format === 'yml'
-      ? new vscode.RelativePattern(watchPath, '**/*.yml')
-      : new vscode.RelativePattern(watchPath, '**/*.bru');
-
     const envExt = format === 'yml' ? 'yml' : 'bru';
-    const envPattern = new vscode.RelativePattern(watchPath, `environments/*.${envExt}`);
-    const configPattern = new vscode.RelativePattern(watchPath, 'bruno.json');
-    const ocYmlPattern = new vscode.RelativePattern(watchPath, 'opencollection.yml');
-    const dotEnvPattern = new vscode.RelativePattern(watchPath, '.env');
 
-    const requestWatcher = vscode.workspace.createFileSystemWatcher(requestPattern);
+    const requestWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(watchPath, format === 'yml' ? '**/*.yml' : '**/*.bru')
+    );
     requestWatcher.onDidCreate(uri => this.handleFileAdd(uri.fsPath, collectionUid, watchPath));
     requestWatcher.onDidChange(uri => this.handleFileChange(uri.fsPath, collectionUid, watchPath));
     requestWatcher.onDidDelete(uri => this.handleFileUnlink(uri.fsPath, collectionUid, watchPath));
-    watchers.push(requestWatcher);
 
-    const envWatcher = vscode.workspace.createFileSystemWatcher(envPattern);
+    const envWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(watchPath, `environments/*.${envExt}`)
+    );
     envWatcher.onDidCreate(uri => addEnvironmentFile(uri.fsPath, collectionUid, watchPath));
     envWatcher.onDidChange(uri => changeEnvironmentFile(uri.fsPath, collectionUid, watchPath));
     envWatcher.onDidDelete(uri => unlinkEnvironmentFile(uri.fsPath, collectionUid));
-    watchers.push(envWatcher);
 
-    const configWatcher = vscode.workspace.createFileSystemWatcher(configPattern);
+    const configWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(watchPath, 'bruno.json')
+    );
     configWatcher.onDidChange(uri => this.handleBrunoConfigChange(uri.fsPath, collectionUid, watchPath));
 
-    const ocYmlWatcher = vscode.workspace.createFileSystemWatcher(ocYmlPattern);
+    // YML format config changes are handled via the collection root file handler
+    const ocYmlWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(watchPath, 'opencollection.yml')
+    );
     ocYmlWatcher.onDidChange(uri => this.handleFileChange(uri.fsPath, collectionUid, watchPath));
-    watchers.push(ocYmlWatcher);
-    watchers.push(configWatcher);
 
-    const dotEnvWatcher = vscode.workspace.createFileSystemWatcher(dotEnvPattern);
-    dotEnvWatcher.onDidCreate(uri => this.handleDotEnvChange(uri.fsPath, collectionUid));
-    dotEnvWatcher.onDidChange(uri => this.handleDotEnvChange(uri.fsPath, collectionUid));
-    watchers.push(dotEnvWatcher);
+    // '.env*' also matches unrelated files such as .envrc, so every event is filtered
+    const dotEnvWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(watchPath, '.env*')
+    );
+    const onDotEnvEvent = (pathname: string, handle: (pathname: string) => void) => {
+      if (isDotEnvFilename(path.basename(pathname))) {
+        handle(pathname);
+      }
+    };
+    dotEnvWatcher.onDidCreate(uri => onDotEnvEvent(uri.fsPath, p => this.handleDotEnvChange(p, collectionUid)));
+    dotEnvWatcher.onDidChange(uri => onDotEnvEvent(uri.fsPath, p => this.handleDotEnvChange(p, collectionUid)));
+    dotEnvWatcher.onDidDelete(uri => onDotEnvEvent(uri.fsPath, p => this.handleDotEnvUnlink(p, collectionUid)));
 
-    this.watchers.set(watchPath, watchers);
+    return [requestWatcher, envWatcher, configWatcher, ocYmlWatcher, dotEnvWatcher];
   }
 
   /**
@@ -1571,8 +1590,11 @@ class CollectionWatcher {
       const requestFiles: string[] = [];
 
       for (const filePath of files) {
+        if (isDotEnvFile(filePath, collectionPath)) {
+          continue;
+        }
+
         if (isBrunoConfigFile(filePath, collectionPath) ||
-            isDotEnvFile(filePath, collectionPath) ||
             isEnvironmentsFolder(filePath, collectionPath) ||
             isCollectionRootFile(filePath, collectionPath) ||
             isFolderRootFile(filePath, collectionPath)) {
@@ -1583,18 +1605,11 @@ class CollectionWatcher {
       }
 
       // Process priority files first
-      const hasDotEnv = priorityFiles.some(f => isDotEnvFile(f, collectionPath));
       for (const filePath of priorityFiles) {
         await this.handleFileAddWithSender(filePath, collectionUid, collectionPath, sender);
       }
 
-      // If no .env file, still send process.env variables
-      if (!hasDotEnv && sender) {
-        sender('main:process-env-update', {
-          collectionUid,
-          processEnvVariables: getProcessEnvVars(collectionUid)
-        });
-      }
+      await this.loadDotEnvFiles(collectionPath, collectionUid, sender);
 
       // Same batched-emit strategy as performInitialScan — one IPC +
       // Redux dispatch per ~500 files instead of one per file.

--- a/src/extension/ipc/collection.ts
+++ b/src/extension/ipc/collection.ts
@@ -7,6 +7,7 @@ import * as fsExtra from 'fs-extra';
 import AdmZip from 'adm-zip';
 import extractZip from 'extract-zip';
 import type { BrunoVariableDataType } from '@usebruno/common/utils';
+import { jsonToDotenv } from '@usebruno/common/utils';
 import { registerHandler, registerEventListener, sendToWebview, broadcastToAllWebviews, emit, getCurrentWebview } from './handlers';
 import { stateManager } from '../webview/state-manager';
 import {
@@ -27,6 +28,7 @@ import {
   getPaths,
   generateUniqueName,
   isDotEnvFile,
+  isValidDotEnvFilename,
   isBrunoConfigFile,
   isBruEnvironmentConfig,
   isCollectionRootBruFile,
@@ -610,6 +612,64 @@ const registerCollectionIpc = (watcher: CollectionWatcherInterface): void => {
     } catch (error) {
       throw error;
     }
+  });
+
+  registerHandler('renderer:save-dotenv-variables', async (args) => {
+    const [collectionPathname, variables, filename = '.env'] = args as [string, Array<{ name: string; value: string }>, string?];
+
+    if (!isValidDotEnvFilename(filename)) {
+      throw new Error('Invalid .env filename');
+    }
+
+    await writeFile(path.join(collectionPathname, filename), jsonToDotenv(variables));
+
+    return { success: true };
+  });
+
+  registerHandler('renderer:save-dotenv-raw', async (args) => {
+    const [collectionPathname, content, filename = '.env'] = args as [string, string, string?];
+
+    if (!isValidDotEnvFilename(filename)) {
+      throw new Error('Invalid .env filename');
+    }
+
+    await writeFile(path.join(collectionPathname, filename), content);
+
+    return { success: true };
+  });
+
+  registerHandler('renderer:create-dotenv-file', async (args) => {
+    const [collectionPathname, filename = '.env'] = args as [string, string?];
+
+    if (!isValidDotEnvFilename(filename)) {
+      throw new Error('Invalid .env filename');
+    }
+
+    const dotEnvPath = path.join(collectionPathname, filename);
+    if (fs.existsSync(dotEnvPath)) {
+      throw new Error(`${filename} file already exists`);
+    }
+
+    await writeFile(dotEnvPath, '');
+
+    return { success: true, filename };
+  });
+
+  registerHandler('renderer:delete-dotenv-file', async (args) => {
+    const [collectionPathname, filename = '.env'] = args as [string, string?];
+
+    if (!isValidDotEnvFilename(filename)) {
+      throw new Error('Invalid .env filename');
+    }
+
+    const dotEnvPath = path.join(collectionPathname, filename);
+    if (!fs.existsSync(dotEnvPath)) {
+      throw new Error(`${filename} file does not exist`);
+    }
+
+    fs.unlinkSync(dotEnvPath);
+
+    return { success: true };
   });
 
   // Rename item (file/folder)

--- a/src/extension/store/process-env.ts
+++ b/src/extension/store/process-env.ts
@@ -29,3 +29,7 @@ export const getProcessEnvVars = (collectionUid: string): EnvVars => {
 export const setDotEnvVars = (collectionUid: string, envVars: EnvVars): void => {
   dotEnvVars[collectionUid] = envVars;
 };
+
+export const clearDotEnvVars = (collectionUid: string): void => {
+  delete dotEnvVars[collectionUid];
+};

--- a/src/extension/utils/filesystem.ts
+++ b/src/extension/utils/filesystem.ts
@@ -376,10 +376,19 @@ export const isLargeFile = (filePath: string, threshold = 10 * 1024 * 1024): boo
   return size > threshold;
 };
 
+export const isDotEnvFilename = (filename: string): boolean => {
+  return filename === '.env' || filename.startsWith('.env.');
+};
+
+export const isValidDotEnvFilename = (filename: string): boolean => {
+  if (!filename || typeof filename !== 'string') return false;
+  if (path.basename(filename) !== filename) return false;
+  return filename === '.env' || /^\.env\.[a-zA-Z0-9._-]+$/.test(filename);
+};
+
 export const isDotEnvFile = (pathname: string, collectionPath: string): boolean => {
   const dirname = path.dirname(pathname);
-  const basename = path.basename(pathname);
-  return path.normalize(dirname) === path.normalize(collectionPath) && basename === '.env';
+  return path.normalize(dirname) === path.normalize(collectionPath) && isDotEnvFilename(path.basename(pathname));
 };
 
 export const isBrunoConfigFile = (pathname: string, collectionPath: string): boolean => {

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -166,6 +166,7 @@ declare module '@usebruno/common/utils' {
   export function parseValueByDataType(value: any, dataType?: BrunoVariableDataType): any;
   export function valueToString(value: unknown, indent?: number): string;
   export function validateDataTypeValue(value: any, dataType?: BrunoVariableDataType): string | null;
+  export function jsonToDotenv(variables: Array<{ name: string; value?: string }>): string;
 }
 
 declare module '@usebruno/schema' {

--- a/src/webview/components/Environments/CollapsibleSection/StyledWrapper.ts
+++ b/src/webview/components/Environments/CollapsibleSection/StyledWrapper.ts
@@ -1,0 +1,86 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  &.collapsed {
+    flex-shrink: 0;
+
+    .section-content {
+      display: none;
+    }
+  }
+
+  &.expanded {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+
+    .section-content {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+    }
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    cursor: pointer;
+    user-select: none;
+    border-radius: 4px;
+    transition: background 0.15s ease;
+    flex-shrink: 0;
+
+    &:hover {
+      background: ${(props) => props.theme.workspace.button.bg};
+    }
+
+    .section-title-wrapper {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .section-icon {
+      color: ${(props) => props.theme.colors.text.muted};
+      transition: transform 0.2s ease;
+
+      &.expanded {
+        transform: rotate(90deg);
+      }
+    }
+
+    .section-title {
+      padding-right: 4px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: ${(props) => props.theme.sidebar.color};
+    }
+
+    .section-badge {
+      font-size: 10px;
+      padding: 1px 6px;
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
+      border-radius: 10px;
+      color: ${(props) => props.theme.colors.text.muted};
+    }
+
+    .section-actions {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+  }
+
+  .section-content {
+    padding: 4px 0;
+  }
+`;
+
+export default StyledWrapper;

--- a/src/webview/components/Environments/CollapsibleSection/index.tsx
+++ b/src/webview/components/Environments/CollapsibleSection/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { IconChevronRight } from '@tabler/icons';
+import StyledWrapper from './StyledWrapper';
+
+interface CollapsibleSectionProps {
+  title: string;
+  expanded: boolean;
+  onToggle: () => void;
+  badge?: number;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+  testId?: string;
+}
+
+const CollapsibleSection = ({
+  title,
+  expanded,
+  onToggle,
+  badge,
+  actions,
+  children,
+  testId
+}: CollapsibleSectionProps) => (
+  <StyledWrapper className={expanded ? 'expanded' : 'collapsed'}>
+    <div className="section-header" onClick={onToggle} data-testid={testId}>
+      <div className="section-title-wrapper">
+        <IconChevronRight size={14} strokeWidth={2} className={`section-icon ${expanded ? 'expanded' : ''}`} />
+        <span className="section-title">{title}</span>
+        {badge !== undefined && badge !== null && <span className="section-badge">{badge}</span>}
+      </div>
+      {actions && (
+        <div className="section-actions" onClick={(e) => e.stopPropagation()}>
+          {actions}
+        </div>
+      )}
+    </div>
+    <div className="section-content">{children}</div>
+  </StyledWrapper>
+);
+
+export default CollapsibleSection;

--- a/src/webview/components/Environments/Common/VariableNameError/index.tsx
+++ b/src/webview/components/Environments/Common/VariableNameError/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { IconAlertCircle } from '@tabler/icons';
+import { Tooltip } from 'react-tooltip';
+
+interface VariableNameErrorProps {
+  formik: any;
+  name: string;
+  index: number;
+}
+
+const VariableNameError = ({ formik, name, index }: VariableNameErrorProps) => {
+  const meta = formik.getFieldMeta(name);
+  const id = `error-${name}-${index}`;
+
+  const isLastRow = index === formik.values.length - 1;
+  const variable = formik.values[index];
+  const isEmptyRow = !variable?.name || variable.name.trim() === '';
+
+  if ((isLastRow && isEmptyRow) || !meta.error || !meta.touched) {
+    return null;
+  }
+
+  return (
+    <span>
+      <IconAlertCircle id={id} className="text-red-600 cursor-pointer" size={20} />
+      <Tooltip className="tooltip-mod" anchorId={id} html={meta.error || ''} />
+    </span>
+  );
+};
+
+export default VariableNameError;

--- a/src/webview/components/Environments/DotEnvFileDetails/StyledWrapper.ts
+++ b/src/webview/components/Environments/DotEnvFileDetails/StyledWrapper.ts
@@ -1,0 +1,93 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: ${(props) => props.theme.bg};
+
+  .header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px 8px 20px;
+    flex-shrink: 0;
+
+    .title {
+      font-size: ${(props) => props.theme.font.size.base};
+      font-weight: 500;
+      color: ${(props) => props.theme.text};
+      margin: 0;
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+
+      .view-toggle {
+        display: flex;
+        border: 1px solid ${(props) => props.theme.border.border0};
+        border-radius: 4px;
+        overflow: hidden;
+
+        .toggle-btn {
+          padding: 4px 12px;
+          font-size: 12px;
+          border: none;
+          background: transparent;
+          color: ${(props) => props.theme.colors.text.muted};
+          cursor: pointer;
+          transition: all 0.15s ease;
+
+          &:first-child {
+            border-right: 1px solid ${(props) => props.theme.border.border0};
+          }
+
+          &:hover {
+            background: ${(props) => props.theme.sidebar.bg};
+          }
+
+          &.active {
+            background: ${(props) => props.theme.brand};
+            color: ${(props) => props.theme.bg};
+          }
+        }
+      }
+
+      .action-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 6px;
+        border: none;
+        background: transparent;
+        color: ${(props) => props.theme.colors.text.muted};
+        cursor: pointer;
+        border-radius: 4px;
+        transition: all 0.15s ease;
+
+        &:hover {
+          background: ${(props) => props.theme.sidebar.bg};
+          color: ${(props) => props.theme.text};
+        }
+
+        &.delete-btn:hover {
+          color: ${(props) => props.theme.colors.text.danger};
+        }
+      }
+    }
+  }
+
+  .content {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    padding: 0 20px 20px 20px;
+  }
+`;
+
+export default StyledWrapper;

--- a/src/webview/components/Environments/DotEnvFileDetails/index.tsx
+++ b/src/webview/components/Environments/DotEnvFileDetails/index.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { IconTrash } from '@tabler/icons';
+import DeleteDotEnvFile from 'components/Environments/EnvironmentSettings/DeleteDotEnvFile';
+import StyledWrapper from './StyledWrapper';
+
+interface DotEnvFileDetailsProps {
+  title: string;
+  children: React.ReactNode;
+  onDelete: () => void;
+  viewMode: 'table' | 'raw';
+  onViewModeChange: (mode: 'table' | 'raw') => void;
+}
+
+const DotEnvFileDetails = ({
+  title,
+  children,
+  onDelete,
+  viewMode,
+  onViewModeChange
+}: DotEnvFileDetailsProps) => {
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  return (
+    <StyledWrapper>
+      <div className="header">
+        <h3 className="title">{title}</h3>
+        <div className="actions">
+          <div className="view-toggle" role="group" aria-label="View mode">
+            <button
+              type="button"
+              className={`toggle-btn ${viewMode === 'table' ? 'active' : ''}`}
+              onClick={() => onViewModeChange('table')}
+              aria-pressed={viewMode === 'table'}
+              data-testid="dotenv-view-table"
+            >
+              Table
+            </button>
+            <button
+              type="button"
+              className={`toggle-btn ${viewMode === 'raw' ? 'active' : ''}`}
+              onClick={() => onViewModeChange('raw')}
+              aria-pressed={viewMode === 'raw'}
+              data-testid="dotenv-view-raw"
+            >
+              Raw
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowDeleteModal(true)}
+            title="Delete .env file"
+            className="action-btn delete-btn"
+            data-testid="delete-dotenv-file"
+          >
+            <IconTrash size={15} strokeWidth={1.5} />
+          </button>
+        </div>
+      </div>
+
+      {showDeleteModal && (
+        <DeleteDotEnvFile onClose={() => setShowDeleteModal(false)} onConfirm={onDelete} filename={title} />
+      )}
+
+      <div className="content">{children}</div>
+    </StyledWrapper>
+  );
+};
+
+export default DotEnvFileDetails;

--- a/src/webview/components/Environments/DotEnvFileEditor/DotEnvRawView.tsx
+++ b/src/webview/components/Environments/DotEnvFileEditor/DotEnvRawView.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import CodeEditor from 'components/CodeEditor';
+
+interface DotEnvRawViewProps {
+  collection?: any;
+  theme: 'dark' | 'light';
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+  isSaving: boolean;
+}
+
+const DotEnvRawView = ({ collection, theme, value, onChange, onSave, onReset, isSaving }: DotEnvRawViewProps) => (
+  <>
+    <div className="raw-editor-container" data-testid="dotenv-raw-editor">
+      <CodeEditor
+        collection={collection}
+        theme={theme}
+        value={value}
+        onEdit={onChange}
+        onSave={onSave}
+        mode="text/plain"
+        enableVariableHighlighting={false}
+        enableBrunoVarInfo={false}
+      />
+    </div>
+    <div className="button-container">
+      <div className="flex items-center">
+        <button type="button" className="submit" onClick={onSave} disabled={isSaving} data-testid="save-dotenv-raw">
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+        <button type="button" className="submit reset ml-2" onClick={onReset} disabled={isSaving} data-testid="reset-dotenv-raw">
+          Reset
+        </button>
+      </div>
+    </div>
+  </>
+);
+
+export default DotEnvRawView;

--- a/src/webview/components/Environments/DotEnvFileEditor/DotEnvTableView.tsx
+++ b/src/webview/components/Environments/DotEnvFileEditor/DotEnvTableView.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { IconTrash } from '@tabler/icons';
+import MultiLineEditor from 'components/MultiLineEditor/index';
+import VariableNameError from 'components/Environments/Common/VariableNameError';
+
+interface DotEnvTableViewProps {
+  formik: any;
+  theme: 'dark' | 'light';
+  onNameChange: (index: number, e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNameBlur: (index: number) => void;
+  onNameKeyDown: (index: number, e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onRemoveVar: (uid: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+  isSaving: boolean;
+}
+
+const DotEnvTableView = ({
+  formik,
+  theme,
+  onNameChange,
+  onNameBlur,
+  onNameKeyDown,
+  onRemoveVar,
+  onSave,
+  onReset,
+  isSaving
+}: DotEnvTableViewProps) => (
+  <>
+    <div className="table-container">
+      <table>
+        <thead>
+          <tr>
+            <td>Name</td>
+            <td>Value</td>
+            <td className="delete-col"></td>
+          </tr>
+        </thead>
+        <tbody>
+          {formik.values.map((variable: any, index: number) => {
+            const isLastRow = index === formik.values.length - 1;
+            const isEmptyRow = !variable.name || variable.name.trim() === '';
+            const isLastEmptyRow = isLastRow && isEmptyRow;
+
+            return (
+              <tr key={variable.uid} data-testid={`dotenv-var-row-${variable.name}`}>
+                <td>
+                  <div className="flex items-center">
+                    <input
+                      type="text"
+                      autoComplete="off"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      spellCheck="false"
+                      className="mousetrap"
+                      id={`${index}.name`}
+                      name={`${index}.name`}
+                      value={variable.name}
+                      placeholder={isLastEmptyRow ? 'Name' : ''}
+                      onChange={(e) => onNameChange(index, e)}
+                      onBlur={() => onNameBlur(index)}
+                      onKeyDown={(e) => onNameKeyDown(index, e)}
+                    />
+                    <VariableNameError formik={formik} name={`${index}.name`} index={index} />
+                  </div>
+                </td>
+                <td className="flex flex-row flex-nowrap items-center">
+                  <div className="overflow-hidden grow w-full relative">
+                    <MultiLineEditor
+                      theme={theme}
+                      value={variable.value}
+                      placeholder={isLastEmptyRow ? 'Value' : ''}
+                      onChange={(newValue: string) => formik.setFieldValue(`${index}.value`, newValue, true)}
+                      onSave={onSave}
+                    />
+                  </div>
+                </td>
+                <td className="delete-col">
+                  {!isLastEmptyRow && (
+                    <button type="button" aria-label="Delete variable" onClick={() => onRemoveVar(variable.uid)}>
+                      <IconTrash strokeWidth={1.5} size={18} />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+
+    <div className="button-container">
+      <div className="flex items-center">
+        <button type="button" className="submit" onClick={onSave} disabled={isSaving} data-testid="save-dotenv">
+          {isSaving ? 'Saving...' : 'Save'}
+        </button>
+        <button type="button" className="submit reset ml-2" onClick={onReset} disabled={isSaving} data-testid="reset-dotenv">
+          Reset
+        </button>
+      </div>
+    </div>
+  </>
+);
+
+export default DotEnvTableView;

--- a/src/webview/components/Environments/DotEnvFileEditor/StyledWrapper.ts
+++ b/src/webview/components/Environments/DotEnvFileEditor/StyledWrapper.ts
@@ -1,0 +1,150 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+
+  .raw-editor-container {
+    flex: 1;
+    overflow: hidden;
+    border-radius: 8px;
+    border: solid 1px ${(props) => props.theme.border.border0};
+
+    .CodeMirror {
+      font-size: ${(props) => props.theme.font.size.base};
+    }
+  }
+
+  .table-container {
+    overflow-y: auto;
+    border-radius: 8px;
+    border: solid 1px ${(props) => props.theme.border.border0};
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-size: 12px;
+
+    td {
+      vertical-align: middle;
+      padding: 2px 10px;
+
+      &:first-child {
+        width: 35%;
+      }
+
+      &.delete-col {
+        width: 40px;
+        text-align: center;
+        padding: 2px 4px;
+      }
+    }
+
+    thead {
+      color: ${(props) => props.theme.table.thead.color} !important;
+      background: ${(props) => props.theme.sidebar.bg};
+      font-size: ${(props) => props.theme.font.size.base};
+      user-select: none;
+
+      td {
+        padding: 5px 10px !important;
+        border-bottom: solid 1px ${(props) => props.theme.border.border0};
+        border-right: solid 1px ${(props) => props.theme.border.border0};
+
+        &:last-child {
+          border-right: none;
+        }
+      }
+    }
+
+    tbody {
+      tr {
+        transition: background 0.1s ease;
+
+        &:last-child td {
+          border-bottom: none;
+        }
+
+        td {
+          border-bottom: solid 1px ${(props) => props.theme.border.border0};
+          border-right: solid 1px ${(props) => props.theme.border.border0};
+
+          &:last-child {
+            border-right: none;
+          }
+        }
+      }
+    }
+  }
+
+  .tooltip-mod {
+    max-width: 200px !important;
+  }
+
+  input[type='text'] {
+    width: 100%;
+    border: 1px solid transparent;
+    outline: none !important;
+    background-color: transparent;
+    color: ${(props) => props.theme.text};
+    padding: 0;
+    border-radius: 4px;
+    transition: all 0.15s ease;
+
+    &:focus {
+      outline: none !important;
+    }
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    color: ${(props) => props.theme.colors.text.muted};
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+    transition: color 0.15s ease, background 0.15s ease;
+  }
+
+  .button-container {
+    padding: 12px 2px;
+    background: ${(props) => props.theme.bg};
+    flex-shrink: 0;
+    display: flex;
+    gap: 8px;
+  }
+
+  .submit {
+    padding: 6px 16px;
+    font-size: ${(props) => props.theme.font.size.sm};
+    border-radius: ${(props) => props.theme.border.radius.base};
+    border: none;
+    background: ${(props) => props.theme.brand};
+    color: ${(props) => props.theme.bg};
+    cursor: pointer;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+
+  .reset {
+    background: transparent;
+    padding: 6px 16px;
+    color: ${(props) => props.theme.brand};
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+`;
+
+export default StyledWrapper;

--- a/src/webview/components/Environments/DotEnvFileEditor/index.tsx
+++ b/src/webview/components/Environments/DotEnvFileEditor/index.tsx
@@ -1,0 +1,242 @@
+import React, { useCallback, useRef, useMemo, useEffect, useState } from 'react';
+import { useFormik } from 'formik';
+import toast from 'react-hot-toast';
+import type { DotEnvVariable } from '@bruno-types';
+import { useTheme } from 'providers/Theme';
+import { uuid } from 'utils/common';
+import { variableNameRegex } from 'utils/common/regex';
+import useDeferredLoading from 'hooks/useDeferredLoading';
+
+import StyledWrapper from './StyledWrapper';
+import DotEnvTableView from './DotEnvTableView';
+import DotEnvRawView from './DotEnvRawView';
+import { variablesToRaw, rawToVariables } from './utils';
+
+interface DotEnvFileEditorProps {
+  variables: DotEnvVariable[];
+  content: string;
+  onSave: (variables: DotEnvVariable[]) => Promise<unknown>;
+  onSaveRaw: (content: string) => Promise<unknown>;
+  setIsModified: (modified: boolean) => void;
+  viewMode: 'table' | 'raw';
+  collection?: any;
+}
+
+const emptyRow = (): DotEnvVariable => ({ uid: uuid(), name: '', value: '' });
+
+const normalizeForComparison = (variables: DotEnvVariable[]) =>
+  variables
+    .filter((variable) => variable.name && variable.name.trim() !== '')
+    .map(({ name, value }) => ({ name, value: value || '' }));
+
+const DotEnvFileEditor = ({
+  variables,
+  content,
+  onSave,
+  onSaveRaw,
+  setIsModified,
+  viewMode,
+  collection
+}: DotEnvFileEditorProps) => {
+  const { displayedTheme } = useTheme();
+  const [rawValue, setRawValue] = useState(content);
+  const [prevViewMode, setPrevViewMode] = useState(viewMode);
+  const [isSaving, setIsSaving] = useState(false);
+  const showSaving = useDeferredLoading(isSaving);
+
+  const initialValues = useMemo(
+    () => [...(variables || []).map((variable) => ({ ...variable, uid: variable.uid || uuid() })), emptyRow()],
+    [variables]
+  );
+
+  const formik = useFormik<DotEnvVariable[]>({
+    enableReinitialize: true,
+    initialValues,
+    validate: (values) => {
+      const errors: Record<number, { name: string }> = {};
+      values.forEach((variable, index) => {
+        const isLastRow = index === values.length - 1;
+        const isEmptyRow = !variable.name || variable.name.trim() === '';
+
+        if (isLastRow && isEmptyRow) {
+          return;
+        }
+
+        if (isEmptyRow) {
+          errors[index] = { name: 'Name cannot be empty' };
+        } else if (!variableNameRegex.test(variable.name)) {
+          errors[index] = {
+            name: 'Name contains invalid characters. Must only contain alphanumeric characters, "-", "_", "." and cannot start with a digit.'
+          };
+        }
+      });
+      return Object.keys(errors).length > 0 ? errors : {};
+    },
+    onSubmit: () => {}
+  });
+
+  const formikRef = useRef(formik);
+  formikRef.current = formik;
+
+  useEffect(() => {
+    setRawValue(content);
+  }, [content]);
+
+  useEffect(() => {
+    if (viewMode === prevViewMode) return;
+
+    if (viewMode === 'raw') {
+      const namedVars = formikRef.current.values.filter((variable) => variable.name && variable.name.trim() !== '');
+      setRawValue(variablesToRaw(namedVars));
+    } else {
+      formikRef.current.setValues([...rawToVariables(rawValue), emptyRow()]);
+    }
+    setPrevViewMode(viewMode);
+  }, [viewMode, prevViewMode, rawValue]);
+
+  const savedValuesJson = useMemo(() => JSON.stringify(normalizeForComparison(variables || [])), [variables]);
+
+  useEffect(() => {
+    if (viewMode === 'raw') {
+      setIsModified(rawValue !== content);
+    } else {
+      setIsModified(JSON.stringify(normalizeForComparison(formik.values)) !== savedValuesJson);
+    }
+  }, [formik.values, savedValuesJson, setIsModified, viewMode, rawValue, content]);
+
+  const handleRemoveVar = useCallback((id: string) => {
+    const currentValues = formikRef.current.values;
+    if (!currentValues.length) return;
+
+    const lastRow = currentValues[currentValues.length - 1];
+    if (lastRow?.uid === id && (!lastRow.name || lastRow.name.trim() === '')) {
+      return;
+    }
+
+    const filteredValues = currentValues.filter((variable) => variable.uid !== id);
+    const lastFilteredRow = filteredValues[filteredValues.length - 1];
+    const hasEmptyLastRow = filteredValues.length > 0 && (!lastFilteredRow.name || lastFilteredRow.name.trim() === '');
+
+    formikRef.current.setValues(hasEmptyLastRow ? filteredValues : [...filteredValues, emptyRow()]);
+  }, []);
+
+  const handleNameChange = useCallback((index: number, e: React.ChangeEvent<HTMLInputElement>) => {
+    formikRef.current.handleChange(e);
+
+    if (index !== formikRef.current.values.length - 1) return;
+
+    const newVariable = emptyRow();
+    setTimeout(() => {
+      formikRef.current.setValues((prev) => {
+        const lastRow = prev[prev.length - 1];
+        return lastRow?.name?.trim() ? [...prev, newVariable] : prev;
+      });
+    }, 0);
+  }, []);
+
+  const handleNameBlur = useCallback((index: number) => {
+    formikRef.current.setFieldTouched(`${index}.name`, true, true);
+  }, []);
+
+  const handleNameKeyDown = useCallback((index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      formikRef.current.setFieldTouched(`${index}.name`, true, true);
+    }
+  }, []);
+
+  const handleSave = useCallback(() => {
+    if (isSaving) return;
+
+    const variablesToSave = formikRef.current.values.filter((variable) => variable.name && variable.name.trim() !== '');
+    const hasValidationErrors = variablesToSave.some((variable) => !variableNameRegex.test(variable.name));
+
+    if (hasValidationErrors) {
+      toast.error('Please fix validation errors before saving');
+      return;
+    }
+
+    setIsSaving(true);
+    onSave(variablesToSave)
+      .then(() => {
+        toast.success('Changes saved successfully');
+        formikRef.current.resetForm({ values: [...variablesToSave, emptyRow()] });
+        setIsModified(false);
+      })
+      .catch((error) => {
+        console.error(error);
+        toast.error('An error occurred while saving the changes');
+      })
+      .finally(() => setIsSaving(false));
+  }, [isSaving, onSave, setIsModified]);
+
+  const handleSaveRaw = useCallback(() => {
+    if (isSaving) return;
+
+    setIsSaving(true);
+    onSaveRaw(rawValue)
+      .then(() => {
+        toast.success('Changes saved successfully');
+        setIsModified(false);
+      })
+      .catch((error) => {
+        console.error(error);
+        toast.error('An error occurred while saving the changes');
+      })
+      .finally(() => setIsSaving(false));
+  }, [isSaving, rawValue, onSaveRaw, setIsModified]);
+
+  const handleReset = useCallback(() => {
+    if (viewMode === 'raw') {
+      setRawValue(content);
+    } else {
+      const originalVars = (variables || []).map((variable) => ({ ...variable, uid: variable.uid || uuid() }));
+      formikRef.current.resetForm({ values: [...originalVars, emptyRow()] });
+    }
+    setIsModified(false);
+  }, [viewMode, content, variables, setIsModified]);
+
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = viewMode === 'raw' ? handleSaveRaw : handleSave;
+
+  useEffect(() => {
+    const handleSaveEvent = () => handleSaveRef.current();
+
+    window.addEventListener('dotenv-save', handleSaveEvent);
+    return () => window.removeEventListener('dotenv-save', handleSaveEvent);
+  }, []);
+
+  if (viewMode === 'raw') {
+    return (
+      <StyledWrapper>
+        <DotEnvRawView
+          collection={collection}
+          theme={displayedTheme}
+          value={rawValue}
+          onChange={setRawValue}
+          onSave={handleSaveRaw}
+          onReset={handleReset}
+          isSaving={showSaving}
+        />
+      </StyledWrapper>
+    );
+  }
+
+  return (
+    <StyledWrapper>
+      <DotEnvTableView
+        formik={formik}
+        theme={displayedTheme}
+        onNameChange={handleNameChange}
+        onNameBlur={handleNameBlur}
+        onNameKeyDown={handleNameKeyDown}
+        onRemoveVar={handleRemoveVar}
+        onSave={handleSave}
+        onReset={handleReset}
+        isSaving={showSaving}
+      />
+    </StyledWrapper>
+  );
+};
+
+export default DotEnvFileEditor;

--- a/src/webview/components/Environments/DotEnvFileEditor/utils.spec.ts
+++ b/src/webview/components/Environments/DotEnvFileEditor/utils.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { rawToVariables, variablesToRaw } from './utils';
+
+const { dotenvToJson } = require('@usebruno/lang');
+
+const asObject = (content: string) =>
+  Object.fromEntries(rawToVariables(content).map((variable) => [variable.name, variable.value]));
+
+describe('dotenv raw/table conversion', () => {
+  const samples = [
+    'HOST=localhost',
+    'HOST = localhost',
+    'export HOST=localhost',
+    'TOKEN=abc # inline comment',
+    '# leading comment\nHOST=localhost\n\nPORT=8081',
+    'QUOTED="a#b"',
+    'LITERAL=\'a#b\'',
+    'BACKTICK=`a\'b"c`',
+    'MULTILINE="line1\\nline2"',
+    'PADDED=\'  spaced  \'',
+    'EMPTY=',
+    'DUP=one\nDUP=two'
+  ];
+
+  it('parses raw content exactly like the parser the extension writes with', () => {
+    samples.forEach((content) => {
+      expect(asObject(content)).toEqual(dotenvToJson(content));
+    });
+  });
+
+  it('round-trips through the table view without changing values', () => {
+    samples.forEach((content) => {
+      expect(asObject(variablesToRaw(rawToVariables(content)))).toEqual(dotenvToJson(content));
+    });
+  });
+});

--- a/src/webview/components/Environments/DotEnvFileEditor/utils.ts
+++ b/src/webview/components/Environments/DotEnvFileEditor/utils.ts
@@ -1,0 +1,34 @@
+import { jsonToDotenv } from '@usebruno/common/utils';
+import type { DotEnvVariable } from '@bruno-types';
+import { uuid } from 'utils/common';
+
+/**
+ * Mirrors dotenv's own LINE regex and unquoting, the parser @usebruno/lang runs on the
+ * extension side. Reimplemented here because dotenv's entry point is node-only, and the two
+ * must agree or a raw edit changes values on the way back to the table view.
+ */
+const DOTENV_LINE = /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/mg;
+
+export const variablesToRaw = (variables: DotEnvVariable[]): string => jsonToDotenv(variables);
+
+export const rawToVariables = (rawContent: string): DotEnvVariable[] => {
+  const variables: DotEnvVariable[] = [];
+  const lines = (rawContent || '').replace(/\r\n?/mg, '\n');
+  const lineMatcher = new RegExp(DOTENV_LINE.source, DOTENV_LINE.flags);
+
+  let match = lineMatcher.exec(lines);
+  while (match !== null) {
+    let value = (match[2] || '').trim();
+    const quote = value[0];
+
+    value = value.replace(/^(['"`])([\s\S]*)\1$/mg, '$2');
+    if (quote === '"') {
+      value = value.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+    }
+
+    variables.push({ uid: uuid(), name: match[1], value, enabled: true, secret: false });
+    match = lineMatcher.exec(lines);
+  }
+
+  return variables;
+};

--- a/src/webview/components/Environments/EnvironmentSettings/DeleteDotEnvFile/StyledWrapper.ts
+++ b/src/webview/components/Environments/EnvironmentSettings/DeleteDotEnvFile/StyledWrapper.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  button.submit {
+    color: white;
+    background-color: var(--color-background-danger) !important;
+    border: inherit !important;
+
+    &:hover {
+      border: inherit !important;
+    }
+  }
+`;
+
+export default Wrapper;

--- a/src/webview/components/Environments/EnvironmentSettings/DeleteDotEnvFile/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSettings/DeleteDotEnvFile/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Portal from 'components/Portal/index';
+import Modal from 'components/Modal/index';
+import StyledWrapper from './StyledWrapper';
+
+interface DeleteDotEnvFileProps {
+  onClose: () => void;
+  onConfirm: () => void;
+  filename: string;
+}
+
+const DeleteDotEnvFile = ({ onClose, onConfirm, filename }: DeleteDotEnvFileProps) => {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Portal>
+      <StyledWrapper>
+        <Modal
+          size="sm"
+          title={`Delete ${filename} File`}
+          confirmText="Delete"
+          handleConfirm={handleConfirm}
+          handleCancel={onClose}
+          confirmButtonColor="danger"
+        >
+          Are you sure you want to delete <span className="font-medium">{filename}</span> file?
+        </Modal>
+      </StyledWrapper>
+    </Portal>
+  );
+};
+
+export default DeleteDotEnvFile;

--- a/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useMemo, useEffect } from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 import { get } from 'lodash';
-import { IconTrash, IconAlertCircle } from '@tabler/icons';
+import { IconTrash } from '@tabler/icons';
 import { useTheme } from 'providers/Theme';
 import { useDispatch, useSelector } from 'react-redux';
 import { valueToString, BRUNO_VARIABLE_DATATYPES } from '@usebruno/common/utils';
@@ -16,9 +16,9 @@ import toast from 'react-hot-toast';
 import { saveEnvironment } from 'providers/ReduxStore/slices/collections/actions';
 import { setEnvironmentsDraft, clearEnvironmentsDraft } from 'providers/ReduxStore/slices/collections';
 import { saveGlobalEnvironment, setGlobalEnvironmentDraft, clearGlobalEnvironmentDraft } from 'providers/ReduxStore/slices/global-environments';
-import { Tooltip } from 'react-tooltip';
 import { getGlobalEnvironmentVariables, flattenItems, isItemARequest } from 'utils/collections';
 import SensitiveFieldWarning from 'components/SensitiveFieldWarning';
+import VariableNameError from 'components/Environments/Common/VariableNameError';
 import { sensitiveFields } from './constants';
 
 interface EnvironmentVariablesProps {
@@ -237,32 +237,6 @@ const EnvironmentVariables = ({
     return () => clearTimeout(timeoutId);
   }, [formik.values, savedValuesJson, environment.uid, isGlobal ? null : collection?.uid, dispatch, hasDraftForThisEnv, environmentsDraft?.variables, isGlobal]);
 
-  const ErrorMessage = ({
-    name,
-    index
-  }: any) => {
-    const meta = formik.getFieldMeta(name);
-    const id = `error-${name}-${index}`;
-
-    const isLastRow = index === formik.values.length - 1;
-    const variable = formik.values[index];
-    const isEmptyRow = !variable?.name || variable.name.trim() === '';
-
-    if (isLastRow && isEmptyRow) {
-      return null;
-    }
-
-    if (!meta.error || !meta.touched) {
-      return null;
-    }
-    return (
-      <span>
-        <IconAlertCircle id={id} className="text-red-600 cursor-pointer" size={20} />
-        <Tooltip className="tooltip-mod" anchorId={id} html={meta.error || ''} />
-      </span>
-    );
-  };
-
   const handleRemoveVar = useCallback((id: any) => {
     const currentValues = formik.values;
 
@@ -464,7 +438,7 @@ const EnvironmentVariables = ({
                         onBlur={() => handleNameBlur(index)}
                         onKeyDown={(e) => handleNameKeyDown(index, e)}
                       />
-                      <ErrorMessage name={`${index}.name`} index={index} />
+                      <VariableNameError formik={formik} name={`${index}.name`} index={index} />
                     </div>
                   </td>
                   <td className="flex flex-row flex-nowrap items-center gap-2">

--- a/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/StyledWrapper.ts
+++ b/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/StyledWrapper.ts
@@ -32,79 +32,100 @@ const StyledWrapper = styled.div`
     border-right: 1px solid ${(props) => props.theme.sidebar.collection.item.indentBorder};
     display: flex;
     flex-direction: column;
+    overflow: hidden;
   }
 
-  .sidebar-header {
+  .sections-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 8px;
+  }
+
+  .section-header {
+    margin-inline: 4px !important;
+    padding-left: 6px !important;
+    padding-right: 3px !important;
+    padding-block: 4px !important;
+    border-radius: 6px;
+  }
+
+  .btn-action {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 16px 16px 12px 16px;
-    
-    .title {
-      font-size: ${(props) => props.theme.font.size.base};
-      font-weight: 500;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: ${(props) => props.theme.colors.text.muted};
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
       color: ${(props) => props.theme.text};
-      margin: 0;
     }
-    
-    .btn-action {
+  }
+
+  .env-list-search {
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin: 0 4px 6px 4px;
+
+    .env-list-search-icon {
+      position: absolute;
+      left: 8px;
+      color: ${(props) => props.theme.colors.text.muted};
+      pointer-events: none;
+    }
+
+    .env-list-search-input {
+      width: 100%;
+      padding: 5px 24px 5px 26px;
+      font-size: 12px;
+      background: transparent;
+      border: 1px solid ${(props) => props.theme.border.border1};
+      border-radius: 6px;
+      color: ${(props) => props.theme.text};
+      transition: border-color 0.15s ease;
+
+      &::placeholder {
+        color: ${(props) => props.theme.colors.text.muted};
+      }
+
+      &:focus {
+        outline: none;
+        border-color: ${(props) => props.theme.colors.accent};
+      }
+    }
+
+    .env-list-search-clear {
+      position: absolute;
+      right: 4px;
       display: flex;
       align-items: center;
       justify-content: center;
-      width: 24px;
-      height: 24px;
-      padding: 0;
+      padding: 2px;
       background: transparent;
       border: none;
-      border-radius: 4px;
-      color: ${(props) => props.theme.colors.text.muted};
       cursor: pointer;
-      transition: all 0.15s ease;
-      
+      color: ${(props) => props.theme.colors.text.muted};
+      border-radius: 3px;
+
       &:hover {
-        background: ${(props) => props.theme.sidebar.collection.item.hoverBg};
         color: ${(props) => props.theme.text};
       }
     }
   }
 
-  .search-container {
-    position: relative;
-    padding: 0 12px 12px 12px;
-    
-    .search-icon {
-      position: absolute;
-      left: 20px;
-      top: 50%;
-      transform: translateY(-100%);
-      color: ${(props) => props.theme.colors.text.muted};
-      pointer-events: none;
-    }
-    
-    .search-input {
-      width: 100%;
-      padding: 6px 8px 6px 28px;
-      font-size: 12px;
-      background: transparent;
-      border: ${(props) => props.theme.sidebar.collection.item.indentBorder};
-      border-radius: 5px;
-      color: ${(props) => props.theme.text};
-      transition: all 0.15s ease;
-      
-      &::placeholder {
-        color: ${(props) => props.theme.colors.text.muted};
-      }
-      
-      &:focus {
-        outline: none;
-      }
-    }
-  }
-
   .environments-list {
-    flex: 1;
     overflow-y: auto;
-    padding: 0 8px;
+    padding: 0 4px;
   }
 
   .environment-item {
@@ -268,6 +289,39 @@ const StyledWrapper = styled.div`
     }
   }
   
+  .no-env-file {
+    padding: 8px 12px;
+    font-size: 12px;
+    color: ${(props) => props.theme.colors.text.muted};
+    font-style: italic;
+  }
+
+  .empty-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 10%;
+    color: ${(props) => props.theme.colors.text.muted};
+
+    svg {
+      opacity: 0.3;
+      margin-bottom: 8px;
+    }
+
+    .title {
+      font-size: 13px;
+      font-weight: 500;
+      margin-bottom: 12px;
+      color: ${(props) => props.theme.colors.text.muted};
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+    }
+  }
+
   .env-error {
     padding: 4px 12px;
     margin-top: 4px;

--- a/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/index.tsx
@@ -1,30 +1,34 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import usePrevious from 'hooks/usePrevious';
 import EnvironmentDetails from './EnvironmentDetails';
-import CreateEnvironment from 'components/Environments/EnvironmentSettings/CreateEnvironment';
-import { IconDownload, IconUpload, IconSearch, IconPlus, IconCheck, IconX } from '@tabler/icons';
+import { IconDownload, IconUpload, IconSearch, IconPlus, IconCheck, IconX, IconFileAlert } from '@tabler/icons';
 import StyledWrapper from './StyledWrapper';
 import ConfirmSwitchEnv from 'components/Environments/ConfirmSwitchEnv';
 import ImportEnvironmentModal from 'components/Environments/Common/ImportEnvironmentModal';
+import CollapsibleSection from 'components/Environments/CollapsibleSection';
+import DotEnvFileDetails from 'components/Environments/DotEnvFileDetails';
+import DotEnvFileEditor from 'components/Environments/DotEnvFileEditor';
+import Button from 'ui/Button';
 import { isEqual } from 'lodash';
-import { useDispatch } from 'react-redux';
-import { addEnvironment, renameEnvironment, selectEnvironment } from 'providers/ReduxStore/slices/collections/actions';
+import { useDispatch, useSelector } from 'react-redux';
+import type { DotEnvFile, DotEnvVariable } from '@bruno-types';
+import {
+  addEnvironment,
+  renameEnvironment,
+  selectEnvironment,
+  saveDotEnvVariables,
+  saveDotEnvRaw,
+  createDotEnvFile,
+  deleteDotEnvFile
+} from 'providers/ReduxStore/slices/collections/actions';
+import { setEnvironmentsDraft, clearEnvironmentsDraft } from 'providers/ReduxStore/slices/collections';
 import { addGlobalEnvironment, renameGlobalEnvironment, selectGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
 import { validateName, validateNameError } from 'utils/common/regex';
 import toast from 'react-hot-toast';
 
-interface EnvironmentListProps {
-  environments: unknown[];
-  activeEnvironmentUid?: boolean;
-  selectedEnvironment?: React.ReactNode;
-  setSelectedEnvironment?: (...args: unknown[]) => unknown;
-  isModified?: boolean;
-  setIsModified?: boolean;
-  collection?: React.ReactNode;
-  setShowExportModal?: boolean;
-  isGlobal?: boolean;
-}
+const EMPTY_ARRAY: DotEnvFile[] = [];
 
+const DOTENV_NAME_PREFIX = '.env';
 
 const EnvironmentList = ({
   environments,
@@ -39,7 +43,6 @@ const EnvironmentList = ({
 }: any) => {
   const dispatch = useDispatch();
 
-  const [openCreateModal, setOpenCreateModal] = useState(false);
   const [openImportModal, setOpenImportModal] = useState(false);
   const [searchText, setSearchText] = useState('');
   const [isCreatingInline, setIsCreatingInline] = useState(false);
@@ -51,15 +54,60 @@ const EnvironmentList = ({
   const createContainerRef = useRef<HTMLDivElement>(null);
 
   const [switchEnvConfirmClose, setSwitchEnvConfirmClose] = useState(false);
-  const [originalEnvironmentVariables, setOriginalEnvironmentVariables] = useState<any[]>([]);
+
+  const [environmentsExpanded, setEnvironmentsExpanded] = useState(true);
+  const [dotEnvExpanded, setDotEnvExpanded] = useState(false);
+  const [activeView, setActiveView] = useState<'environment' | 'dotenv'>('environment');
+  const [isDotEnvModified, setIsDotEnvModified] = useState(false);
+  const [dotEnvViewMode, setDotEnvViewMode] = useState<'table' | 'raw'>('table');
+  const [selectedDotEnvFile, setSelectedDotEnvFile] = useState<string | null>(null);
+  const [isCreatingDotEnvInline, setIsCreatingDotEnvInline] = useState(false);
+  const [newDotEnvName, setNewDotEnvName] = useState(DOTENV_NAME_PREFIX);
+  const [dotEnvNameError, setDotEnvNameError] = useState('');
+  const dotEnvInputRef = useRef<HTMLInputElement>(null);
+  const dotEnvCreateContainerRef = useRef<HTMLDivElement>(null);
+
+  const dotEnvFiles = useSelector((state: any) => {
+    if (isGlobal) return EMPTY_ARRAY;
+    const coll = state.collections.collections.find((c: any) => c.uid === collection?.uid);
+    return coll?.dotEnvFiles || EMPTY_ARRAY;
+  });
 
   const envUids = environments ? environments.map((env: any) => env.uid) : [];
   const prevEnvUids = usePrevious(envUids);
 
+  const environmentsDraftUid = collection?.environmentsDraft?.environmentUid;
+
+  const handleDotEnvModifiedChange = useCallback((modified: boolean) => {
+    setIsDotEnvModified(modified);
+    if (modified) {
+      dispatch(setEnvironmentsDraft({
+        collectionUid: collection.uid,
+        environmentUid: `dotenv:${selectedDotEnvFile}`,
+        variables: []
+      }));
+    } else if (environmentsDraftUid?.startsWith('dotenv:')) {
+      dispatch(clearEnvironmentsDraft({ collectionUid: collection.uid }));
+    }
+  }, [dispatch, collection?.uid, selectedDotEnvFile, environmentsDraftUid]);
+
+  useEffect(() => {
+    if (!dotEnvFiles.length) {
+      setSelectedDotEnvFile(null);
+      setActiveView('environment');
+      handleDotEnvModifiedChange(false);
+      return;
+    }
+
+    const fileExists = dotEnvFiles.some((file: DotEnvFile) => file.filename === selectedDotEnvFile);
+    if (!selectedDotEnvFile || !fileExists) {
+      setSelectedDotEnvFile(dotEnvFiles[0].filename);
+    }
+  }, [dotEnvFiles]);
+
   useEffect(() => {
     if (!environments?.length) {
       setSelectedEnvironment(null);
-      setOriginalEnvironmentVariables([]);
       return;
     }
 
@@ -78,14 +126,12 @@ const EnvironmentList = ({
       if (hasSelectedEnvironmentChanged || selectedEnvironment.uid !== _selectedEnvironment?.uid) {
         setSelectedEnvironment(_selectedEnvironment);
       }
-      setOriginalEnvironmentVariables(_selectedEnvironment?.variables || []);
       return;
     }
 
     const environment = environments?.find((env: any) => env.uid === activeEnvironmentUid) || environments?.[0];
 
     setSelectedEnvironment(environment);
-    setOriginalEnvironmentVariables(environment?.variables || []);
   }, [environments, activeEnvironmentUid, selectedEnvironment]);
 
   useEffect(() => {
@@ -131,12 +177,47 @@ const EnvironmentList = ({
     };
   }, [isCreatingInline]);
 
+  useEffect(() => {
+    if (!isCreatingDotEnvInline) return;
+
+    const handleClickOutside = (event: any) => {
+      if (dotEnvCreateContainerRef.current && !dotEnvCreateContainerRef.current.contains(event.target)) {
+        handleCancelDotEnvCreate();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isCreatingDotEnvInline]);
+
   const handleEnvironmentClick = (env: any) => {
+    if (activeView === 'dotenv' && isDotEnvModified) {
+      setSwitchEnvConfirmClose(true);
+      return;
+    }
     if (!isModified) {
       setSelectedEnvironment(env);
+      setActiveView('environment');
+      setEnvironmentsExpanded(true);
     } else {
       setSwitchEnvConfirmClose(true);
     }
+  };
+
+  const handleDotEnvClick = (filename: string) => {
+    if (isModified) {
+      setSwitchEnvConfirmClose(true);
+      return;
+    }
+    if (activeView === 'dotenv' && isDotEnvModified && selectedDotEnvFile !== filename) {
+      setSwitchEnvConfirmClose(true);
+      return;
+    }
+    setSelectedDotEnvFile(filename);
+    setActiveView('dotenv');
+    setDotEnvExpanded(true);
   };
 
   const handleEnvironmentDoubleClick = (env: any) => {
@@ -163,10 +244,6 @@ const EnvironmentList = ({
       });
   };
 
-  if (!selectedEnvironment) {
-    return null;
-  }
-
   const validateEnvironmentName = (name: any, excludeUid: string | null = null) => {
     if (!name || name.trim() === '') {
       return 'Name is required';
@@ -188,7 +265,7 @@ const EnvironmentList = ({
   };
 
   const handleCreateEnvClick = () => {
-    if (!isModified) {
+    if (!isModified && !isDotEnvModified) {
       setIsCreatingInline(true);
       setNewEnvName('');
       setEnvNameError('');
@@ -284,7 +361,7 @@ const EnvironmentList = ({
   };
 
   const handleImportClick = () => {
-    if (!isModified) {
+    if (!isModified && !isDotEnvModified) {
       setOpenImportModal(true);
     } else {
       setSwitchEnvConfirmClose(true);
@@ -303,12 +380,181 @@ const EnvironmentList = ({
     }
   };
 
+  const handleSaveDotEnv = (variables: DotEnvVariable[]) => {
+    if (!selectedDotEnvFile) return Promise.reject(new Error('No file selected'));
+    return dispatch(saveDotEnvVariables(collection.uid, variables, selectedDotEnvFile)) as unknown as Promise<unknown>;
+  };
+
+  const handleSaveDotEnvRaw = (content: string) => {
+    if (!selectedDotEnvFile) return Promise.reject(new Error('No file selected'));
+    return dispatch(saveDotEnvRaw(collection.uid, content, selectedDotEnvFile)) as unknown as Promise<unknown>;
+  };
+
+  const handleCreateDotEnvInlineClick = () => {
+    if (isModified || isDotEnvModified) {
+      setSwitchEnvConfirmClose(true);
+      return;
+    }
+    setIsCreatingDotEnvInline(true);
+    setNewDotEnvName(DOTENV_NAME_PREFIX);
+    setDotEnvNameError('');
+    setTimeout(() => {
+      const input = dotEnvInputRef.current;
+      input?.focus();
+      input?.setSelectionRange(input.value.length, input.value.length);
+    }, 50);
+  };
+
+  const handleCancelDotEnvCreate = () => {
+    setIsCreatingDotEnvInline(false);
+    setNewDotEnvName(DOTENV_NAME_PREFIX);
+    setDotEnvNameError('');
+  };
+
+  const validateDotEnvName = (name: string) => {
+    if (!name || name.trim() === '') {
+      return 'Name is required';
+    }
+
+    if (!name.startsWith(DOTENV_NAME_PREFIX)) {
+      return 'File name must start with .env';
+    }
+
+    // Same rule as isValidDotEnvFilename on the extension side
+    if (!/^\.env(\.[a-zA-Z0-9._-]+)?$/.test(name)) {
+      return 'File name must be .env or .env.<suffix>';
+    }
+
+    if (dotEnvFiles.some((file: DotEnvFile) => file.filename === name)) {
+      return 'File already exists';
+    }
+
+    return null;
+  };
+
+  const handleSaveNewDotEnv = () => {
+    const error = validateDotEnvName(newDotEnvName);
+    if (error) {
+      setDotEnvNameError(error);
+      return;
+    }
+
+    (dispatch(createDotEnvFile(collection.uid, newDotEnvName)) as unknown as Promise<void>)
+      .then(() => {
+        toast.success(`${newDotEnvName} file created!`);
+        setIsCreatingDotEnvInline(false);
+        setSelectedDotEnvFile(newDotEnvName);
+        setNewDotEnvName(DOTENV_NAME_PREFIX);
+        setDotEnvNameError('');
+        setActiveView('dotenv');
+        setDotEnvExpanded(true);
+      })
+      .catch((error: Error) => {
+        toast.error(error.message || 'Failed to create .env file');
+      });
+  };
+
+  const handleDotEnvNameChange = (e: any) => {
+    const value = e.target.value;
+    setNewDotEnvName(value.startsWith(DOTENV_NAME_PREFIX) ? value : DOTENV_NAME_PREFIX);
+    if (dotEnvNameError) {
+      setDotEnvNameError('');
+    }
+  };
+
+  const handleDotEnvNameKeyDown = (e: any) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSaveNewDotEnv();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      handleCancelDotEnvCreate();
+    } else if (e.key === 'Backspace') {
+      const input = e.target;
+      if (input.selectionStart <= DOTENV_NAME_PREFIX.length && input.selectionEnd <= DOTENV_NAME_PREFIX.length) {
+        e.preventDefault();
+      }
+    }
+  };
+
+  const handleDeleteDotEnvFile = (filename: string) => {
+    (dispatch(deleteDotEnvFile(collection.uid, filename)) as unknown as Promise<void>)
+      .then(() => {
+        toast.success(`${filename} file deleted!`);
+        handleDotEnvModifiedChange(false);
+
+        const remainingFiles = dotEnvFiles.filter((file: DotEnvFile) => file.filename !== filename);
+        if (remainingFiles.length) {
+          setSelectedDotEnvFile(remainingFiles[0].filename);
+          return;
+        }
+
+        setActiveView('environment');
+        if (environments?.length) {
+          setSelectedEnvironment(environments.find((env: any) => env.uid === activeEnvironmentUid) || environments[0]);
+        }
+      })
+      .catch((error: Error) => {
+        toast.error(error.message || 'Failed to delete .env file');
+      });
+  };
+
   const filteredEnvironments
     = environments?.filter((env: any) => env.name.toLowerCase().includes(searchText.toLowerCase())) || [];
 
+  const selectedDotEnvData = dotEnvFiles.find((file: DotEnvFile) => file.filename === selectedDotEnvFile);
+
+  const renderContent = () => {
+    if (activeView === 'dotenv' && selectedDotEnvData) {
+      return (
+        <DotEnvFileDetails
+          title={selectedDotEnvData.filename}
+          onDelete={() => handleDeleteDotEnvFile(selectedDotEnvData.filename)}
+          viewMode={dotEnvViewMode}
+          onViewModeChange={setDotEnvViewMode}
+        >
+          <DotEnvFileEditor
+            variables={selectedDotEnvData.variables || []}
+            content={selectedDotEnvData.content}
+            onSave={handleSaveDotEnv}
+            onSaveRaw={handleSaveDotEnvRaw}
+            setIsModified={handleDotEnvModifiedChange}
+            viewMode={dotEnvViewMode}
+            collection={collection}
+          />
+        </DotEnvFileDetails>
+      );
+    }
+
+    if (selectedEnvironment) {
+      return (
+        <EnvironmentDetails
+          environment={selectedEnvironment}
+          setIsModified={setIsModified}
+          collection={collection}
+          isGlobal={isGlobal}
+        />
+      );
+    }
+
+    return (
+      <div className="empty-state">
+        <IconFileAlert size={48} strokeWidth={1.5} />
+        <div className="title">No Environments</div>
+        <div className="actions">
+          <Button size="sm" color="secondary" onClick={handleCreateEnvClick}>
+            Create Environment
+          </Button>
+          <Button size="sm" color="secondary" onClick={handleImportClick}>
+            Import Environment
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
   return (
     <StyledWrapper>
-      {openCreateModal && <CreateEnvironment collection={collection} onClose={() => setOpenCreateModal(false)} />}
       {openImportModal && (
         <ImportEnvironmentModal type={isGlobal ? 'global' : 'collection'} collection={collection} onClose={() => setOpenImportModal(false)} />
       )}
@@ -321,142 +567,264 @@ const EnvironmentList = ({
         )}
 
         <div className="sidebar">
-          <div className="sidebar-header">
-            <h2 className="title">Environments</h2>
-            <div className="flex items-center gap-2">
-              <button className="btn-action" onClick={() => handleCreateEnvClick()} title="Create environment">
-                <IconPlus size={16} strokeWidth={1.5} />
-              </button>
-              <button className="btn-action" onClick={() => handleImportClick()} title="Import environment">
-                <IconDownload size={16} strokeWidth={1.5} />
-              </button>
-              <button className="btn-action" onClick={() => handleExportClick()} title="Export environment">
-                <IconUpload size={16} strokeWidth={1.5} />
-              </button>
-            </div>
-          </div>
-
-          <div className="search-container">
-            <IconSearch size={14} strokeWidth={1.5} className="search-icon" />
-            <input
-              type="text"
-              placeholder="Search environments..."
-              value={searchText}
-              onChange={(e) => setSearchText(e.target.value)}
-              className="search-input"
-            />
-          </div>
-
-          <div className="environments-list">
-            {filteredEnvironments.map((env: any) => <div
-              key={env.uid}
-              id={env.uid}
-              className={`environment-item ${selectedEnvironment.uid === env.uid ? 'active' : ''} ${renamingEnvUid === env.uid ? 'renaming' : ''} ${activeEnvironmentUid === env.uid ? 'activated' : ''}`}
-              onClick={() => renamingEnvUid !== env.uid && handleEnvironmentClick(env)}
-              onDoubleClick={() => handleEnvironmentDoubleClick(env)}
-            >
-              {renamingEnvUid === env.uid ? (
-                <div className="rename-container" ref={renameContainerRef}>
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    className="environment-name-input"
-                    value={newEnvName}
-                    onChange={handleEnvNameChange}
-                    onKeyDown={handleEnvNameKeyDown}
-                    autoComplete="off"
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck="false"
-                  />
-                  <div className="inline-actions">
-                    <button
-                      className="inline-action-btn save"
-                      onClick={handleSaveRename}
-                      onMouseDown={(e) => e.preventDefault()}
-                      title="Save"
-                    >
-                      <IconCheck size={14} strokeWidth={2} />
-                    </button>
-                    <button
-                      className="inline-action-btn cancel"
-                      onClick={handleCancelRename}
-                      onMouseDown={(e) => e.preventDefault()}
-                      title="Cancel"
-                    >
-                      <IconX size={14} strokeWidth={2} />
-                    </button>
-                  </div>
-                </div>
-              ) : (
+          <div className="sections-container">
+            <CollapsibleSection
+              title="Environments"
+              expanded={environmentsExpanded}
+              onToggle={() => setEnvironmentsExpanded(!environmentsExpanded)}
+              actions={(
                 <>
-                  <span className="environment-name">{env.name}</span>
-                  <div className="environment-actions">
-                    {activeEnvironmentUid === env.uid ? (
-                      <div className="activated-checkmark" title="Active environment">
-                        <IconCheck size={16} strokeWidth={2} />
-                      </div>
-                    ) : (
-                      <button
-                        className="activate-btn"
-                        onClick={(e) => handleActivateEnvironment(e, env)}
-                        title="Activate environment"
-                      >
-                        <IconCheck size={16} strokeWidth={2} />
-                      </button>
-                    )}
-                  </div>
+                  <button
+                    type="button"
+                    className="btn-action"
+                    onClick={() => {
+                      setEnvironmentsExpanded(true);
+                      handleCreateEnvClick();
+                    }}
+                    title="Create environment"
+                  >
+                    <IconPlus size={14} strokeWidth={1.5} />
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-action"
+                    onClick={() => {
+                      setEnvironmentsExpanded(true);
+                      handleImportClick();
+                    }}
+                    title="Import environment"
+                  >
+                    <IconDownload size={14} strokeWidth={1.5} />
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-action"
+                    onClick={() => {
+                      setEnvironmentsExpanded(true);
+                      handleExportClick();
+                    }}
+                    title="Export environment"
+                  >
+                    <IconUpload size={14} strokeWidth={1.5} />
+                  </button>
                 </>
               )}
-            </div>)}
-
-            {isCreatingInline && (
-              <div className="environment-item creating" ref={createContainerRef}>
+            >
+              <div className="env-list-search">
+                <IconSearch size={13} strokeWidth={1.5} className="env-list-search-icon" />
                 <input
-                  ref={inputRef}
                   type="text"
-                  className="environment-name-input"
-                  value={newEnvName}
-                  onChange={handleEnvNameChange}
-                  onKeyDown={handleEnvNameKeyDown}
-                  placeholder="Environment name..."
+                  placeholder="Search environments..."
+                  value={searchText}
+                  onChange={(e) => setSearchText(e.target.value)}
+                  className="env-list-search-input"
                   autoComplete="off"
                   autoCorrect="off"
                   autoCapitalize="off"
                   spellCheck="false"
                 />
-                <div className="inline-actions">
+                {searchText && (
                   <button
-                    className="inline-action-btn save"
-                    onClick={handleSaveNewEnv}
+                    className="env-list-search-clear"
+                    title="Clear search"
+                    onClick={() => setSearchText('')}
                     onMouseDown={(e) => e.preventDefault()}
-                    title="Save"
                   >
-                    <IconCheck size={14} strokeWidth={2} />
+                    <IconX size={12} strokeWidth={1.5} />
                   </button>
-                  <button
-                    className="inline-action-btn cancel"
-                    onClick={handleCancelCreate}
-                    onMouseDown={(e) => e.preventDefault()}
-                    title="Cancel"
-                  >
-                    <IconX size={14} strokeWidth={2} />
-                  </button>
-                </div>
+                )}
               </div>
-            )}
 
-            {envNameError && (isCreatingInline || renamingEnvUid) && <div className="env-error">{envNameError}</div>}
+              <div className="environments-list">
+                {filteredEnvironments.map((env: any) => <div
+                  key={env.uid}
+                  id={env.uid}
+                  className={`environment-item ${activeView === 'environment' && selectedEnvironment?.uid === env.uid ? 'active' : ''} ${renamingEnvUid === env.uid ? 'renaming' : ''} ${activeEnvironmentUid === env.uid ? 'activated' : ''}`}
+                  onClick={() => renamingEnvUid !== env.uid && handleEnvironmentClick(env)}
+                  onDoubleClick={() => handleEnvironmentDoubleClick(env)}
+                >
+                  {renamingEnvUid === env.uid ? (
+                    <div className="rename-container" ref={renameContainerRef}>
+                      <input
+                        ref={inputRef}
+                        type="text"
+                        className="environment-name-input"
+                        value={newEnvName}
+                        onChange={handleEnvNameChange}
+                        onKeyDown={handleEnvNameKeyDown}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck="false"
+                      />
+                      <div className="inline-actions">
+                        <button
+                          className="inline-action-btn save"
+                          onClick={handleSaveRename}
+                          onMouseDown={(e) => e.preventDefault()}
+                          title="Save"
+                        >
+                          <IconCheck size={14} strokeWidth={2} />
+                        </button>
+                        <button
+                          className="inline-action-btn cancel"
+                          onClick={handleCancelRename}
+                          onMouseDown={(e) => e.preventDefault()}
+                          title="Cancel"
+                        >
+                          <IconX size={14} strokeWidth={2} />
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <span className="environment-name">{env.name}</span>
+                      <div className="environment-actions">
+                        {activeEnvironmentUid === env.uid ? (
+                          <div className="activated-checkmark" title="Active environment">
+                            <IconCheck size={16} strokeWidth={2} />
+                          </div>
+                        ) : (
+                          <button
+                            className="activate-btn"
+                            onClick={(e) => handleActivateEnvironment(e, env)}
+                            title="Activate environment"
+                          >
+                            <IconCheck size={16} strokeWidth={2} />
+                          </button>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>)}
+
+                {isCreatingInline && (
+                  <div className="environment-item creating" ref={createContainerRef}>
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      className="environment-name-input"
+                      value={newEnvName}
+                      onChange={handleEnvNameChange}
+                      onKeyDown={handleEnvNameKeyDown}
+                      placeholder="Environment name..."
+                      autoComplete="off"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      spellCheck="false"
+                    />
+                    <div className="inline-actions">
+                      <button
+                        className="inline-action-btn save"
+                        onClick={handleSaveNewEnv}
+                        onMouseDown={(e) => e.preventDefault()}
+                        title="Save"
+                      >
+                        <IconCheck size={14} strokeWidth={2} />
+                      </button>
+                      <button
+                        className="inline-action-btn cancel"
+                        onClick={handleCancelCreate}
+                        onMouseDown={(e) => e.preventDefault()}
+                        title="Cancel"
+                      >
+                        <IconX size={14} strokeWidth={2} />
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {envNameError && (isCreatingInline || renamingEnvUid) && <div className="env-error">{envNameError}</div>}
+
+                {!filteredEnvironments.length && !isCreatingInline && (
+                  <div className="no-env-file">
+                    <span>No environments</span>
+                  </div>
+                )}
+              </div>
+            </CollapsibleSection>
+
+            {!isGlobal && (
+              <CollapsibleSection
+                title=".env Files"
+                testId="dotenv-files-section"
+                expanded={dotEnvExpanded}
+                onToggle={() => setDotEnvExpanded(!dotEnvExpanded)}
+                badge={dotEnvFiles.length}
+                actions={(
+                  <button
+                    type="button"
+                    className="btn-action"
+                    onClick={handleCreateDotEnvInlineClick}
+                    title="Create .env file"
+                    data-testid="create-dotenv-file"
+                  >
+                    <IconPlus size={14} strokeWidth={1.5} />
+                  </button>
+                )}
+              >
+                <div className="environments-list">
+                  {dotEnvFiles.map((file: DotEnvFile) => (
+                    <div
+                      key={file.filename}
+                      className={`environment-item ${activeView === 'dotenv' && selectedDotEnvFile === file.filename ? 'active' : ''}`}
+                      onClick={() => handleDotEnvClick(file.filename)}
+                      data-testid={`dotenv-file-${file.filename}`}
+                    >
+                      <span className="environment-name">{file.filename}</span>
+                    </div>
+                  ))}
+
+                  {isCreatingDotEnvInline && (
+                    <div className="environment-item creating" ref={dotEnvCreateContainerRef}>
+                      <input
+                        ref={dotEnvInputRef}
+                        type="text"
+                        className="environment-name-input"
+                        data-testid="dotenv-name-input"
+                        value={newDotEnvName}
+                        onChange={handleDotEnvNameChange}
+                        onKeyDown={handleDotEnvNameKeyDown}
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck="false"
+                      />
+                      <div className="inline-actions">
+                        <button
+                          className="inline-action-btn save"
+                          onClick={handleSaveNewDotEnv}
+                          onMouseDown={(e) => e.preventDefault()}
+                          title="Create"
+                        >
+                          <IconCheck size={14} strokeWidth={2} />
+                        </button>
+                        <button
+                          className="inline-action-btn cancel"
+                          onClick={handleCancelDotEnvCreate}
+                          onMouseDown={(e) => e.preventDefault()}
+                          title="Cancel"
+                        >
+                          <IconX size={14} strokeWidth={2} />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {dotEnvNameError && isCreatingDotEnvInline && <div className="env-error">{dotEnvNameError}</div>}
+
+                  {!dotEnvFiles.length && !isCreatingDotEnvInline && (
+                    <div className="no-env-file">
+                      <span>No .env files</span>
+                    </div>
+                  )}
+                </div>
+              </CollapsibleSection>
+            )}
           </div>
         </div>
 
-        <EnvironmentDetails
-          environment={selectedEnvironment}
-          setIsModified={setIsModified}
-          originalEnvironmentVariables={originalEnvironmentVariables}
-          collection={collection}
-          isGlobal={isGlobal}
-        />
+        {renderContent()}
       </div>
     </StyledWrapper>
   );

--- a/src/webview/components/Environments/EnvironmentSettings/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSettings/index.tsx
@@ -1,34 +1,7 @@
 import React, { useState } from 'react';
-import CreateEnvironment from 'components/Environments/EnvironmentSettings/CreateEnvironment';
 import EnvironmentList from './EnvironmentList';
 import StyledWrapper from './StyledWrapper';
-import { IconFileAlert } from '@tabler/icons';
-import ImportEnvironmentModal from 'components/Environments/Common/ImportEnvironmentModal';
 import ExportEnvironmentModal from 'components/Environments/Common/ExportEnvironmentModal';
-import Button from 'ui/Button';
-
-interface DefaultTabProps {
-  setTab?: (...args: unknown[]) => unknown;
-  collection?: React.ReactNode;
-}
-
-
-const DefaultTab = ({
-  setTab
-}: any) => (
-  <div className="empty-state">
-    <IconFileAlert size={48} strokeWidth={1.5} />
-    <div className="title">No Environments</div>
-    <div className="actions">
-      <Button size="sm" color="secondary" onClick={() => setTab('create')}>
-        Create Environment
-      </Button>
-      <Button size="sm" color="secondary" onClick={() => setTab('import')}>
-        Import Environment
-      </Button>
-    </div>
-  </div>
-);
 
 const EnvironmentSettings = ({
   collection
@@ -40,22 +13,7 @@ const EnvironmentSettings = ({
     if (!environments.length) return null;
     return environments.find((env: any) => env.uid === collection?.activeEnvironmentUid) || environments[0];
   });
-  const [tab, setTab] = useState('default');
   const [showExportModal, setShowExportModal] = useState(false);
-
-  if (!environments || !environments.length) {
-    return (
-      <StyledWrapper>
-        {tab === 'create' ? (
-          <CreateEnvironment collection={collection} onClose={() => setTab('default')} />
-        ) : tab === 'import' ? (
-          <ImportEnvironmentModal type="collection" collection={collection} onClose={() => setTab('default')} />
-        ) : (
-          <DefaultTab setTab={setTab} />
-        )}
-      </StyledWrapper>
-    );
-  }
 
   return (
     <StyledWrapper>

--- a/src/webview/hooks/useDeferredLoading/index.ts
+++ b/src/webview/hooks/useDeferredLoading/index.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useRef } from 'react';
+
+const useDeferredLoading = (isLoading: boolean, delay = 200): boolean => {
+  const [showLoading, setShowLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (isLoading) {
+      timerRef.current = setTimeout(() => setShowLoading(true), delay);
+    } else {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setShowLoading(false);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [isLoading, delay]);
+
+  return showLoading;
+};
+
+export default useDeferredLoading;

--- a/src/webview/pages/Bruno/index.tsx
+++ b/src/webview/pages/Bruno/index.tsx
@@ -148,7 +148,8 @@ export default function Main(): React.ReactElement {
       if (!activeTab) return;
 
       if (activeTab.type === 'environment-settings' || activeTab.type === 'global-environment-settings') {
-        window.dispatchEvent(new CustomEvent('environment-save'));
+        const draftUid = findCollectionByUid(collections, activeTab.collectionUid)?.environmentsDraft?.environmentUid;
+        window.dispatchEvent(new CustomEvent(draftUid?.startsWith('dotenv:') ? 'dotenv-save' : 'environment-save'));
         return;
       }
 

--- a/src/webview/providers/App/useIpcEvents.ts
+++ b/src/webview/providers/App/useIpcEvents.ts
@@ -15,6 +15,7 @@ import {
   collectionUnlinkEnvFileEvent,
   collectionUnlinkFileEvent,
   processEnvUpdateEvent,
+  setDotEnvVariables,
   requestCancelled,
   runFolderEvent,
   runRequestEvent,
@@ -61,6 +62,7 @@ import type {
   CollectionRenamedEventPayload,
   ScriptEnvironmentUpdateEventPayload,
   ProcessEnvUpdateEventPayload,
+  SetDotEnvVariablesPayload,
   BrunoConfigUpdateEventPayload,
   RunFolderEventPayload,
   RunRequestEventPayload,
@@ -356,6 +358,10 @@ const useIpcEvents = () => {
 
     const removeProcessEnvUpdatesListener = ipcRenderer.on('main:process-env-update', (val: unknown) => {
       dispatch(processEnvUpdateEvent(val as ProcessEnvUpdateEventPayload));
+    });
+
+    const removeDotEnvFileUpdateListener = ipcRenderer.on('main:dotenv-file-update', (val: unknown) => {
+      dispatch(setDotEnvVariables(val as SetDotEnvVariablesPayload));
     });
 
     const removeConsoleLogListener = ipcRenderer.on('main:console-log', (val: unknown) => {
@@ -667,6 +673,7 @@ const useIpcEvents = () => {
       removePreRequestTestResultsListener();
       removePostResponseTestResultsListener();
       removeProcessEnvUpdatesListener();
+      removeDotEnvFileUpdateListener();
       removeConsoleLogListener();
       removeConfigUpdatesListener();
       removePreferencesUpdatesListener();

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -9,7 +9,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import trim from 'lodash/trim';
 import type { RootState, AppDispatch } from 'providers/ReduxStore/index';
-import type { AppCollection, AppItem, RequestSent } from '@bruno-types';
+import type { AppCollection, AppItem, DotEnvVariable, RequestSent } from '@bruno-types';
 import { variableNameRegex } from 'utils/common/regex';
 
 /** Redux thunk action creator type */
@@ -2009,6 +2009,32 @@ export const renameEnvironment = (newName: string, environmentUid: string, colle
       .catch(reject);
   });
 };
+
+const invokeForCollection = (
+  collectionUid: string,
+  channel: string,
+  ...args: unknown[]
+): ThunkAction<Promise<unknown>> => (dispatch, getState) => {
+  const collection = findCollectionByUid(getState().collections.collections, collectionUid);
+  if (!collection) {
+    return Promise.reject(new Error('Collection not found'));
+  }
+
+  const { ipcRenderer } = window;
+  return ipcRenderer.invoke(channel, collection.pathname, ...args);
+};
+
+export const saveDotEnvVariables = (collectionUid: string, variables: DotEnvVariable[], filename = '.env') =>
+  invokeForCollection(collectionUid, 'renderer:save-dotenv-variables', variables, filename);
+
+export const saveDotEnvRaw = (collectionUid: string, content: string, filename = '.env') =>
+  invokeForCollection(collectionUid, 'renderer:save-dotenv-raw', content, filename);
+
+export const createDotEnvFile = (collectionUid: string, filename = '.env') =>
+  invokeForCollection(collectionUid, 'renderer:create-dotenv-file', filename);
+
+export const deleteDotEnvFile = (collectionUid: string, filename = '.env') =>
+  invokeForCollection(collectionUid, 'renderer:delete-dotenv-file', filename);
 
 export const deleteEnvironment = (environmentUid: string, collectionUid: string): ThunkAction<Promise<unknown>> => (dispatch, getState) => {
   return new Promise((resolve, reject) => {

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -44,6 +44,7 @@ import type {
   CloneItemPayload,
   ScriptEnvironmentUpdateEventPayload,
   ProcessEnvUpdateEventPayload,
+  SetDotEnvVariablesPayload,
   RequestCancelledPayload,
   ResponseReceivedPayload,
   ResponseClearedPayload,
@@ -2121,6 +2122,33 @@ export const collectionsSlice = createSlice({
       }
     },
 
+    setDotEnvVariables: (state, action: PayloadAction<SetDotEnvVariablesPayload>) => {
+      const { collectionUid, filename, variables, content, exists } = action.payload;
+      const collection = findCollectionByUid(state.collections, collectionUid);
+      if (!collection) return;
+
+      const dotEnvFiles = collection.dotEnvFiles || [];
+      const existingIndex = dotEnvFiles.findIndex((file) => file.filename === filename);
+
+      if (existingIndex >= 0) {
+        if (exists) {
+          dotEnvFiles[existingIndex] = { filename, variables, content };
+        } else {
+          dotEnvFiles.splice(existingIndex, 1);
+        }
+      } else if (exists) {
+        dotEnvFiles.push({ filename, variables, content });
+      }
+
+      dotEnvFiles.sort((a, b) => {
+        if (a.filename === '.env') return -1;
+        if (b.filename === '.env') return 1;
+        return a.filename.localeCompare(b.filename);
+      });
+
+      collection.dotEnvFiles = dotEnvFiles;
+    },
+
     clearTimeline: (state, action: PayloadAction<ClearTimelinePayload>) => {
       const collection = findCollectionByUid(state.collections, action.payload.collectionUid);
       if (collection) {
@@ -3268,6 +3296,7 @@ export const {
   responseCleared,
   scriptEnvironmentUpdateEvent,
   processEnvUpdateEvent,
+  setDotEnvVariables,
   clearTimeline,
   clearRequestTimeline,
   collectionUnlinkEnvFileEvent,

--- a/src/webview/providers/ReduxStore/slices/collections/types.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/types.ts
@@ -2,7 +2,7 @@
  * Payload types for collection slice reducers
  */
 import type { UID, KeyValue, AuthMode, BrunoVariableDataType } from '@bruno-types';
-import type { AppCollection, AppItem, RequestSent, SecurityConfig } from '@bruno-types';
+import type { AppCollection, AppItem, DotEnvVariable, RequestSent, SecurityConfig } from '@bruno-types';
 
 export interface CollectionUidPayload {
   collectionUid: UID;
@@ -102,6 +102,13 @@ export interface ScriptEnvironmentUpdateEventPayload extends CollectionUidPayloa
 
 export interface ProcessEnvUpdateEventPayload extends CollectionUidPayload {
   processEnvVariables: Record<string, unknown>;
+}
+
+export interface SetDotEnvVariablesPayload extends CollectionUidPayload {
+  filename: string;
+  variables: DotEnvVariable[];
+  content: string;
+  exists: boolean;
 }
 
 export interface RequestCancelledPayload extends ItemUidPayload {}

--- a/src/webview/shims/bruno-common-utils.spec.ts
+++ b/src/webview/shims/bruno-common-utils.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { jsonToDotenv as packageJsonToDotenv } from '@usebruno/common/utils';
 import {
+  jsonToDotenv,
   getDataTypeFromValue,
   parseValueByDataType,
   valueToString,
@@ -60,6 +62,25 @@ describe('bruno-common-utils datatype shim', () => {
       expect(validateDataTypeValue(parseValueByDataType('abc', 'number'), 'number')).toMatch(/not a valid number/);
       expect(validateDataTypeValue(parseValueByDataType('30', 'number'), 'number')).toBeNull();
       expect(validateDataTypeValue(parseValueByDataType('{"a":1}', 'object'), 'object')).toBeNull();
+    });
+  });
+
+  describe('jsonToDotenv', () => {
+    const cases = [
+      [{ name: 'HOST', value: 'localhost' }],
+      [{ name: 'MULTILINE', value: 'a\nb' }],
+      [{ name: 'HASH', value: 'a#b' }],
+      [{ name: 'HASH_AND_QUOTE', value: 'a#b\'c' }],
+      [{ name: 'HASH_ALL_QUOTES', value: 'a#b\'c`d"e' }],
+      [{ name: 'PADDED', value: '  spaced  ' }],
+      [{ name: 'EMPTY' }],
+      [{ name: '', value: 'dropped' }, { name: 'KEPT', value: '1' }]
+    ];
+
+    it('serializes exactly like @usebruno/common, so the extension and webview never disagree', () => {
+      cases.forEach((variables) => {
+        expect(jsonToDotenv(variables)).toBe(packageJsonToDotenv(variables));
+      });
     });
   });
 });

--- a/src/webview/shims/bruno-common-utils.ts
+++ b/src/webview/shims/bruno-common-utils.ts
@@ -81,13 +81,15 @@ export interface DotenvVariable {
 }
 
 /**
- * Serializes variables to .env file content. Mirrors @usebruno/common's implementation;
- * reimplemented here because the rsbuild alias redirects @usebruno/common/utils to this shim.
+ * Serializes variables to .env file content. Copied from @usebruno/common because the
+ * rsbuild alias points @usebruno/common/utils at this shim, so its version is unreachable
+ * here. The two must stay byte-identical or the extension and the webview disagree on
+ * what a saved file should look like.
  *
- * Quoting follows what the dotenv parser does with each quote style:
- * - unquoted preserves \, " and ' but treats # as a comment and trims whitespace
- * - single and backtick quotes are fully literal
- * - double quotes expand \n and \r only
+ * A value is quoted based on how the dotenv parser reads each quote style back:
+ * - unquoted keeps \, " and ', but ends the value at a # and drops surrounding spaces
+ * - single and backtick quotes are taken literally
+ * - double quotes are literal except for \n and \r, which expand
  */
 export const jsonToDotenv = (variables: DotenvVariable[]): string => {
   if (!Array.isArray(variables)) {

--- a/src/webview/shims/bruno-common-utils.ts
+++ b/src/webview/shims/bruno-common-utils.ts
@@ -75,6 +75,59 @@ export const validateDataTypeValue = (value: any, dataType?: BrunoVariableDataTy
   return null;
 };
 
+export interface DotenvVariable {
+  name: string;
+  value?: string;
+}
+
+/**
+ * Serializes variables to .env file content. Mirrors @usebruno/common's implementation;
+ * reimplemented here because the rsbuild alias redirects @usebruno/common/utils to this shim.
+ *
+ * Quoting follows what the dotenv parser does with each quote style:
+ * - unquoted preserves \, " and ' but treats # as a comment and trims whitespace
+ * - single and backtick quotes are fully literal
+ * - double quotes expand \n and \r only
+ */
+export const jsonToDotenv = (variables: DotenvVariable[]): string => {
+  if (!Array.isArray(variables)) {
+    return '';
+  }
+
+  return variables
+    .filter((variable) => variable.name && variable.name.trim() !== '')
+    .map((variable) => {
+      const value = variable.value || '';
+
+      if (value.includes('\n') || value.includes('\r')) {
+        return `${variable.name}="${value.replace(/\r/g, '\\r').replace(/\n/g, '\\n')}"`;
+      }
+
+      if (value.includes('#')) {
+        if (!value.includes('\'')) {
+          return `${variable.name}='${value}'`;
+        }
+        if (!value.includes('`')) {
+          return `${variable.name}=\`${value}\``;
+        }
+        return `${variable.name}="${value.replace(/"/g, '\\"')}"`;
+      }
+
+      if (value !== value.trim()) {
+        if (!value.includes('\'')) {
+          return `${variable.name}='${value}'`;
+        }
+        if (!value.includes('`')) {
+          return `${variable.name}=\`${value}\``;
+        }
+        return `${variable.name}="${value}"`;
+      }
+
+      return `${variable.name}=${value}`;
+    })
+    .join('\n');
+};
+
 interface QueryParam {
   name: string;
   value?: string;

--- a/tests/e2e/specs/dotenv-files.spec.ts
+++ b/tests/e2e/specs/dotenv-files.spec.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame, Page } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  findCollectionDir,
+  waitForNewWebviewFrame
+} from '../utils/page/actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+/**
+ * Open the environment settings panel. It is only reachable from the environment
+ * selector in the collection toolbar, and the "Configure" entry only appears once
+ * an environment exists, so one is created on the way in.
+ */
+async function openEnvironmentSettings(page: Page, sidebar: Frame, collectionName: string): Promise<Frame> {
+  await buildCommonLocators(sidebar).sidebar.collectionName(collectionName).click();
+
+  const settings = await waitForNewWebviewFrame(page, sidebar);
+  await settings.locator('[data-testid="environment-selector-trigger"]').click();
+  await settings.locator('#create-env').click();
+  await settings.locator('#environment-name').fill('Local');
+  await settings.locator('button').filter({ hasText: 'Create' }).last().click();
+
+  const environments = await waitForNewWebviewFrame(page, settings);
+  await expect(environments.locator('[data-testid="dotenv-files-section"]')).toBeVisible({ timeout: 15_000 });
+
+  return environments;
+}
+
+test.describe('.env files', () => {
+  test('lists, edits and deletes .env files alongside environments', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'DotEnv Collection';
+    await createCollection(page, sidebar, collectionName, tmpDir);
+
+    const dotEnvPath = path.join(findCollectionDir(tmpDir), '.env');
+    fs.writeFileSync(dotEnvPath, '# credentials\nHOST=localhost\n');
+
+    const environments = await openEnvironmentSettings(page, sidebar, collectionName);
+
+    await environments.locator('[data-testid="dotenv-files-section"]').click();
+    const dotEnvRow = environments.locator('[data-testid="dotenv-file-.env"]');
+    await expect(dotEnvRow).toBeVisible({ timeout: 10_000 });
+
+    await dotEnvRow.click();
+    await expect(environments.locator('[data-testid="dotenv-var-row-HOST"]')).toBeVisible({ timeout: 10_000 });
+
+    const lastNameInput = environments.locator('[data-testid^="dotenv-var-row-"] input[type="text"]').last();
+    await lastNameInput.fill('PORT');
+    await environments.locator('[data-testid="save-dotenv"]').click();
+
+    await expect(async () => {
+      expect(fs.readFileSync(dotEnvPath, 'utf8')).toContain('PORT=');
+    }).toPass({ timeout: 10_000 });
+    expect(fs.readFileSync(dotEnvPath, 'utf8')).toContain('HOST=localhost');
+
+    await environments.locator('[data-testid="delete-dotenv-file"]').click();
+    await environments.locator('button').filter({ hasText: 'Delete' }).last().click();
+
+    await expect(async () => {
+      expect(fs.existsSync(dotEnvPath)).toBe(false);
+    }).toPass({ timeout: 10_000 });
+    await expect(dotEnvRow).toBeHidden({ timeout: 10_000 });
+  });
+
+  test('keeps comments when saving from the raw view', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'DotEnv Raw Collection';
+    await createCollection(page, sidebar, collectionName, tmpDir);
+
+    const dotEnvPath = path.join(findCollectionDir(tmpDir), '.env.local');
+    fs.writeFileSync(dotEnvPath, '# staging credentials\nTOKEN=abc\n');
+
+    const environments = await openEnvironmentSettings(page, sidebar, collectionName);
+
+    await environments.locator('[data-testid="dotenv-files-section"]').click();
+    await environments.locator('[data-testid="dotenv-file-.env.local"]').click();
+    await environments.locator('[data-testid="dotenv-view-raw"]').click();
+
+    const editor = environments.locator('[data-testid="dotenv-raw-editor"] .CodeMirror');
+    await expect(editor).toContainText('# staging credentials', { timeout: 10_000 });
+
+    await environments.locator('[data-testid="save-dotenv-raw"]').click();
+
+    await expect(async () => {
+      const content = fs.readFileSync(dotEnvPath, 'utf8');
+      expect(content).toContain('# staging credentials');
+      expect(content).toContain('TOKEN=abc');
+    }).toPass({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Description

VSCODE-86: .ENV Files is missing in VS code Bruno's environments.

## Root cause

The extension read the collection's `.env` file only to resolve `process.env` values at request time and never passed those files to the UI so the environments screen had nothing to show.

## Solution

The collection watcher now loads all `.env` files from the collection root and watches for changes. Their variables and raw content are sent to the webview, where they can be viewed and edited through the new environment UI. Save, create, and delete actions use new IPC handlers and the existing .env serializer.

## Recordings / Screenshots

**Before**
<img width="1468" height="638" alt="Screenshot 2026-08-14 at 11 17 41 AM" src="https://github.com/user-attachments/assets/121e6176-49dc-4a2e-8e92-23e3ae9b83e8" />


<!-- attach the recording/screenshot showing the missing .env files -->

**After**

<img width="1455" height="781" alt="Screenshot 2026-08-14 at 10 57 30 AM" src="https://github.com/user-attachments/assets/ec042174-0897-4a9a-8230-2e55fb932359" />
