### PR TITLE
fix(vars): show correct variable values for object data type

### DIFF
--- a/src/webview/globalStyles.ts
+++ b/src/webview/globalStyles.ts
@@ -376,6 +376,7 @@ const GlobalStyle = createGlobalStyle`
     font-family: Inter, sans-serif;
     font-weight: 400;
     word-break: break-word;
+    white-space: pre-wrap;
     line-height: 1.25rem;
     color: ${(props) => props.theme.dropdown.color};
     min-height: 1.75rem;

--- a/src/webview/utils/codemirror/brunoVarInfo.tsx
+++ b/src/webview/utils/codemirror/brunoVarInfo.tsx
@@ -359,7 +359,6 @@ export const renderVarInfo = (token: any, options: any) => {
 
     const allVariables = collection ? getAllVariables(collection, item) : {};
 
-    // The raw value, not the resolved one. #usebruno/bruno/#6265
     const editorInitialValue = valueToString(rawValue, VALUE_INDENT);
 
     const cmEditor = CodeMirror(editorContainer, {
@@ -390,7 +389,7 @@ export const renderVarInfo = (token: any, options: any) => {
       maskedEditor.enable();
     }
 
-    // Must match what the editor holds, or a no-op blur reads as an edit and saves.
+    // Must match the editor's content, or a no-op blur reads as an edit and saves.
     let originalValue = editorInitialValue;
     let isEditing = false;
 

--- a/src/webview/utils/codemirror/brunoVarInfo.tsx
+++ b/src/webview/utils/codemirror/brunoVarInfo.tsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 
 import { interpolate, mockDataFunctions } from '@usebruno/common';
+import { valueToString } from '@usebruno/common/utils';
 import { getVariableScope, isVariableSecret, getAllVariables } from 'utils/collections';
 import { updateVariableInScope } from 'providers/ReduxStore/slices/collections/actions';
 import store from 'providers/ReduxStore';
@@ -55,6 +56,8 @@ export const COPY_SUCCESS_TIMEOUT = 1000;
 const EDITOR_MIN_HEIGHT = 1.75;
 const EDITOR_MAX_HEIGHT = 11.125;
 
+const VALUE_INDENT = 2;
+
 /**
  * Calculate editor height based on content, clamped between min and max
  * @param {number} contentHeight - The actual content height from CodeMirror
@@ -97,7 +100,7 @@ const getScopeLabel = (scopeType: string) => {
 };
 
 const getMaskedDisplay = (value: any) => {
-  const contentLength = (value || '').length;
+  const contentLength = valueToString(value, VALUE_INDENT).length;
   return contentLength > 0 ? '*'.repeat(contentLength) : '';
 };
 
@@ -105,7 +108,7 @@ const updateValueDisplay = (valueDisplay: any, value: any, isSecret: any, isMask
   if ((isSecret || isMasked) && !isRevealed) {
     valueDisplay.textContent = getMaskedDisplay(value);
   } else {
-    valueDisplay.textContent = value || '';
+    valueDisplay.textContent = valueToString(value, VALUE_INDENT);
   }
 };
 
@@ -131,7 +134,7 @@ const containsSecretVariableReferences = (rawValue: any, collection: any, item: 
   return false;
 };
 
-const getCopyButton = (variableValue: string, onCopyCallback?: () => void) => {
+const getCopyButton = (variableValue: unknown, onCopyCallback?: () => void) => {
   const copyButton = document.createElement('button');
 
   copyButton.className = 'copy-button';
@@ -149,7 +152,7 @@ const getCopyButton = (variableValue: string, onCopyCallback?: () => void) => {
     }
 
     navigator.clipboard
-      .writeText(variableValue)
+      .writeText(valueToString(variableValue, VALUE_INDENT))
       .then(() => {
         isCopied = true;
         copyButton.innerHTML = CHECKMARK_ICON_SVG_TEXT;
@@ -268,7 +271,7 @@ export const renderVarInfo = (token: any, options: any) => {
   // Check if variable is read-only (process.env, runtime, dynamic/faker, oauth2, and undefined variables cannot be edited)
   const isReadOnly = scopeInfo.type === 'process.env' || scopeInfo.type === 'runtime' || scopeInfo.type === 'dynamic' || scopeInfo.type === 'oauth2' || scopeInfo.type === 'undefined';
 
-  const rawValue = scopeInfo.value || '';
+  const rawValue = scopeInfo.value ?? '';
 
   const isSecret = scopeInfo.type !== 'undefined' ? isVariableSecret(scopeInfo) : false;
   const hasSecretReferences = containsSecretVariableReferences(rawValue, collection, item);
@@ -356,8 +359,11 @@ export const renderVarInfo = (token: any, options: any) => {
 
     const allVariables = collection ? getAllVariables(collection, item) : {};
 
+    // The raw value, not the resolved one. #usebruno/bruno/#6265
+    const editorInitialValue = valueToString(rawValue, VALUE_INDENT);
+
     const cmEditor = CodeMirror(editorContainer, {
-      value: typeof rawValue === 'string' ? rawValue : String(rawValue), // Use raw value (e.g., {{echo-host}} not resolved value) (ensure it's always a string for CodeMirror) #usebruno/bruno/#6265
+      value: editorInitialValue,
       mode: 'brunovariables',
       theme: cmTheme,
       lineWrapping: true,
@@ -384,7 +390,8 @@ export const renderVarInfo = (token: any, options: any) => {
       maskedEditor.enable();
     }
 
-    let originalValue = rawValue;
+    // Must match what the editor holds, or a no-op blur reads as an edit and saves.
+    let originalValue = editorInitialValue;
     let isEditing = false;
 
     cmEditor.setOption('extraKeys', {
@@ -446,7 +453,7 @@ export const renderVarInfo = (token: any, options: any) => {
     }
 
     // Copy button (copy actual value, not masked)
-    const copyButton = getCopyButton(variableValue || '', () => {
+    const copyButton = getCopyButton(variableValue, () => {
       if (isEditing) {
         setTimeout(() => {
           cmEditor.focus();
@@ -545,7 +552,7 @@ export const renderVarInfo = (token: any, options: any) => {
     }
 
     // Copy button (always copy actual value, not masked)
-    const copyButton = getCopyButton(variableValue || '');
+    const copyButton = getCopyButton(variableValue);
     iconsContainer.appendChild(copyButton);
 
     valueContainer.appendChild(valueDisplay);

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -15,8 +15,6 @@ const TYPED_REQUEST_BRU = [
   'vars:post-response {', '  saved: res.body.token', '}', ''
 ].join('\n');
 
-// A folder holding a request that consumes object vars declared above it, at folder and
-// collection level.
 const FOLDER_NAME = 'Api';
 
 const COLLECTION_ROOT_BRU = [
@@ -95,8 +93,6 @@ test.describe('Data types in request variables', () => {
     // The object var's annotation is untouched throughout.
     expect(fs.readFileSync(requestFile, 'utf8')).toContain('@object');
 
-    // The editable half of the popover is what a save writes back, so "[object Object]"
-    // there would persist that literal string to disk.
     const locators = buildCommonLocators(editor);
     const cfgToken = locators.requestUrl.highlightedToken('cfg');
     await expect(cfgToken).toBeVisible({ timeout: 15_000 });
@@ -118,8 +114,6 @@ test.describe('Data types in request variables', () => {
     await expect(popoverEditor).not.toContainText('[object Object]');
   });
 
-  // An object var is most often declared once at folder or collection level and consumed
-  // by the requests below it, so the popover has to resolve those scopes too.
   test('object vars inherited from folder and collection render as JSON in the popover', async ({ page, tmpDir }) => {
     const sidebar = await openBrunoSidebar(page);
     const collectionName = 'Inherited Vars';
@@ -142,8 +136,7 @@ test.describe('Data types in request variables', () => {
       sidebar.locator('[data-testid="sidebar-collection-item-row"]').filter({ hasText: 'Nested' })
     ).toBeVisible({ timeout: 15_000 });
 
-    // Expanding the folder re-renders the tree, and a click landing mid-render never
-    // reaches the open-request handler.
+    // A click landing mid re-render never reaches the open-request handler.
     await page.waitForTimeout(1500);
     const opened = await openRequest(page, sidebar, collectionName, 'Nested');
     const editor = await getActiveEditorFrame(page, opened);
@@ -167,7 +160,6 @@ test.describe('Data types in request variables', () => {
       await expect(locators.varPopover.editableDisplay()).toContainText(`"scope": "${scope}"`);
       await expect(popover).not.toContainText('[object Object]');
 
-      // Drop the popover so the next hover starts from a clean slate.
       await editor.evaluate(() => {
         document.querySelectorAll('.CodeMirror-brunoVarInfo').forEach((el) => el.remove());
       });

--- a/tests/e2e/specs/datatype-vars.spec.ts
+++ b/tests/e2e/specs/datatype-vars.spec.ts
@@ -2,16 +2,35 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Page, Frame } from '@playwright/test';
 import { test, expect } from '../utils/fixtures';
-import { openBrunoSidebar, createCollection, openRequest, openRequestPaneTab, findCollectionDir } from '../utils/page/actions';
+import { openBrunoSidebar, createCollection, expandCollection, openRequest, openRequestPaneTab, findCollectionDir } from '../utils/page/actions';
 import { getActiveEditorFrame } from '../utils/page/oauth2-actions';
+import { buildCommonLocators } from '../utils/page/locators';
 
 // A request with a typed (object) pre-request var, a plain string pre-request var,
 // and a post-response var (which holds a JS expression, so it must NOT get a type).
 const TYPED_REQUEST_BRU = [
   'meta {', '  name: Typed', '  type: http', '  seq: 1', '}', '',
-  'get {', '  url: https://usebruno.com', '  body: none', '  auth: inherit', '}', '',
+  'get {', '  url: https://usebruno.com/{{cfg}}', '  body: none', '  auth: inherit', '}', '',
   'vars:pre-request {', '  @object', '  cfg: {"host":"localhost"}', '  token: abc123', '}', '',
   'vars:post-response {', '  saved: res.body.token', '}', ''
+].join('\n');
+
+// A folder holding a request that consumes object vars declared above it, at folder and
+// collection level.
+const FOLDER_NAME = 'Api';
+
+const COLLECTION_ROOT_BRU = [
+  'vars:pre-request {', '  @object', '  cfgCollection: {"scope":"collection"}', '}', ''
+].join('\n');
+
+const FOLDER_ROOT_BRU = [
+  'meta {', `  name: ${FOLDER_NAME}`, '}', '',
+  'vars:pre-request {', '  @object', '  cfgFolder: {"scope":"folder"}', '}', ''
+].join('\n');
+
+const NESTED_REQUEST_BRU = [
+  'meta {', '  name: Nested', '  type: http', '  seq: 1', '}', '',
+  'get {', '  url: https://usebruno.com/{{cfgFolder}}/{{cfgCollection}}', '  body: none', '  auth: inherit', '}', ''
 ].join('\n');
 
 async function openTypedVars(page: Page, tmpDir: string): Promise<Frame> {
@@ -75,5 +94,84 @@ test.describe('Data types in request variables', () => {
     await expect.poll(() => fs.readFileSync(requestFile, 'utf8'), { timeout: 15_000 }).not.toContain('@number');
     // The object var's annotation is untouched throughout.
     expect(fs.readFileSync(requestFile, 'utf8')).toContain('@object');
+
+    // The editable half of the popover is what a save writes back, so "[object Object]"
+    // there would persist that literal string to disk.
+    const locators = buildCommonLocators(editor);
+    const cfgToken = locators.requestUrl.highlightedToken('cfg');
+    await expect(cfgToken).toBeVisible({ timeout: 15_000 });
+
+    const popover = locators.varPopover.container();
+    await expect(async () => {
+      await locators.requestUrl.editor().hover({ position: { x: 2, y: 2 } });
+      await cfgToken.hover();
+      await expect(popover).toBeVisible({ timeout: 1_000 });
+    }).toPass({ timeout: 5_000 });
+
+    const editableDisplay = locators.varPopover.editableDisplay();
+    await expect(editableDisplay).toContainText('"host": "localhost"');
+    await expect(popover).not.toContainText('[object Object]');
+
+    await editableDisplay.click();
+    const popoverEditor = locators.varPopover.editor();
+    await expect(popoverEditor).toContainText('"host": "localhost"');
+    await expect(popoverEditor).not.toContainText('[object Object]');
+  });
+
+  // An object var is most often declared once at folder or collection level and consumed
+  // by the requests below it, so the popover has to resolve those scopes too.
+  test('object vars inherited from folder and collection render as JSON in the popover', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Inherited Vars';
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    const folderDir = path.join(collectionDir, FOLDER_NAME);
+    fs.mkdirSync(folderDir, { recursive: true });
+    fs.writeFileSync(path.join(collectionDir, 'collection.bru'), COLLECTION_ROOT_BRU, 'utf8');
+    fs.writeFileSync(path.join(folderDir, 'folder.bru'), FOLDER_ROOT_BRU, 'utf8');
+    fs.writeFileSync(path.join(folderDir, 'Nested.bru'), NESTED_REQUEST_BRU, 'utf8');
+
+    await expandCollection(sidebar, collectionName);
+    const folderRow = sidebar
+      .locator('[data-testid="sidebar-collection-item-row"]')
+      .filter({ hasText: FOLDER_NAME });
+    await expect(folderRow).toBeVisible({ timeout: 15_000 });
+    await folderRow.click();
+    await expect(
+      sidebar.locator('[data-testid="sidebar-collection-item-row"]').filter({ hasText: 'Nested' })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Expanding the folder re-renders the tree, and a click landing mid-render never
+    // reaches the open-request handler.
+    await page.waitForTimeout(1500);
+    const opened = await openRequest(page, sidebar, collectionName, 'Nested');
+    const editor = await getActiveEditorFrame(page, opened);
+
+    const locators = buildCommonLocators(editor);
+    const popover = locators.varPopover.container();
+
+    for (const { name, scope } of [
+      { name: 'cfgFolder', scope: 'folder' },
+      { name: 'cfgCollection', scope: 'collection' }
+    ]) {
+      const token = locators.requestUrl.highlightedToken(name);
+      await expect(token).toBeVisible({ timeout: 15_000 });
+
+      await expect(async () => {
+        await locators.requestUrl.editor().hover({ position: { x: 2, y: 2 } });
+        await token.hover();
+        await expect(popover).toBeVisible({ timeout: 1_000 });
+      }).toPass({ timeout: 5_000 });
+
+      await expect(locators.varPopover.editableDisplay()).toContainText(`"scope": "${scope}"`);
+      await expect(popover).not.toContainText('[object Object]');
+
+      // Drop the popover so the next hover starts from a clean slate.
+      await editor.evaluate(() => {
+        document.querySelectorAll('.CodeMirror-brunoVarInfo').forEach((el) => el.remove());
+      });
+      await expect(locators.varPopover.all()).toHaveCount(0, { timeout: 5_000 });
+    }
   });
 });

--- a/tests/e2e/specs/path-params.spec.ts
+++ b/tests/e2e/specs/path-params.spec.ts
@@ -20,7 +20,7 @@ async function editPathParamViaPopover(
 ): Promise<void> {
   const locators = buildCommonLocators(editor);
 
-  const paramSpan = locators.requestUrl.pathParamToken(paramName);
+  const paramSpan = locators.requestUrl.highlightedToken(paramName);
   await expect(paramSpan).toBeVisible({ timeout: 5_000 });
 
   // Retry the hover: move off the token first so a fresh mouseover fires.
@@ -55,7 +55,7 @@ async function editPathParamViaPopover(
   await editor.evaluate(() => {
     document.querySelectorAll('.CodeMirror-brunoVarInfo').forEach((el) => el.remove());
   });
-  await expect(popover).toHaveCount(0, { timeout: 5_000 });
+  await expect(locators.varPopover.all()).toHaveCount(0, { timeout: 5_000 });
 }
 
 // Read the path param value from the Params -> Path table.

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -23,7 +23,6 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   },
   requestUrl: {
     editor: () => frame.locator('#request-url'),
-    // A highlighted token in the URL editor: a `:param` or a `{{variable}}`.
     highlightedToken: (name: string) =>
       frame
         .locator('#request-url .CodeMirror span.cm-variable-valid, #request-url .CodeMirror span.cm-variable-invalid')
@@ -32,8 +31,7 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   },
   // Var-info hover popover shown over a highlighted token.
   varPopover: {
-    // A dismissed popover lingers for the length of its fade, so a re-hover can briefly
-    // leave two in the DOM: `all` counts them, the rest read the newest.
+    // A dismissed popover lingers for its fade, so a re-hover can briefly leave two.
     all: () => frame.locator('.CodeMirror-brunoVarInfo'),
     container: () => frame.locator('.CodeMirror-brunoVarInfo').last(),
     editableDisplay: () => frame.locator('.CodeMirror-brunoVarInfo').last().locator('.var-value-editable-display'),

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -23,8 +23,8 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   },
   requestUrl: {
     editor: () => frame.locator('#request-url'),
-    // A `:param` token highlighted in the URL editor.
-    pathParamToken: (name: string) =>
+    // A highlighted token in the URL editor: a `:param` or a `{{variable}}`.
+    highlightedToken: (name: string) =>
       frame
         .locator('#request-url .CodeMirror span.cm-variable-valid, #request-url .CodeMirror span.cm-variable-invalid')
         .filter({ hasText: name })
@@ -32,8 +32,11 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   },
   // Var-info hover popover shown over a highlighted token.
   varPopover: {
-    container: () => frame.locator('.CodeMirror-brunoVarInfo'),
-    editableDisplay: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editable-display'),
+    // A dismissed popover lingers for the length of its fade, so a re-hover can briefly
+    // leave two in the DOM: `all` counts them, the rest read the newest.
+    all: () => frame.locator('.CodeMirror-brunoVarInfo'),
+    container: () => frame.locator('.CodeMirror-brunoVarInfo').last(),
+    editableDisplay: () => frame.locator('.CodeMirror-brunoVarInfo').last().locator('.var-value-editable-display'),
     editor: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror'),
     editorFocused: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-focused'),
     editorLine: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-line').first()


### PR DESCRIPTION
## Description

Jira: VSCODE-138

## Root cause

Var was handing the value straight to the page as if it were text. An object turns into `[object Object]` when it gets treated that way.

## Solution

The variable value is now formatted before display, so objects show as readable, indented JSON. This also fixes object edits being saved as `[object Object]` and `0` or `false` values appearing blank.

## Recordings / Screenshots

**Before**
<img width="1377" height="586" alt="Screenshot 2026-08-19 at 5 16 55 PM" src="https://github.com/user-attachments/assets/8ef780a4-1a23-42c5-ac1b-ad9e17086ced" />

**After**

<img width="1470" height="585" alt="Screenshot 2026-08-19 at 5 16 12 PM" src="https://github.com/user-attachments/assets/e22b2e3a-44cd-47cf-868d-6849913404a8" />
