### PR TITLE
fix(prompt-variable)-not parsed as query parameter

### DIFF
--- a/src/webview/utils/url/index.ts
+++ b/src/webview/utils/url/index.ts
@@ -79,8 +79,9 @@ export const splitOnFirst = (str: string | null | undefined, char: string): stri
   if (!str || !str.length) {
     return [str ?? ''];
   }
+  const masked = str.replace(/\{\{.*?\}\}/g, (match) => '_'.repeat(match.length));
+  const index = masked.indexOf(char);
 
-  const index = str.indexOf(char);
   if (index === -1) {
     return [str];
   }


### PR DESCRIPTION
**Jira: VSCODE-142**
### Description
Prompt variable in URL is not parsed as query parameter.
### Problem
Prompt variable in URL is getting added to query paramater
### Fix
When prompt variable in URL is variable, it doesn't get added to query param.
### Screenshot
**Before**
<img width="819" height="304" alt="Screenshot 2026-08-18 at 3 28 03 PM" src="https://github.com/user-attachments/assets/9f262269-2030-4757-b424-5c6b0e4c3e29" />

**After**
<img width="826" height="255" alt="Screenshot 2026-08-18 at 3 24 56 PM" src="https://github.com/user-attachments/assets/cc841d83-471a-4beb-a75c-617fbfc35be5" />

