### PR TITLE
fix: strip comments from the JSON body before sending it

### DIFF
--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -10,6 +10,7 @@ import { getCookieStringForUrl, saveCookies } from '../../utils/cookies';
 import { createFormData, formatMultipartData } from '../../utils/form-data';
 import { readFileBody, getSelectedFileBodyEntry, DEFAULT_FILE_BODY_CONTENT_TYPE } from '../../utils/file-body';
 import { safeStringifyJSON } from '../../utils/common';
+import { stripJsonComments } from '../../utils/strip-json-comments';
 import { getPreferences, preferencesUtil } from '../../store/preferences';
 import { getProcessEnvVars } from '../../store/process-env';
 import { getCertsAndProxyConfig } from './cert-utils';
@@ -618,7 +619,9 @@ const getRequestData = (body: BrunoRequest['body']): unknown => {
 
   switch (body.mode) {
     case 'json':
-      return body.json || undefined;
+      // Stripped the way the desktop app and the CLI do it. A commented body is not valid
+      // JSON, and axios ends up sending the whole text as a JSON string instead of an object.
+      return body.json ? stripJsonComments(body.json) : undefined;
 
     case 'text':
       return body.text || undefined;

--- a/src/extension/ipc/network/prepare-request.spec.ts
+++ b/src/extension/ipc/network/prepare-request.spec.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'vitest';
+import { prepareBody } from './prepare-request';
+
+const jsonBody = (json: string) => prepareBody({ mode: 'json', json }, {});
+
+describe('prepareBody strips comments from a json body', () => {
+  test('line comment', () => {
+    expect(jsonBody('{\n  "a": 1 // note\n}')).toEqual({ a: 1 });
+  });
+
+  test('comment on its own line', () => {
+    expect(jsonBody('{\n  // note\n  "a": 1\n}')).toEqual({ a: 1 });
+  });
+
+  test('block comment', () => {
+    expect(jsonBody('{\n  /* note */ "a": 1\n}')).toEqual({ a: 1 });
+  });
+
+  test('a double slash inside a value is not a comment', () => {
+    expect(jsonBody('{\n  "url": "http://example.com//path" // note\n}')).toEqual({
+      url: 'http://example.com//path'
+    });
+  });
+
+  test('escaped quotes inside a value survive', () => {
+    expect(jsonBody('{\n  "quote": "he said \\"hi \\"" // note\n}')).toEqual({
+      quote: 'he said "hi "'
+    });
+  });
+
+  test('a body that is still invalid falls back to the comment-free text', () => {
+    // Unquoted variables only become valid JSON after interpolation, which runs later.
+    const result = jsonBody('{\n  "id": {{id}} // note\n}');
+    expect(typeof result).toBe('string');
+    expect(result).not.toContain('//');
+  });
+
+  test('an empty body sends nothing', () => {
+    expect(jsonBody('')).toBeUndefined();
+  });
+
+  test('the content type is still defaulted', () => {
+    const headers: Record<string, string> = {};
+    prepareBody({ mode: 'json', json: '{}' }, headers);
+    expect(headers['content-type']).toBe('application/json');
+  });
+});

--- a/src/extension/ipc/network/prepare-request.ts
+++ b/src/extension/ipc/network/prepare-request.ts
@@ -2,6 +2,7 @@
 import type { AxiosRequestConfig } from 'axios';
 import { get, filter } from 'lodash';
 import { utils as brunoUtilsRaw } from '@usebruno/common';
+import { stripJsonComments } from '../../utils/strip-json-comments';
 
 // Type assertion for @usebruno/common utils (no type definitions available)
 const brunoUtils = brunoUtilsRaw as {
@@ -84,13 +85,22 @@ const prepareBody = (body: BrunoRequest['body'], headers: Record<string, string>
   }
 
   switch (body.mode) {
-    case 'json':
+    case 'json': {
       headers['content-type'] = headers['content-type'] || 'application/json';
-      try {
-        return body.json ? JSON.parse(body.json) : undefined;
-      } catch {
-        return body.json;
+      if (!body.json) {
+        return undefined;
       }
+      // Comments are stripped the way the desktop app and the CLI do it. Without this a
+      // commented body fails to parse, and axios ends up sending the text as a JSON string.
+      const json = stripJsonComments(body.json);
+      try {
+        return JSON.parse(json);
+      } catch {
+        // Still not valid JSON on its own: unquoted variables are only resolved later, by
+        // interpolation. Hand over the comment-free text so it can parse after that.
+        return json;
+      }
+    }
 
     case 'text':
       headers['content-type'] = headers['content-type'] || 'text/plain';

--- a/src/extension/utils/strip-json-comments.ts
+++ b/src/extension/utils/strip-json-comments.ts
@@ -1,0 +1,64 @@
+/**
+ * Removes `//` line comments and block comments from a JSON body, leaving string literals
+ * untouched.
+ *
+ * The desktop app and the CLI run the request body through `decomment` before sending it
+ * (see `bruno-electron/src/ipc/network/prepare-request.js`), so collections are commonly
+ * authored with comments. This keeps the extension in line without pulling in a JavaScript
+ * parser: a JSON body has no regular expressions or template literals, so a string-aware
+ * scan is enough to tell a comment from a `//` that happens to live inside a value.
+ */
+export const stripJsonComments = (text: string): string => {
+  let result = '';
+  let index = 0;
+  let insideString = false;
+  let escaped = false;
+
+  while (index < text.length) {
+    const char = text[index];
+
+    if (insideString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        insideString = false;
+      }
+      index++;
+      continue;
+    }
+
+    if (char === '"') {
+      insideString = true;
+      result += char;
+      index++;
+      continue;
+    }
+
+    // The newline is left in place: dropping it would join the next line to this one.
+    if (char === '/' && text[index + 1] === '/') {
+      while (index < text.length && text[index] !== '\n') {
+        index++;
+      }
+      continue;
+    }
+
+    if (char === '/' && text[index + 1] === '*') {
+      index += 2;
+      while (index < text.length && !(text[index] === '*' && text[index + 1] === '/')) {
+        index++;
+      }
+      index += 2;
+      continue;
+    }
+
+    result += char;
+    index++;
+  }
+
+  return result;
+};
+
+export default stripJsonComments;


### PR DESCRIPTION
Fixes #137.

## Problem

A JSON body with `//` comments is sent as a **quoted JSON string** instead of an object. The same collection works in the desktop app and in the CLI, because both run the body through `decomment` first:

- `packages/bruno-electron/src/ipc/network/prepare-request.js`
- `packages/bruno-cli/src/runner/prepare-request.js`

So a collection authored in the desktop app — where JSON body comments have been supported since usebruno/bruno#396 — silently breaks when the same `.bru` files are run from VS Code. In our shared collection that was 80 of 127 requests with a JSON body. On a strict API it surfaces as a confusing validation error; ours (Django/DRF) answers `Invalid data. Expected a dictionary, but got str.`

Two places build the body here, and both have the bug:

**1. `getRequestData` in `ipc/network/index.ts`** — this is the one that runs for a normal send:

```ts
case 'json':
  return body.json || undefined;
```

The raw commented text becomes `request.data`. `interpolateVars` takes the string branch, and axios' `stringifySafely` cannot parse it, so it falls back to `JSON.stringify(rawString)` and the request goes out double-encoded. Its own doc comment says *"Similar to bruno-cli's prepare-request.js"* — which is exactly where the CLI applies `decomment`.

**2. `prepareBody` in `ipc/network/prepare-request.ts`** — reached when `data` is undefined:

```ts
try {
  return body.json ? JSON.parse(body.json) : undefined;
} catch {
  return body.json;      // still commented, so axios quotes it
}
```

## Fix

`decomment` is not a dependency of this repo (`script-runner.ts` declares a local `decomment` that currently returns the script untouched), so rather than pulling the package in, this adds a small dependency-free helper: a JSON body has no regular expressions or template literals, so a string-aware scan is enough to tell a comment from a `//` that happens to live inside a value.

- `getRequestData` returns `stripJsonComments(body.json)` — same shape and type as before, just comment-free, mirroring `decomment(request.body.json)` in the CLI.
- `prepareBody` parses the stripped text, and **falls back to the stripped text rather than to `body.json`**. A body that mixes comments with unquoted variables (`"quantity": {{qty}}`) is still not valid JSON after stripping, so it takes that path; returning the raw text would hand `interpolateVars` a string that still contains `//` and the interpolated result would be quoted all the same. It also returns `undefined` for an empty body, so nothing is sent.

If you would rather match `bruno-electron` byte for byte by depending on `decomment`, swapping the helper is a one-line change — I kept it dependency-free to avoid touching the lockfile.

## Tests

`src/extension/ipc/network/prepare-request.spec.ts` covers `prepareBody` with a line comment, a comment on its own line, a block comment, a `//` inside a string value, escaped quotes inside a value, the still-invalid fallback, an empty body, and the content-type default. (`getRequestData` is module-private, so it is not covered directly; happy to export it if you want a spec on it too.)

I verified the behaviour against the `decomment` that ships with the desktop app (4.1.0), comparing the body builder's output after variable interpolation and axios' `stringifySafely` rule; the two agree on every case except the ones that are invalid JSON in every client anyway, such as a trailing comma left behind by commenting a field out.

I also patched the shipped 5.0.2 bundle locally with the same change and confirmed against a real API that the request now arrives as an object.

---

Note: I used AI assistance to investigate and prepare this change.
