### PR TITLE
fix(request-pane): let the body, script and tests editors fill the pane and show fold controls

### DIFF
--- a/src/webview/components/RequestPane/Script/index.tsx
+++ b/src/webview/components/RequestPane/Script/index.tsx
@@ -6,6 +6,7 @@ import { updateRequestScript, updateResponseScript } from 'providers/ReduxStore/
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from 'components/Tabs';
+import StyledWrapper from './StyledWrapper';
 
 interface ScriptProps {
   item: unknown;
@@ -67,7 +68,7 @@ const Script = ({
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
   return (
-    <div className="w-full h-full flex flex-col">
+    <StyledWrapper className="w-full h-full flex flex-col">
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="pre-request">Pre Request</TabsTrigger>
@@ -106,7 +107,7 @@ const Script = ({
           />
         </TabsContent>
       </Tabs>
-    </div>
+    </StyledWrapper>
   );
 };
 

--- a/src/webview/components/RequestPane/Tests/StyledWrapper.ts
+++ b/src/webview/components/RequestPane/Tests/StyledWrapper.ts
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const StyledWrapper = styled.div`
   div.CodeMirror {
     height: inherit;
   }
 `;
 
-export default Wrapper;
+export default StyledWrapper;

--- a/src/webview/components/RequestPane/Tests/index.tsx
+++ b/src/webview/components/RequestPane/Tests/index.tsx
@@ -5,6 +5,7 @@ import CodeEditor from 'components/CodeEditor';
 import { updateRequestTests } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
+import StyledWrapper from './StyledWrapper';
 
 interface TestsProps {
   item: unknown;
@@ -36,18 +37,20 @@ const Tests = ({
   const onSave = () => dispatch(saveRequest(item.uid, collection.uid));
 
   return (
-    <CodeEditor
-      collection={collection}
-      value={tests || ''}
-      theme={displayedTheme}
-      font={get(preferences, 'font.codeFont', 'default')}
-      fontSize={get(preferences, 'font.codeFontSize')}
-      onEdit={onEdit}
-      mode="javascript"
-      onRun={onRun}
-      onSave={onSave}
-      showHintsFor={['req', 'res', 'bru']}
-    />
+    <StyledWrapper className="w-full h-full">
+      <CodeEditor
+        collection={collection}
+        value={tests || ''}
+        theme={displayedTheme}
+        font={get(preferences, 'font.codeFont', 'default')}
+        fontSize={get(preferences, 'font.codeFontSize')}
+        onEdit={onEdit}
+        mode="javascript"
+        onRun={onRun}
+        onSave={onSave}
+        showHintsFor={['req', 'res', 'bru']}
+      />
+    </StyledWrapper>
   );
 };
 

--- a/src/webview/utils/codemirror/setup.ts
+++ b/src/webview/utils/codemirror/setup.ts
@@ -5,6 +5,7 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 import 'codemirror/theme/monokai.css';
 import 'codemirror/addon/scroll/simplescrollbars.css';
+import 'codemirror/addon/fold/foldgutter.css';
 
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/xml/xml');

--- a/tests/e2e/specs/request-body-editor.spec.ts
+++ b/tests/e2e/specs/request-body-editor.spec.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Frame } from '@playwright/test';
+import { test, expect } from '../utils/fixtures';
+import { openBrunoSidebar, createCollection, openRequest, findCollectionDir, openRequestPaneTab } from '../utils/page/actions';
+
+const TEST_SERVER = 'http://127.0.0.1:8081';
+
+async function setupRequest(page: any, tmpDir: string, collectionName: string): Promise<Frame> {
+  const sidebar = await openBrunoSidebar(page);
+  await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+  const collectionDir = findCollectionDir(tmpDir);
+
+  fs.writeFileSync(path.join(collectionDir, 'Echo.bru'), [
+    'meta {', '  name: Echo', '  type: http', '  seq: 1', '}', '',
+    'post {', `  url: ${TEST_SERVER}/api/echo/json`, '  body: json', '  auth: none', '}', '',
+    'body:json {', '  {', '    "name": "bruno",', '    "tags": [', '      "api"', '    ]', '  }', '}', ''
+  ].join('\n'), 'utf8');
+
+  const editor = await openRequest(page, sidebar, collectionName, 'Echo');
+  await openRequestPaneTab(editor, 'Body');
+  return editor;
+}
+
+test.describe('Request body editor', () => {
+  test('fills the height of the request pane', async ({ page, tmpDir }) => {
+    const editor = await setupRequest(page, tmpDir, 'Body Editor Height');
+    const body = editor.locator('.flex-boundary .CodeMirror').first();
+    await expect(body).toBeVisible({ timeout: 10_000 });
+
+    await expect(async () => {
+      const fill = await body.evaluate((el: any) => {
+        const editorHeight = el.getBoundingClientRect().height;
+        const containerHeight = el.parentElement.getBoundingClientRect().height;
+        return containerHeight > 0 ? editorHeight / containerHeight : 0;
+      });
+      expect(fill).toBeGreaterThan(0.98);
+    }).toPass({ timeout: 10_000 });
+  });
+
+  test('offers fold controls on a json body', async ({ page, tmpDir }) => {
+    const editor = await setupRequest(page, tmpDir, 'Body Editor Folding');
+    const body = editor.locator('.flex-boundary .CodeMirror').first();
+    const foldControl = body.locator('.CodeMirror-foldgutter-open').first();
+
+    await expect(foldControl).toBeVisible({ timeout: 10_000 });
+
+    await foldControl.click();
+    await expect(body.locator('.CodeMirror-foldmarker')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Description

Jira: VSCODE-153
Body, Script, and Test editors don’t use the full available width, and the JSON body is missing fold controls.

## Solution

The body, script and tests panels now take the height of their container. The missing stylesheet is loaded with the rest of the editor styling, which brings collapsing and expanding back everywhere an editor is used.

## Recordings / Screenshots

**Before**

<img width="1003" height="732" alt="image" src="https://github.com/user-attachments/assets/4563c9c4-1543-47ac-b7c4-ccd66af724bd" />

**After**
<img width="1071" height="746" alt="Screenshot 2026-08-26 at 3 18 51 PM" src="https://github.com/user-attachments/assets/319e9fb9-98aa-429e-a99f-cfe964744b15" />
