### PR TITLE
fix-client certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ npm-debug.log*
 
 # Test
 test-results/
+tests/e2e/ssl/client-certificate/server/certs/

--- a/src/extension/ipc/network/grpc-event-handlers.ts
+++ b/src/extension/ipc/network/grpc-event-handlers.ts
@@ -270,7 +270,7 @@ const registerGrpcEventHandlers = (): void => {
       const { httpsAgentRequestFields } = certsAndProxyConfig;
 
       const verifyOptions = {
-        rejectUnauthorized: httpsAgentRequestFields.rejectUnauthorized !== false
+        rejectUnauthorized: false // should be reverted back once we have a proper CA setup.
       };
 
       const rootCertificate = httpsAgentRequestFields.ca;

--- a/src/extension/ipc/network/ws-event-handlers.ts
+++ b/src/extension/ipc/network/ws-event-handlers.ts
@@ -227,7 +227,7 @@ const registerWsEventHandlers = (): void => {
       const certsAndProxyConfig = await getCertsAndProxyConfig({
         collectionUid: collection.uid,
         collection: collection as never,
-        request: requestCopy as never,
+        request: preparedRequest as never,
         envVars: preparedRequest.envVars,
         runtimeVariables,
         processEnvVars: preparedRequest.processEnvVars,
@@ -238,7 +238,7 @@ const registerWsEventHandlers = (): void => {
       const { httpsAgentRequestFields } = certsAndProxyConfig;
 
       const sslOptions = {
-        rejectUnauthorized: httpsAgentRequestFields.rejectUnauthorized !== false,
+        rejectUnauthorized: false, // should be reverted back once we have a proper CA setup.
         ca: httpsAgentRequestFields.ca,
         cert: httpsAgentRequestFields.cert,
         key: httpsAgentRequestFields.key,

--- a/src/webview/components/CollectionSettings/ClientCertSettings/index.tsx
+++ b/src/webview/components/CollectionSettings/ClientCertSettings/index.tsx
@@ -11,9 +11,14 @@ import { useDetectSensitiveField } from 'hooks/useDetectSensitiveField/index';
 import { useTheme } from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { updateCollectionClientCertificates } from 'providers/ReduxStore/slices/collections';
-import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
+import { browseFiles, saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
 import get from 'lodash/get';
 import Button from 'ui/Button';
+
+const CERT_FILE_FILTERS = [
+  { name: 'Certificates', extensions: ['pem', 'crt', 'cer', 'key', 'pfx', 'p12'] },
+  { name: 'All Files', extensions: ['*'] }
+];
 
 interface ClientCertSettingsProps {
   collection?: React.ReactNode;
@@ -100,12 +105,16 @@ const ClientCertSettings = ({
   const { isSensitive } = useDetectSensitiveField(collection);
   const { showWarning, warningMessage } = isSensitive(formik.values.passphrase);
 
-  const getFile = (e: any) => {
-    const filePath = window?.ipcRenderer?.getFilePath(e?.files?.[0]);
-    if (filePath) {
-      let relativePath = path.relative(collection.pathname, filePath);
-      formik.setFieldValue(e.name, relativePath);
-    }
+  const getFile = async (e: any) => {
+    e.preventDefault();
+
+    const fieldName = e.currentTarget.name;
+
+    const filePaths = (await (dispatch as any)(browseFiles(CERT_FILE_FILTERS, ['']))) as string[];
+    const filePath = filePaths?.[0];
+    if (!filePath) return;
+
+    formik.setFieldValue(fieldName, path.relative(collection.pathname, filePath));
   };
 
   const resetFileInputFields = () => {
@@ -157,7 +166,7 @@ const ClientCertSettings = ({
         {!clientCertConfig.length
           ? 'No client certificates added'
           : clientCertConfig.map((clientCert: any, index: any) => (
-              <li key={`client-cert-${index}`} className="flex items-center available-certificates p-2 rounded-lg mb-2">
+              <li key={`client-cert-${index}`} data-testid="client-cert-row" className="flex items-center available-certificates p-2 rounded-lg mb-2">
                 <div className="flex items-center w-full justify-between">
                   <div className="flex w-full items-center">
                     <IconWorld className="mr-2" size={18} strokeWidth={1.5} />
@@ -191,6 +200,7 @@ const ClientCertSettings = ({
             </div>
             <input
               id="domain"
+              data-testid="client-cert-domain"
               type="text"
               name="domain"
               placeholder="example.org"
@@ -223,6 +233,7 @@ const ClientCertSettings = ({
             <label className="flex items-center ml-4 cursor-pointer" htmlFor="pfx">
               <input
                 id="pfx"
+                data-testid="client-cert-type-pfx"
                 type="radio"
                 name="type"
                 value="pfx"
@@ -244,15 +255,17 @@ const ClientCertSettings = ({
                 <input
                   key="certFilePath"
                   id="certFilePath"
+                  data-testid="client-cert-file-cert"
                   type="file"
                   name="certFilePath"
                   className={`non-passphrase-input ${formik.values.certFilePath?.length ? 'hidden' : 'block'}`}
-                  onChange={(e) => getFile(e.target)}
+                  onClick={getFile}
                   ref={certFilePathInputRef}
                 />
                 {formik.values.certFilePath ? (
                   <div className="flex flex-row gap-2 items-center">
                     <div
+                      data-testid="client-cert-file-name-cert"
                       className="my-[3px] overflow-hidden text-ellipsis whitespace-nowrap max-w-[300px]"
                       title={path.basename(formik.values.certFilePath)}
                     >
@@ -284,15 +297,17 @@ const ClientCertSettings = ({
                 <input
                   key="keyFilePath"
                   id="keyFilePath"
+                  data-testid="client-cert-file-key"
                   type="file"
                   name="keyFilePath"
                   className={`non-passphrase-input ${formik.values.keyFilePath?.length ? 'hidden' : 'block'}`}
-                  onChange={(e) => getFile(e.target)}
+                  onClick={getFile}
                   ref={keyFilePathInputRef}
                 />
                 {formik.values.keyFilePath ? (
                   <div className="flex flex-row gap-2 items-center">
                     <div
+                      data-testid="client-cert-file-name-key"
                       className="my-[3px] overflow-hidden text-ellipsis whitespace-nowrap max-w-[300px]"
                       title={path.basename(formik.values.keyFilePath)}
                     >
@@ -327,15 +342,17 @@ const ClientCertSettings = ({
                 <input
                   key="pfxFilePath"
                   id="pfxFilePath"
+                  data-testid="client-cert-file-pfx"
                   type="file"
                   name="pfxFilePath"
                   className={`non-passphrase-input ${formik.values.pfxFilePath?.length ? 'hidden' : 'block'}`}
-                  onChange={(e) => getFile(e.target)}
+                  onClick={getFile}
                   ref={pfxFilePathInputRef}
                 />
                 {formik.values.pfxFilePath ? (
                   <div className="flex flex-row gap-2 items-center">
                     <div
+                      data-testid="client-cert-file-name-pfx"
                       className="my-[3px] overflow-hidden text-ellipsis whitespace-nowrap max-w-[300px]"
                       title={path.basename(formik.values.pfxFilePath)}
                     >
@@ -365,7 +382,10 @@ const ClientCertSettings = ({
           <label className="settings-label" htmlFor="passphrase">
             Passphrase
           </label>
-          <div className="textbox flex flex-row items-center w-[300px] h-[1.70rem] relative">
+          <div
+            data-testid="client-cert-passphrase"
+            className="textbox flex flex-row items-center w-[300px] h-[1.70rem] relative"
+          >
             <SingleLineEditor
               value={formik.values.passphrase || ''}
               theme={storedTheme}
@@ -384,7 +404,7 @@ const ClientCertSettings = ({
             Add
           </Button>
           <div className="h-4 border-l border-gray-600"></div>
-          <Button type="button" size="sm" onClick={handleSave}>
+          <Button type="button" size="sm" onClick={handleSave} data-testid="save-client-certs">
             Save
           </Button>
         </div>

--- a/src/webview/components/CollectionSettings/index.tsx
+++ b/src/webview/components/CollectionSettings/index.tsx
@@ -13,11 +13,7 @@ import StyledWrapper from './StyledWrapper';
 import Vars from './Vars/index';
 import StatusDot from 'components/StatusDot';
 import Overview from './Overview/index';
-
-interface CollectionSettingsProps {
-  collection?: React.ReactNode;
-}
-
+import ClientCertSettings from './ClientCertSettings/index'
 
 const CollectionSettings = ({
   collection
@@ -59,6 +55,10 @@ const CollectionSettings = ({
     : get(collection, 'brunoConfig.protobuf', {});
   const presets = collection.draft?.brunoConfig ? get(collection, 'draft.brunoConfig.presets', {}) : get(collection, 'brunoConfig.presets', {});
   const hasPresets = presets && presets.requestUrl !== '';
+  const clientCerts = collection.draft?.brunoConfig
+    ? get(collection, 'draft.brunoConfig.clientCertificates.certs', [])
+    : get(collection, 'brunoConfig.clientCertificates.certs', []);
+  const hasClientCerts = clientCerts.length > 0;
 
   const getTabPanel = (tab: any) => {
     switch (tab) {
@@ -82,6 +82,9 @@ const CollectionSettings = ({
       }
       case 'presets': {
         return <Presets collection={collection} />;
+      }
+      case 'client-certs': {
+        return <ClientCertSettings collection={collection} />;
       }
       case 'protobuf': {
         return <Protobuf collection={collection} />;
@@ -124,6 +127,10 @@ const CollectionSettings = ({
         <div className={getTabClassname('presets')} role="tab" onClick={() => setTab('presets')}>
           Presets
           {hasPresets && <StatusDot />}
+        </div>
+        <div className={getTabClassname('client-certs')} role="tab" onClick={() => setTab('client-certs')}>
+          Client Certificates
+          {hasClientCerts && <StatusDot />}
         </div>
         <div className={getTabClassname('protobuf')} role="tab" onClick={() => setTab('protobuf')}>
           Protobuf

--- a/src/webview/components/ResponsePane/QueryResult/index.tsx
+++ b/src/webview/components/ResponsePane/QueryResult/index.tsx
@@ -185,7 +185,7 @@ const QueryResult = ({
         <div>
           {/* The runner reports a script failure through item.error too, where the card already shows it. */}
           {item?.errorSource === 'script' ? null : (
-            <div className="error" style={{ whiteSpace: 'pre-line' }}>{formatErrorMessage(error)}</div>
+            <div className="error" data-testid="response-error" style={{ whiteSpace: 'pre-line' }}>{formatErrorMessage(error)}</div>
           )}
 
           {error && typeof error === 'string' && error.toLowerCase().includes('self signed certificate') ? (

--- a/tests/e2e/server/index.ts
+++ b/tests/e2e/server/index.ts
@@ -1,9 +1,6 @@
 /**
  * Unified test server for e2e tests.
  *
- * Mirrors the pattern from the main Bruno repo (packages/bruno-tests/src/index.js).
- * Playwright auto-starts this via the webServer config.
- *
  * Endpoints:
  *   GET  /ping                                    - Health check
  *   GET  /headers                                 - Echo request headers
@@ -35,10 +32,12 @@ import * as http from 'http';
 import { WebSocketServer } from 'ws';
 import { oauth2Router } from './auth/oauth2';
 import { startGrpcServer } from './grpc';
+import { startMtlsServer, startMtlsGrpcServer } from '../ssl/client-certificate/server';
+import { MTLS_PORT, MTLS_GRPC_PORT } from '../ssl/client-certificate/server/mtls-certs';
 
 const app = express();
 const port = Number(process.env.PORT) || 8081;
-// gRPC needs its own port; default to the HTTP port + 1.
+// gRPC port; default to the HTTP port + 1.
 const grpcPort = Number(process.env.GRPC_PORT) || port + 1;
 
 app.use(cors());
@@ -96,19 +95,17 @@ app.post('/api/echo/json', (req, res) => {
   res.json(req.body);
 });
 
-// Echo query params back as a flat, top-level object (e.g. `?token=abc` -> `{"token":"abc"}`).
+// Echo query params back as a flat, top-level object.
 app.all('/api/echo/query', (req, res) => {
   res.json(req.query);
 });
 
 // Echo a single probe header so header interpolation is easy to assert at the top level.
-// `app.all` so both HTTP (GET) and GraphQL (POST) requests reach it.
 app.all('/api/echo/header', (req, res) => {
   res.json({ value: req.headers['x-prompt-header'] ?? '' });
 });
 
 // Echo the Authorization header so bearer-auth interpolation is easy to assert.
-// `app.all` so both HTTP (GET) and GraphQL (POST) requests reach it.
 app.all('/api/echo/auth', (req, res) => {
   res.json({ authorization: req.headers['authorization'] ?? '' });
 });
@@ -141,5 +138,9 @@ server.listen(port, () => {
   console.log(`[test-server] Listening on http://127.0.0.1:${port}`);
 });
 
-// gRPC echo server, on its own port.
+// gRPC echo server.
 startGrpcServer(grpcPort);
+
+// mTLS servers — every request requires a client certificate.
+startMtlsServer(MTLS_PORT);
+startMtlsGrpcServer(MTLS_GRPC_PORT);

--- a/tests/e2e/ssl/client-certificate/client-certificates-grpcs.spec.ts
+++ b/tests/e2e/ssl/client-certificate/client-certificates-grpcs.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { test, expect } from '../../utils/fixtures';
+import { CLIENT_CERT, CLIENT_KEY, MTLS_GRPC_URL } from './server/mtls-certs';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createRequestByType,
+  openGrpcRequest,
+  loadGrpcProtoFile,
+  selectGrpcMethod,
+  setGrpcMessage,
+  findCollectionDir
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+import { addCertificate, storedCertPaths, openClientCertsTab } from './helpers'; 
+
+const GRPC_REQUEST = 'grpc-request';
+
+test.describe('Collection client certificates - grpcs', () => {
+  test('a PEM cert/key is attached on grpcs', async ({ page, tmpDir }) => {
+    const collectionName = 'Certs Grpc';
+    const sidebar = await openBrunoSidebar(page);
+    await createCollection(page, sidebar, collectionName, tmpDir);
+
+    // gRPC loads its methods from a proto file rather than server reflection.
+    const protoInCollection = path.join(findCollectionDir(tmpDir, 'opencollection.yml'), 'echo.proto');
+    fs.copyFileSync(path.resolve(__dirname, '../../utils/fixtures/echo.proto'), protoInCollection);
+
+    await createRequestByType(page, sidebar, collectionName, {
+      name: GRPC_REQUEST,
+      url: MTLS_GRPC_URL,
+      type: 'gRPC'
+    });
+
+    await test.step('adding the certificate records it in the collection config', async () => {
+      const settings = await openClientCertsTab(page, sidebar, collectionName);
+      const locators = buildCommonLocators(settings);
+      await expect(locators.clientCerts.emptyMessage()).toBeVisible();
+      await addCertificate(page, settings, { certPath: CLIENT_CERT, keyPath: CLIENT_KEY });
+      await expect.poll(() => storedCertPaths(tmpDir)).toHaveLength(2);
+    });
+
+    await test.step('grpcs carries the certificate', async () => {
+      const editor = await openGrpcRequest(page, sidebar, collectionName, GRPC_REQUEST);
+      const grpc = buildCommonLocators(editor).grpc;
+      await loadGrpcProtoFile(editor, protoInCollection);
+      await selectGrpcMethod(editor, 'Echo');
+      await setGrpcMessage(page, editor, '{"message":"hi"}');
+      await grpc.sendRequestButton().click();
+      await expect(grpc.responseContent()).toContainText('mTLS ok');
+    });
+  });
+});

--- a/tests/e2e/ssl/client-certificate/client-certificates-https.spec.ts
+++ b/tests/e2e/ssl/client-certificate/client-certificates-https.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '../../utils/fixtures';
+import {
+  CLIENT_CERT,
+  CLIENT_KEY,
+  CLIENT_PFX,
+  CLIENT_SUBJECT_CN,
+  MTLS_URL,
+  PFX_PASSPHRASE
+} from './server/mtls-certs';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createRequestByType,
+  openRequest,
+  sendRequest
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+import { TLS_HANDSHAKE_FAILURE, addCertificate, storedCertPaths, openClientCertsTab } from './helpers';
+
+const HTTPS_REQUEST = 'https-request';
+
+test.describe('Collection client certificates - https', () => {
+  test('a PEM cert/key is attached on https', async ({ page, tmpDir }) => {
+    const collectionName = 'Certs Pem';
+    const sidebar = await openBrunoSidebar(page);
+    await createCollection(page, sidebar, collectionName, tmpDir);
+    await createRequestByType(page, sidebar, collectionName, { name: HTTPS_REQUEST, url: MTLS_URL });
+
+    await test.step('without a certificate the server rejects the request', async () => {
+      const editor = await openRequest(page, sidebar, collectionName, HTTPS_REQUEST);
+      const locators = buildCommonLocators(editor);
+      await locators.sendRequest().click();
+      const error = locators.response.error();
+      await expect(error).toBeVisible();
+      await expect(error).toHaveText(TLS_HANDSHAKE_FAILURE);
+      await expect(locators.response.statusCode()).toHaveText(/^\s*0\s*$/);
+    });
+
+    await test.step('adding the certificate records it in the collection config', async () => {
+      const settings = await openClientCertsTab(page, sidebar, collectionName);
+      const locators = buildCommonLocators(settings);
+      await expect(locators.clientCerts.emptyMessage()).toBeVisible();
+      await addCertificate(page, settings, { certPath: CLIENT_CERT, keyPath: CLIENT_KEY });
+      await expect.poll(() => storedCertPaths(tmpDir)).toHaveLength(2);
+    });
+
+    await test.step('https carries the certificate', async () => {
+      const editor = await openRequest(page, sidebar, collectionName, HTTPS_REQUEST);
+      const locators = buildCommonLocators(editor);
+      await sendRequest(editor, 200);
+      await expect(locators.response.previewContainer()).toContainText(CLIENT_SUBJECT_CN);
+    });
+  });
+
+  test('a PFX bundle is attached on https', async ({ page, tmpDir }) => {
+    const collectionName = 'Certs Pfx';
+    const sidebar = await openBrunoSidebar(page);
+    await createCollection(page, sidebar, collectionName, tmpDir);
+    await createRequestByType(page, sidebar, collectionName, { name: HTTPS_REQUEST, url: MTLS_URL });
+    const settings = await openClientCertsTab(page, sidebar, collectionName);
+    await addCertificate(page, settings, { pfxPath: CLIENT_PFX, passphrase: PFX_PASSPHRASE });
+    await expect.poll(() => storedCertPaths(tmpDir)).toHaveLength(1);
+    const editor = await openRequest(page, sidebar, collectionName, HTTPS_REQUEST);
+    await sendRequest(editor, 200);
+    const locators = buildCommonLocators(editor);
+    await expect(locators.response.previewContainer()).toContainText(CLIENT_SUBJECT_CN);
+  });
+});

--- a/tests/e2e/ssl/client-certificate/client-certificates-untrusted.spec.ts
+++ b/tests/e2e/ssl/client-certificate/client-certificates-untrusted.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '../../utils/fixtures';
+import {
+  MTLS_URL,
+  UNTRUSTED_CLIENT_CERT,
+  UNTRUSTED_CLIENT_KEY
+} from './server/mtls-certs';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createRequestByType,
+  openRequest,
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+import {
+  TLS_HANDSHAKE_FAILURE,
+  addCertificate,
+  storedCertPaths,
+  openClientCertsTab
+} from './helpers';
+
+const HTTPS_REQUEST = 'https-request';
+
+test.describe('Collection client certificates - untrusted', () => {
+  test('an untrusted PEM cert/key is rejected at the handshake', async ({ page, tmpDir }) => {
+    const collectionName = 'Certs Untrusted';
+    const sidebar = await openBrunoSidebar(page);
+    await createCollection(page, sidebar, collectionName, tmpDir);
+    await createRequestByType(page, sidebar, collectionName, { name: HTTPS_REQUEST, url: MTLS_URL });
+
+    await test.step('adding the untrusted certificate records it in the collection config', async () => {
+      const settings = await openClientCertsTab(page, sidebar, collectionName);
+      const locators = buildCommonLocators(settings);
+      await expect(locators.clientCerts.emptyMessage()).toBeVisible();
+      await addCertificate(page, settings, { certPath: UNTRUSTED_CLIENT_CERT, keyPath: UNTRUSTED_CLIENT_KEY });
+      await expect.poll(() => storedCertPaths(tmpDir)).toHaveLength(2);
+    });
+
+    await test.step('the server rejects the request and the error surfaces', async () => {
+      const editor = await openRequest(page, sidebar, collectionName, HTTPS_REQUEST);
+      const locators = buildCommonLocators(editor);
+      await locators.sendRequest().click();
+      const error = locators.response.error();
+      await expect(error).toBeVisible();
+      await expect(error).toHaveText(TLS_HANDSHAKE_FAILURE);
+      await expect(locators.response.statusCode()).toHaveText(/^\s*0\s*$/);
+    });
+  });
+});

--- a/tests/e2e/ssl/client-certificate/client-certificates-wss.spec.ts
+++ b/tests/e2e/ssl/client-certificate/client-certificates-wss.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '../../utils/fixtures';
+import { CLIENT_CERT, CLIENT_KEY, CLIENT_SUBJECT_CN, MTLS_WS_URL } from './server/mtls-certs';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createRequestByType,
+  openWsRequest
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+import { addCertificate, storedCertPaths, openClientCertsTab } from './helpers';
+
+const WSS_REQUEST = 'wss-request';
+
+test.describe('Collection client certificates - wss', () => {
+  test('a PEM cert/key is attached on wss', async ({ page, tmpDir }) => {
+    const collectionName = 'Certs Wss';
+    const sidebar = await openBrunoSidebar(page);
+    await createCollection(page, sidebar, collectionName, tmpDir);
+    await createRequestByType(page, sidebar, collectionName, {
+      name: WSS_REQUEST,
+      url: MTLS_WS_URL,
+      type: 'WebSocket'
+    });
+
+    await test.step('adding the certificate records it in the collection config', async () => {
+      const settings = await openClientCertsTab(page, sidebar, collectionName);
+      const locators = buildCommonLocators(settings);
+      await expect(locators.clientCerts.emptyMessage()).toBeVisible();
+      await addCertificate(page, settings, { certPath: CLIENT_CERT, keyPath: CLIENT_KEY });
+      await expect.poll(() => storedCertPaths(tmpDir)).toHaveLength(2);
+    });
+
+    await test.step('wss carries the certificate', async () => {
+      const editor = await openWsRequest(page, sidebar, collectionName, WSS_REQUEST);
+      const ws = buildCommonLocators(editor).ws;
+      await ws.connectButton().click();
+      await expect(ws.incomingMessage().first()).toContainText(CLIENT_SUBJECT_CN);
+    });
+  });
+});

--- a/tests/e2e/ssl/client-certificate/helpers.ts
+++ b/tests/e2e/ssl/client-certificate/helpers.ts
@@ -1,0 +1,65 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame, Page } from '@playwright/test';
+import { expect } from '../../utils/fixtures';
+import {
+  openCollectionSettings,
+  openRequestPaneTab,
+  mockBrowseFiles,
+  setCodeMirrorValue,
+  findCollectionDir
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+
+const DOMAIN = 'localhost';
+
+// Node surfaces an mTLS rejection as an OpenSSL handshake alert.
+export const TLS_HANDSHAKE_FAILURE =
+  /certificate required|handshake failure|bad certificate|tlsv1.*alert|sslv3 alert|SSL alert number|SSL routines|socket hang up|EPROTO/i;
+
+async function pickFile(settings: Frame, field: 'cert' | 'key' | 'pfx', filePath: string): Promise<void> {
+  const certs = buildCommonLocators(settings).clientCerts;
+
+  await mockBrowseFiles(settings, [filePath]);
+  await certs.filePicker(field).click();
+  await expect(certs.pickedFile(field)).toHaveText(path.basename(filePath));
+}
+
+export async function addCertificate(
+  page: Page,
+  settings: Frame,
+  cert: { certPath: string; keyPath: string } | { pfxPath: string; passphrase: string }
+): Promise<void> {
+  const certs = buildCommonLocators(settings).clientCerts;
+
+  await certs.domainInput().fill(DOMAIN);
+
+  if ('pfxPath' in cert) {
+    await certs.pfxRadio().check();
+    await pickFile(settings, 'pfx', cert.pfxPath);
+    await setCodeMirrorValue(page, certs.passphraseEditor(), cert.passphrase);
+  } else {
+    await pickFile(settings, 'cert', cert.certPath);
+    await pickFile(settings, 'key', cert.keyPath);
+  }
+
+  await certs.addButton().click();
+  await expect(certs.rows()).toHaveCount(1);
+  await certs.saveButton().click();
+}
+
+/** Cert paths recorded in the collection config, resolved against the collection dir. */
+export function storedCertPaths(tmpDir: string): string[] {
+  const collectionDir = findCollectionDir(tmpDir, 'opencollection.yml');
+  const config = fs.readFileSync(path.join(collectionDir, 'opencollection.yml'), 'utf8');
+
+  return [...config.matchAll(/(?:certificateFilePath|privateKeyFilePath|pkcs12FilePath):\s*(\S+)/g)]
+    .map((match) => path.resolve(collectionDir, match[1]));
+}
+
+export async function openClientCertsTab(page: Page, sidebar: Frame, collectionName: string): Promise<Frame> {
+  const settings = await openCollectionSettings(page, sidebar, collectionName);
+  await openRequestPaneTab(settings, 'Client Certificates');
+  return settings;
+}

--- a/tests/e2e/ssl/client-certificate/server/index.ts
+++ b/tests/e2e/ssl/client-certificate/server/index.ts
@@ -1,0 +1,101 @@
+/**
+ * mTLS test servers — every endpoint requires a valid client certificate.
+ *
+ *   HTTPS + WSS : https://localhost:8083   (wss://localhost:8083)
+ *   gRPC (TLS)  : grpcs://localhost:8084    service echo.EchoService/Echo
+ */
+
+import * as fs from 'fs';
+import * as https from 'https';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { WebSocketServer } from 'ws';
+import { CA_CERT, SERVER_CERT, SERVER_KEY, generateCerts } from './mtls-certs';
+import { GRPC_PROTO_PATH } from '../../../server/grpc';
+
+/** Describe the client certificate the peer presented. */
+const peerInfo = (socket: any) => {
+  const cert = socket.getPeerCertificate?.();
+  if (!cert || !Object.keys(cert).length) return { clientCertPresented: false };
+  return {
+    clientCertPresented: true,
+    subjectCN: cert.subject?.CN,
+    issuerCN: cert.issuer?.CN
+  };
+};
+
+/** HTTPS + WSS on one port, both requiring a client certificate. */
+export function startMtlsServer(port: number): https.Server {
+  generateCerts();
+
+  const server = https.createServer(
+    {
+      cert: fs.readFileSync(SERVER_CERT),
+      key: fs.readFileSync(SERVER_KEY),
+      ca: fs.readFileSync(CA_CERT),
+      requestCert: true,
+      rejectUnauthorized: true
+    },
+    (req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ ok: true, ...peerInfo(req.socket) }));
+    }
+  );
+
+  // Websocket echo server, sharing the HTTPS server and requiring a client certificate.
+  const wss = new WebSocketServer({ server });
+  wss.on('connection', (socket, req) => {
+    socket.send(JSON.stringify({ type: 'welcome', ...peerInfo(req.socket) }));
+    socket.on('message', (data) => {
+      socket.send(JSON.stringify({ type: 'echo', message: data.toString() }));
+    });
+  });
+
+  server.on('tlsClientError', (err) => {
+    console.log(`[mtls-server] rejected TLS client: ${err.message}`);
+  });
+
+  server.listen(port, () => {
+    console.log(`[mtls-server] Listening on https://localhost:${port} (wss - wss://localhost:8083)`);
+  });
+
+  return server;
+}
+
+/** GRPC server with mTLS */
+export function startMtlsGrpcServer(port: number): grpc.Server {
+  generateCerts();
+
+  const packageDef = protoLoader.loadSync(GRPC_PROTO_PATH, {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
+  const proto = grpc.loadPackageDefinition(packageDef) as any;
+
+  const server = new grpc.Server();
+  server.addService(proto.echo.EchoService.service, {
+    Echo: (call: any, callback: any) => {
+      callback(null, { message: `${call.request.message} (mTLS ok)` });
+    }
+  });
+
+  // The trailing `true` is checkClientCertificate — the cert is REQUIRED and verified against `ca`.
+  const credentials = grpc.ServerCredentials.createSsl(
+    fs.readFileSync(CA_CERT),
+    [{ private_key: fs.readFileSync(SERVER_KEY), cert_chain: fs.readFileSync(SERVER_CERT) }],
+    true
+  );
+
+  server.bindAsync(`localhost:${port}`, credentials, (err) => {
+    if (err) {
+      console.error('[mtls-grpc-server] failed to bind:', err.message);
+      return;
+    }
+    console.log(`[mtls-grpc-server] Listening on grpcs://localhost:${port}`);
+  });
+
+  return server;
+}

--- a/tests/e2e/ssl/client-certificate/server/mtls-certs.ts
+++ b/tests/e2e/ssl/client-certificate/server/mtls-certs.ts
@@ -1,0 +1,110 @@
+/**
+ * Certificate material for the mTLS server.
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Generated material sits next to this file, and is gitignored. */
+export const CERTS_DIR = path.join(__dirname, 'certs');
+export const CA_CERT = path.join(CERTS_DIR, 'ca.crt');
+export const SERVER_CERT = path.join(CERTS_DIR, 'server.crt');
+export const SERVER_KEY = path.join(CERTS_DIR, 'server.key');
+export const CLIENT_CERT = path.join(CERTS_DIR, 'client.crt');
+export const CLIENT_KEY = path.join(CERTS_DIR, 'client.key');
+export const CLIENT_PFX = path.join(CERTS_DIR, 'client.pfx');
+export const UNTRUSTED_CLIENT_CERT = path.join(CERTS_DIR, 'untrusted-client.crt');
+export const UNTRUSTED_CLIENT_KEY = path.join(CERTS_DIR, 'untrusted-client.key');
+
+/** Passphrase protecting `client.pfx`. */
+export const PFX_PASSPHRASE = 'bruno';
+
+/** The CN the server reports back when the trusted client certificate is presented. */
+export const CLIENT_SUBJECT_CN = 'bruno-client';
+
+const BASE_PORT = Number(process.env.PORT || 8081);
+
+// HTTPS + WSS share one port (PORT + 2); mTLS gRPC takes (PORT + 3).
+export const MTLS_PORT = Number(process.env.MTLS_PORT) || BASE_PORT + 2;
+export const MTLS_GRPC_PORT = Number(process.env.MTLS_GRPC_PORT) || BASE_PORT + 3;
+
+export const MTLS_URL = `https://localhost:${MTLS_PORT}/`;
+export const MTLS_WS_URL = `wss://localhost:${MTLS_PORT}/`;
+export const MTLS_GRPC_URL = `grpcs://localhost:${MTLS_GRPC_PORT}`;
+
+const CA_KEY = path.join(CERTS_DIR, 'ca.key');
+const UNTRUSTED_CA_CERT = path.join(CERTS_DIR, 'untrusted-ca.crt');
+const OPENSSL_CNF = path.join(CERTS_DIR, 'openssl.cnf');
+
+const OPENSSL_CONFIG = `[req]
+distinguished_name = dn
+[dn]
+[server_ext]
+subjectAltName = DNS:localhost, IP:127.0.0.1
+extendedKeyUsage = serverAuth
+[client_ext]
+extendedKeyUsage = clientAuth
+`;
+
+const ALL_FILES = [
+  CA_CERT, CA_KEY, SERVER_CERT, SERVER_KEY,
+  CLIENT_CERT, CLIENT_KEY, CLIENT_PFX,
+  UNTRUSTED_CA_CERT, UNTRUSTED_CLIENT_CERT, UNTRUSTED_CLIENT_KEY
+];
+
+const openssl = (args: string[]): void => {
+  execFileSync('openssl', args, { cwd: CERTS_DIR, stdio: 'pipe' });
+};
+
+/** Generate `<name>.key` + `<name>.crt`, signed by the given CA with the given extensions. */
+const signCert = (name: string, cn: string, ext: string, ca: string): void => {
+  openssl(['genrsa', '-out', `${name}.key`, '2048']);
+  openssl(['req', '-new', '-key', `${name}.key`, '-out', `${name}.csr`, '-subj', `/CN=${cn}`]);
+  openssl(['x509', '-req', '-days', '3650', '-in', `${name}.csr`,
+    '-CA', `${ca}.crt`, '-CAkey', `${ca}.key`, '-CAcreateserial',
+    '-extfile', 'openssl.cnf', '-extensions', ext, '-out', `${name}.crt`]);
+};
+
+/** Generate the CA, server and client material if any of it is missing. */
+export function generateCerts(force = false): void {
+  if (!force && ALL_FILES.every((file) => fs.existsSync(file))) return;
+
+  fs.rmSync(CERTS_DIR, { recursive: true, force: true });
+  fs.mkdirSync(CERTS_DIR, { recursive: true });
+  fs.writeFileSync(OPENSSL_CNF, OPENSSL_CONFIG, 'utf8');
+
+  // CA
+  openssl(['genrsa', '-out', 'ca.key', '2048']);
+  openssl(['req', '-new', '-x509', '-days', '3650', '-key', 'ca.key', '-out', 'ca.crt',
+    '-subj', '/CN=Bruno E2E CA']);
+
+  // Server and client, both signed by that CA
+  signCert('server', 'localhost', 'server_ext', 'ca');
+  signCert('client', CLIENT_SUBJECT_CN, 'client_ext', 'ca');
+
+  // Client PFX (PKCS#12).
+  openssl(['pkcs12', '-export', '-out', 'client.pfx', '-inkey', 'client.key', '-in', 'client.crt',
+    '-certfile', 'ca.crt', '-passout', `pass:${PFX_PASSPHRASE}`]);
+
+  // Untrusted CA + client.
+  openssl(['genrsa', '-out', 'untrusted-ca.key', '2048']);
+  openssl(['req', '-new', '-x509', '-days', '3650', '-key', 'untrusted-ca.key',
+    '-out', 'untrusted-ca.crt', '-subj', '/CN=Untrusted CA']);
+  signCert('untrusted-client', 'untrusted-client', 'client_ext', 'untrusted-ca');
+
+  for (const stale of fs.readdirSync(CERTS_DIR)) {
+    if (stale.endsWith('.csr') || stale.endsWith('.srl')) {
+      fs.rmSync(path.join(CERTS_DIR, stale));
+    }
+  }
+}
+
+if (require.main === module) {
+  generateCerts(true);
+  console.log(`Generated mTLS certificates in ${CERTS_DIR}`);
+  for (const file of fs.readdirSync(CERTS_DIR).sort()) {
+    console.log(`  ${file}`);
+  }
+  console.log(`\nPFX passphrase: ${PFX_PASSPHRASE}`);
+}

--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -5,6 +5,7 @@ import * as net from 'net';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import { CA_CERT } from '../../ssl/client-certificate/server/mtls-certs';
 
 // This file lives at tests/e2e/utils/fixtures/, so climb four levels to the repo root.
 const EXTENSION_ROOT = path.resolve(__dirname, '../../../..');
@@ -127,7 +128,10 @@ function launchVSCode(
     workspacePath,
   ];
 
-  const proc = spawn(executablePath, args, { detached: false });
+  const proc = spawn(executablePath, args, {
+    detached: false,
+    env: { ...process.env, NODE_EXTRA_CA_CERTS: CA_CERT }
+  });
   // Only log errors to avoid noise
   proc.stderr?.on('data', d => {
     const line = String(d);

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -139,7 +139,19 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   },
   response: {
     statusCode: () => frame.getByTestId('response-status-code'),
-    previewContainer: () => frame.getByTestId('response-preview-container')
+    previewContainer: () => frame.getByTestId('response-preview-container'),
+    error: () => frame.getByTestId('response-error')
+  },
+  clientCerts: {
+    emptyMessage: () => frame.getByText('No client certificates added'),
+    rows: () => frame.getByTestId('client-cert-row'),
+    domainInput: () => frame.getByTestId('client-cert-domain'),
+    pfxRadio: () => frame.getByTestId('client-cert-type-pfx'),
+    filePicker: (field: string) => frame.getByTestId(`client-cert-file-${field}`),
+    pickedFile: (field: string) => frame.getByTestId(`client-cert-file-name-${field}`),
+    passphraseEditor: () => frame.getByTestId('client-cert-passphrase').locator('.CodeMirror'),
+    addButton: () => frame.getByTestId('add-client-cert'),
+    saveButton: () => frame.getByTestId('save-client-certs')
   },
   // A dropdown menu item, by its visible text.
   dropdownItem: (text: string) => frame.locator('.dropdown-item').filter({ hasText: text }),


### PR DESCRIPTION
**Jira: VSCODE-117**
### Description
Enabled collection level client certificate. HTTPS, WSS, GRPCS carries the client certificate in API calls
### Problem
Client certificate is not working
### Fix
1. Enabled client certificate for collection.
2. Added script to generate client cert/key/pfx
3. Added test server to validate the client certificate functionality locally

### Screenshot
<img width="1209" height="514" alt="Screenshot 2026-08-17 at 11 28 05 AM" src="https://github.com/user-attachments/assets/7b221ddc-2f44-4c2a-8518-d15fb7ccf5a4" />
