### PR TITLE
fix: open saved request in active view column

### DIFF
--- a/src/extension/panels/transient-request-panel.ts
+++ b/src/extension/panels/transient-request-panel.ts
@@ -322,16 +322,20 @@ async function saveTransientRequest(
   }
 
   try {
-    // Write the file using the stringify worker (same as renderer:new-request)
     const { stringifyRequestViaWorker } = require('@usebruno/filestore');
     const content = await stringifyRequestViaWorker({ ...itemData, name, filename }, { format });
     fs.writeFileSync(fullPath, content, 'utf-8');
 
     savedPanels.add(itemUid);
-    panel.dispose();
 
-    // Open the saved file in the regular editor
-    await vscode.commands.executeCommand('vscode.openWith', vscode.Uri.file(fullPath), 'bruno.requestEditor');
+    const targetViewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      vscode.Uri.file(fullPath),
+      'bruno.requestEditor',
+      { viewColumn: targetViewColumn, preview: false }
+    );
+    panel.dispose();
 
     vscode.window.showInformationMessage(`Request saved as "${name}"`);
   } catch (err: any) {


### PR DESCRIPTION
### Description

* update saveTransientRequest function to specify view column when opening saved requests
* ensure saved requests do not open in preview mode
* dispose of the panel after saving the request

### Screenshot


https://github.com/user-attachments/assets/99215299-4640-44e3-855d-7c650c5c606b

