### PR TITLE
fix(timeline): keep the json response visible in xml mode and restore fold controls

### DIFF
--- a/src/webview/utils/codemirror/setup.ts
+++ b/src/webview/utils/codemirror/setup.ts
@@ -5,6 +5,7 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/addon/scroll/simplescrollbars.css';
+import 'codemirror/addon/fold/foldgutter.css';
 
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/xml/xml');

--- a/src/webview/utils/common/format-response.spec.ts
+++ b/src/webview/utils/common/format-response.spec.ts
@@ -1,0 +1,23 @@
+import { formatResponse } from './index';
+
+const toBase64 = (value: string) => Buffer.from(value, 'utf8').toString('base64');
+
+describe('formatResponse', () => {
+  describe('XML mode', () => {
+    it('formats an XML response', () => {
+      const xml = '<root><item>value</item></root>';
+      const result = formatResponse(xml, toBase64(xml), 'application/xml', null);
+
+      expect(result).toContain('<root>');
+      expect(result).toContain('<item>value</item>');
+    });
+
+    it('keeps a parsed JSON response visible', () => {
+      const json = { name: 'bruno', tags: ['api'] };
+      const result = formatResponse(json, toBase64(JSON.stringify(json)), 'application/xml', null);
+
+      expect(result).toContain('"name": "bruno"');
+      expect(result).toContain('"api"');
+    });
+  });
+});

--- a/src/webview/utils/common/index.tsx
+++ b/src/webview/utils/common/index.tsx
@@ -340,11 +340,11 @@ export const formatResponse = (
       return typeof data === 'string' ? data : safeStringifyJSON(data, false) ?? '';
     }
 
-    const parsed = safeParseXML(typeof data === 'string' ? data : '', { collapseContent: true });
-    if (typeof parsed === 'string') {
-      return parsed;
+    if (typeof data !== 'string') {
+      return safeStringifyJSON(data, true) ?? '';
     }
-    return safeStringifyJSON(parsed, true) ?? '';
+
+    return safeParseXML(data, { collapseContent: true });
   }
 
   if (mode.includes('html')) {

--- a/tests/e2e/specs/timeline.spec.ts
+++ b/tests/e2e/specs/timeline.spec.ts
@@ -207,4 +207,30 @@ test.describe('Response timeline', () => {
     await expect(editor.locator('[data-testid="timeline-item"]').first())
       .toContainText('ERR_BAD_REQUEST', { timeout: 15_000 });
   });
+
+  test('a json body can be collapsed from the fold gutter', async ({ page, tmpDir }) => {
+    const collectionName = 'Timeline Fold Gutter';
+    const { sidebar, collectionDir } = await setupCollection(page, collectionName, tmpDir);
+
+    fs.writeFileSync(path.join(collectionDir, 'Echo.bru'), [
+      'meta {', '  name: Echo', '  type: http', '  seq: 1', '}', '',
+      'post {', `  url: ${TEST_SERVER}/api/echo/json`, '  body: json', '  auth: none', '}', '',
+      'body:json {', '  {', '    "name": "bruno",', '    "tags": [', '      "api"', '    ]', '  }', '}', ''
+    ].join('\n'), 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Echo');
+    await sendRequest(editor, 200);
+    await openTimelineTab(editor);
+
+    await editor.locator('[data-testid="timeline-item-header"]').first().click();
+    await editor.locator('.tl-tab').filter({ hasText: /^Response/ }).first().click();
+
+    const body = editor.locator('[data-testid="timeline-panel-response"]').first().locator('.CodeMirror').first();
+    const foldControl = body.locator('.CodeMirror-foldgutter-open').first();
+
+    await expect(foldControl).toBeVisible({ timeout: 10_000 });
+
+    await foldControl.click();
+    await expect(body.locator('.CodeMirror-foldmarker')).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
## Description

Jira: VSCODE-151,152

- Opening a JSON response in the timeline and switching the body format to XML made the response vanish. 
- The JSON body in the timeline was also missing the formatting and close/expand

## Root cause

- The XML view only handled a response that arrives as plain text, so a JSON response, which arrives already parsed, was read as empty and nothing was drawn. 
- The fold arrows never got the styling that renders them, so the control sat in the gutter with no size and nothing visible to click.

## Solution

The XML view now falls back to the indented JSON when the response is not text, so the body stays on screen in every format. The stylesheet that draws the fold arrows is loaded along with the rest of the editor styling, which brings back collapsing and expanding everywhere the editor is used.

## Recordings / Screenshots

**Before**
<img width="3085" height="1920" alt="image-20260824-120105" src="https://github.com/user-attachments/assets/e0b8f44e-701f-4919-aa0d-79625d18150a" />



**After**
<img width="1374" height="707" alt="Screenshot 2026-08-25 at 3 57 58 PM" src="https://github.com/user-attachments/assets/f7d3fc47-0b12-4119-8793-f5d23c42290d" />
 <img width="1396" height="679" alt="Screenshot 2026-08-25 at 3 58 19 PM" src="https://github.com/user-attachments/assets/56750d8e-939a-45a8-99f1-21630f282692" />

