### PR TITLE
fix-show updated env values in request

### DIFF
--- a/src/webview/components/Environments/CreateGlobalEnvironment/index.tsx
+++ b/src/webview/components/Environments/CreateGlobalEnvironment/index.tsx
@@ -80,6 +80,7 @@ const CreateGlobalEnvironment: React.FC<CreateGlobalEnvironmentProps> = ({ onClo
             <div className="flex items-center mt-2">
               <input
                 id="environment-name"
+                data-testid="environment-name"
                 type="text"
                 name="name"
                 ref={inputRef}

--- a/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.tsx
+++ b/src/webview/components/Environments/EnvironmentSettings/EnvironmentList/EnvironmentDetails/EnvironmentVariables/index.tsx
@@ -456,6 +456,7 @@ const EnvironmentVariables = ({
                         autoCapitalize="off"
                         spellCheck="false"
                         className="mousetrap"
+                        data-testid="env-var-name"
                         id={`${index}.name`}
                         name={`${index}.name`}
                         value={variable.name}
@@ -501,6 +502,7 @@ const EnvironmentVariables = ({
                       <input
                         type="checkbox"
                         className="mousetrap"
+                        data-testid="env-var-secret"
                         name={`${index}.secret`}
                         checked={variable.secret}
                         onChange={formik.handleChange}

--- a/src/webview/components/Environments/GlobalEnvironmentSettings/index.tsx
+++ b/src/webview/components/Environments/GlobalEnvironmentSettings/index.tsx
@@ -15,7 +15,7 @@ const DefaultTab = ({
     <IconFileAlert size={48} strokeWidth={1.5} />
     <div className="title">No Global Environments</div>
     <div className="actions">
-      <Button size="sm" color="secondary" onClick={() => setTab('create')}>
+      <Button size="sm" color="secondary" onClick={() => setTab('create')} data-testid="create-environment">
         Create Environment
       </Button>
       <Button size="sm" color="secondary" onClick={() => setTab('import')}>

--- a/src/webview/components/Modal/index.tsx
+++ b/src/webview/components/Modal/index.tsx
@@ -74,6 +74,7 @@ const ModalFooter = ({
           disabled={confirmDisabled}
           onClick={handleSubmit}
           className="submit"
+          data-testid="modal-confirm-button"
         >
           {confirmText}
         </Button>

--- a/src/webview/utils/codemirror/brunoVarInfo.tsx
+++ b/src/webview/utils/codemirror/brunoVarInfo.tsx
@@ -277,7 +277,8 @@ export const renderVarInfo = (token: any, options: any) => {
   const hasSecretReferences = containsSecretVariableReferences(rawValue, collection, item);
   const shouldMaskValue = isSecret || hasSecretReferences;
 
-  const isMasked = options.variables?.maskedEnvVariables?.includes(variableName);
+  const allVariables = collection ? getAllVariables(collection, item) : {};
+  const isMasked = allVariables?.maskedEnvVariables?.includes(variableName);
 
   const into = document.createElement('div');
   into.className = 'bruno-var-info-container';
@@ -356,8 +357,6 @@ export const renderVarInfo = (token: any, options: any) => {
     // Detect current theme from DOM
     const isDarkTheme = document.documentElement.classList.contains('dark');
     const cmTheme = isDarkTheme ? 'monokai' : 'default';
-
-    const allVariables = collection ? getAllVariables(collection, item) : {};
 
     const editorInitialValue = valueToString(rawValue, VALUE_INDENT);
 

--- a/tests/e2e/specs/global-env-secret-mask.spec.ts
+++ b/tests/e2e/specs/global-env-secret-mask.spec.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame, Locator, Page } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import {
+  openBrunoSidebar,
+  createCollection,
+  openRequest,
+  findCollectionDir,
+  setCodeMirrorValue,
+  runCommand
+} from '../utils/page/actions';
+import { getActiveEditorFrame } from '../utils/page/oauth2-actions';
+import { buildCommonLocators } from '../utils/page/locators';
+
+const SECRET_VALUE = 'abc123';
+
+const REQUEST_BRU = [
+  'meta {', '  name: Masked', '  type: http', '  seq: 1', '}', '',
+  'get {', '  url: https://usebruno.com/{{token}}', '  body: none', '  auth: none', '}', ''
+].join('\n');
+
+async function frameWith(page: Page, probe: (frame: Frame) => Locator, timeout = 20_000): Promise<Frame> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      if (frame === page.mainFrame()) continue;
+      try {
+        if (await probe(frame).count() > 0) return frame;
+      } catch {
+        // frame detached mid-poll, skip
+      }
+    }
+    await page.waitForTimeout(400);
+  }
+  throw new Error(`No webview frame matched the probe within ${timeout}ms`);
+}
+
+async function readVarPopoverValue(editor: Frame): Promise<string> {
+  const ui = buildCommonLocators(editor);
+  await ui.varPopover.container().evaluateAll((popovers) => popovers.forEach((el) => el.remove()));
+
+  const token = ui.requestUrl.pathParamToken('token');
+  await expect(token).toBeVisible();
+  await token.hover();
+
+  const value = ui.varPopover.editableDisplay();
+  await expect(value).toBeVisible();
+  return (await value.textContent()) ?? '';
+}
+
+test.describe('Global environment secrets', () => {
+  test('marking a variable secret masks it in request tab', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Secret Mask';
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    fs.writeFileSync(path.join(findCollectionDir(tmpDir), 'Masked.bru'), REQUEST_BRU, 'utf8');
+
+    await runCommand(page, 'Bruno: Open Global Environments');
+    let globalEnv = await frameWith(page, (f) => buildCommonLocators(f).environments.createEnvironment());
+    let globalEnvUi = buildCommonLocators(globalEnv);
+
+    await globalEnvUi.environments.createEnvironment().click();
+    await globalEnvUi.environments.nameInput().fill('Globals');
+    await globalEnvUi.environments.confirmCreate().click();
+
+    await expect(globalEnvUi.environments.save()).toBeVisible();
+    await globalEnvUi.environments.varNameInput(0).fill('token');
+    await setCodeMirrorValue(page, globalEnvUi.environments.varValueEditor('token'), SECRET_VALUE);
+    await globalEnvUi.environments.save().click();
+
+    const opened = await openRequest(page, sidebar, collectionName, 'Masked');
+    const editor = await getActiveEditorFrame(page, opened);
+    const editorUi = buildCommonLocators(editor);
+
+    await editorUi.environments.selectorTrigger().click();
+    await editorUi.environments.scopeTab('global').click();
+    await editorUi.dropdownItem('Globals').first().click();
+
+    expect(await readVarPopoverValue(editor)).toBe(SECRET_VALUE);
+
+    const workbench = buildCommonLocators(page).workbench;
+    await workbench.editorTab('Global Environments').click();
+    globalEnv = await frameWith(page, (f) => buildCommonLocators(f).environments.save());
+    globalEnvUi = buildCommonLocators(globalEnv);
+    await globalEnvUi.environments.varSecretCheckbox('token').check();
+    await globalEnvUi.environments.save().click();
+
+    await workbench.editorTab('Masked.bru').click();
+
+    await expect
+      .poll(() => readVarPopoverValue(editor))
+      .toMatch(/^\*+$/);
+  });
+});

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -39,6 +39,18 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     editorFocused: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-focused'),
     editorLine: () => frame.locator('.CodeMirror-brunoVarInfo .var-value-editor .CodeMirror-line').first()
   },
+  environments: {
+    selectorTrigger: () => frame.getByTestId('environment-selector-trigger'),
+    scopeTab: (scope: 'collection' | 'global') => frame.getByTestId(`env-tab-${scope}`),
+    createEnvironment: () => frame.getByTestId('create-environment'),
+    nameInput: () => frame.getByTestId('environment-name'),
+    confirmCreate: () => frame.getByTestId('modal-confirm-button'),
+    varNameInput: (index: number) => frame.getByTestId('env-var-name').nth(index),
+    varValueEditor: (name: string) => frame.getByTestId(`env-var-row-${name}`).locator('.CodeMirror'),
+    varSecretCheckbox: (name: string) =>
+      frame.getByTestId(`env-var-row-${name}`).getByTestId('env-var-secret'),
+    save: () => frame.getByTestId('save-env')
+  },
   paramsTable: {
     // Value cell of the path-params table.
     pathValueCell: () =>


### PR DESCRIPTION
### Description
Jira: VSCODE-130
### Problem
When secret is configured, it's not getting updated immediately in requests
### Fix
Instead of getting cached env data, live data is used to get the env data so secret configured will be available immediately to request.