### PR TITLE
fix(grpc-message): show Add message for client-streaming/bidi-streaming methods.

### DIFF
--- a/src/webview/components/RequestPane/GrpcBody/StyledWrapper.ts
+++ b/src/webview/components/RequestPane/GrpcBody/StyledWrapper.ts
@@ -100,6 +100,10 @@ const Wrapper = styled.div`
   .editor-container {
     flex: 1;
     min-height: 0;
+
+    div.CodeMirror {
+      height: 100%;
+    }
   }
 
   .empty-state {

--- a/src/webview/components/RequestPane/GrpcQueryUrl/index.tsx
+++ b/src/webview/components/RequestPane/GrpcQueryUrl/index.tsx
@@ -88,6 +88,7 @@ const GrpcQueryUrl = ({
 
     dispatch(updateRequestMethod({
       method: path,
+      methodType: type,
       itemUid: item.uid,
       collectionUid: collection.uid
     }));

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -626,7 +626,7 @@ export const collectionsSlice = createSlice({
     },
 
     updateRequestMethod: (state, action: PayloadAction<UpdateRequestMethodPayload>) => {
-      const { collectionUid, itemUid, method } = action.payload;
+      const { collectionUid, itemUid, method, methodType } = action.payload;
       const collection = findCollectionByUid(state.collections, collectionUid);
       if (collection) {
         const item = findItemInCollection(collection, itemUid);
@@ -634,6 +634,7 @@ export const collectionsSlice = createSlice({
           const draft = ensureDraft(item);
           if (draft.request) {
             (draft.request as { method?: string }).method = method;
+            (draft.request as { methodType?: string }).methodType = methodType;
           }
         }
       }

--- a/src/webview/providers/ReduxStore/slices/collections/types.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/types.ts
@@ -262,6 +262,7 @@ export interface UpdateRequestGraphqlVariablesPayload extends ItemUidPayload {
 
 export interface UpdateRequestMethodPayload extends ItemUidPayload {
   method: string;
+  methodType?: string;
 }
 
 export interface AddFormUrlEncodedParamPayload extends ItemUidPayload {}

--- a/tests/e2e/grpc/method-type/grpc-method-type.spec.ts
+++ b/tests/e2e/grpc/method-type/grpc-method-type.spec.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame, Page } from '@playwright/test';
+import { test, expect } from '../../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createRequestByType,
+  openGrpcRequest,
+  loadGrpcProtoFile,
+  selectGrpcMethod,
+  openGrpcMessageTab,
+  findCollectionDir
+} from '../../utils/page/actions';
+import { buildCommonLocators } from '../../utils/page/locators';
+
+/**
+ * Message tab only allows more than one request message for client-streaming / bidi-streaming methods.
+ *
+ * Methods come from `streaming.proto` (one rpc per method type).
+ */
+
+const GRPC_SERVER = 'grpc://localhost:8082';
+
+async function setupGrpcRequest(
+  page: Page,
+  tmpDir: string,
+  collectionName: string,
+  requestName: string
+): Promise<Frame> {
+  const sidebar = await openBrunoSidebar(page);
+  await createCollection(page, sidebar, collectionName, tmpDir);
+
+  const protoInCollection = path.join(tmpDir, 'streaming.proto');
+  fs.copyFileSync(path.resolve(__dirname, '../../utils/fixtures/streaming.proto'), protoInCollection);
+
+  await createRequestByType(page, sidebar, collectionName, { name: requestName, url: GRPC_SERVER, type: 'gRPC' });
+  const editor = await openGrpcRequest(page, sidebar, collectionName, requestName);
+
+  await loadGrpcProtoFile(editor, protoInCollection);
+  await openGrpcMessageTab(editor);
+  return editor;
+}
+
+test.describe('gRPC method type', () => {
+  test('the selected method type drives how many request messages are allowed', async ({ page, tmpDir }) => {
+    const editor = await setupGrpcRequest(page, tmpDir, 'gRPC Method Type', 'MethodType');
+    const grpc = buildCommonLocators(editor).grpc;
+
+    // Unary
+    await selectGrpcMethod(editor, 'SayHello');
+    await expect(grpc.messages()).toHaveCount(1);
+    await expect(grpc.addMessageButton()).toHaveCount(0);
+
+    // Client-streaming
+    await selectGrpcMethod(editor, 'Collect');
+    await expect(grpc.addMessageButton()).toBeVisible();
+    await grpc.addMessageButton().click();
+    await expect(grpc.messages()).toHaveCount(2);
+
+    // Server-streaming
+    await selectGrpcMethod(editor, 'Subscribe');
+    await expect(grpc.messages()).toHaveCount(1);
+    await expect(grpc.addMessageButton()).toHaveCount(0);
+
+    // Bidi-streaming
+    await selectGrpcMethod(editor, 'Chat');
+    await expect(grpc.addMessageButton()).toBeVisible();
+    await expect(grpc.messages()).toHaveCount(2);
+
+    await selectGrpcMethod(editor, 'SayHello');
+    await expect(grpc.messages()).toHaveCount(1);
+    await expect(grpc.addMessageButton()).toHaveCount(0);
+  });
+});

--- a/tests/e2e/utils/fixtures/streaming.proto
+++ b/tests/e2e/utils/fixtures/streaming.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package streaming;
+
+// gRPC method types
+service StreamService {
+  rpc SayHello (Msg) returns (Msg);
+  rpc Collect (stream Msg) returns (Msg);
+  rpc Subscribe (Msg) returns (stream Msg);
+  rpc Chat (stream Msg) returns (stream Msg);
+}
+
+message Msg {
+  string message = 1;
+}

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -525,14 +525,16 @@ export async function selectGrpcMethod(editor: Frame, methodText: string): Promi
   await expect(grpc.selectedMethodName()).toContainText(methodText, { timeout: 5_000 });
 }
 
-/** Set the first gRPC request message (JSON) on the Message tab. */
-export async function setGrpcMessage(page: Page, editor: Frame, json: string): Promise<void> {
+export async function openGrpcMessageTab(editor: Frame): Promise<void> {
   const locators = buildCommonLocators(editor);
   const messageTab = locators.tabs.byText('Message');
-  await expect(messageTab).toBeVisible({ timeout: 10_000 });
+  await expect(messageTab).toBeVisible();
   await messageTab.click();
+}
 
-  await setCodeMirrorValue(page, locators.grpc.messageEditor(), json);
+export async function setGrpcMessage(page: Page, editor: Frame, json: string): Promise<void> {
+  await openGrpcMessageTab(editor);
+  await setCodeMirrorValue(page, buildCommonLocators(editor).grpc.messageEditor(), json);
 }
 
 /**

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -125,6 +125,8 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     methodItem: (text: string) => frame.getByTestId('grpc-method-item').filter({ hasText: text }),
     selectedMethodName: () => frame.getByTestId('selected-grpc-method-name'),
     messageEditor: () => frame.getByTestId('grpc-messages-container').locator('.CodeMirror-wrap').first(),
+    messages: () => frame.getByTestId('grpc-messages-container').locator('.message-container'),
+    addMessageButton: () => frame.getByTestId('grpc-add-message-button'),
     sendRequestButton: () => frame.getByTestId('grpc-send-request-button'),
     responseStatusCode: () => frame.getByTestId('grpc-response-status-code'),
     responseContent: () => frame.getByTestId('grpc-response-content')


### PR DESCRIPTION
**Jira: VSCODE-29/VSCODE-30**
### Description
Show `Add Message` for `client-streaming` / `bidi-streaming` methods. `Add Message` is hidden for other methods. 
### Problem
- Multiple messages are shown when it's not `client-streaming` / `bidi-streaming` methods.
- Unable to add multiple messages

### Fix
- `Add Message` is available for `client-streaming` / `bidi-streaming` methods. Multiple messages can be added here.
- If it's not `client-streaming` / `bidi-streaming` methods, then multiple messages cannot be added and `Add Message` is hidden.
- When user switches `client-streaming -> unary -> bidi-streaming` - the messages added in `client-streaming` will be visible for `bidi-streaming`

### Screenshot

https://github.com/user-attachments/assets/1bc51981-a542-46f8-8c96-78a5ceff4067

