### PR TITLE
fix(script-errors): link the error file path to the failing line, and stop sending when the pre-request script fails

### DIFF
--- a/src/bruno-types/app/collection-ext.ts
+++ b/src/bruno-types/app/collection-ext.ts
@@ -106,6 +106,7 @@ export interface AppItem extends Item {
   /** File size in MB (for large files) */
   size?: number;
   error?: { message: string } | null;
+  errorSource?: string | null;
 }
 
 export interface AppCollection extends Omit<Collection, 'items'> {

--- a/src/bruno-types/common/index.ts
+++ b/src/bruno-types/common/index.ts
@@ -5,14 +5,15 @@ export type { MultipartFormEntry, MultipartForm } from './multipart-form';
 export type { FileEntry, FileList } from './file';
 export type { GraphqlBody } from './graphql';
 export type { Script, ScriptErrorContext, ScriptErrorContextLine, ScriptMetadata, ScriptSegment } from './scripts';
-export type { ScriptErrorPhase } from './script-errors';
+export type { ScriptErrorPhase, ScriptType } from './script-errors';
 export {
   SCRIPT_ERROR_PHASES,
   SCRIPT_ERROR_FIELDS,
   scriptErrorMessageField,
   scriptErrorContextField,
   getScriptError,
-  hasScriptError
+  hasScriptError,
+  isScriptSourcedError
 } from './script-errors';
 export type {
   Auth,

--- a/src/bruno-types/common/script-errors.ts
+++ b/src/bruno-types/common/script-errors.ts
@@ -8,6 +8,8 @@ export const SCRIPT_ERROR_PHASES = [
 
 export type ScriptErrorPhase = (typeof SCRIPT_ERROR_PHASES)[number]['phase'];
 
+export type ScriptType = (typeof SCRIPT_ERROR_PHASES)[number]['scriptType'];
+
 export const scriptErrorMessageField = (phase: ScriptErrorPhase): string => `${phase}ScriptErrorMessage`;
 
 export const scriptErrorContextField = (phase: ScriptErrorPhase): string => `${phase}ScriptErrorContext`;
@@ -27,3 +29,6 @@ export const getScriptError = (
 
 export const hasScriptError = (item: Record<string, unknown> | null | undefined): boolean =>
   SCRIPT_ERROR_PHASES.some(({ phase }) => Boolean(item?.[scriptErrorMessageField(phase)]));
+
+export const isScriptSourcedError =(item: Record<string, unknown> | null | undefined): boolean =>
+  item?.errorSource === 'script';

--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -1052,22 +1052,28 @@ const registerNetworkIpc = (): void => {
         cancelTokenUid
       });
 
-      let skipRequest = false;
-      try {
-        const preRequestResult = await runPreRequestScript(scriptRequest, scriptContext);
+      const preRequestResult = await runPreRequestScript(scriptRequest, scriptContext);
 
-        notifyScriptExecution('main:run-request-event', 'pre-request', { itemUid, requestUid, collectionUid }, preRequestResult);
+      notifyScriptExecution('main:run-request-event', 'pre-request', { itemUid, requestUid, collectionUid }, preRequestResult);
 
-        skipRequest = preRequestResult.skipRequest || false;
-
-        if (preRequestResult.runtimeVariables) {
-          Object.assign(mutableRuntimeVariables, preRequestResult.runtimeVariables);
-          scriptContext.runtimeVariables = mutableRuntimeVariables;
-          context.runtimeVariables = mutableRuntimeVariables as Record<string, string>;
-        }
-      } catch (preReqError) {
-        console.error('Pre-request script error:', preReqError);
+      if (preRequestResult.runtimeVariables) {
+        Object.assign(mutableRuntimeVariables, preRequestResult.runtimeVariables);
+        scriptContext.runtimeVariables = mutableRuntimeVariables;
+        context.runtimeVariables = mutableRuntimeVariables as Record<string, string>;
       }
+
+      if (!preRequestResult.success) {
+        return {
+          status: 'Error',
+          isError: true,
+          error: preRequestResult.error || 'An error occurred in pre request script',
+          errorSource: 'script',
+          size: 0,
+          duration: 0
+        };
+      }
+
+      const skipRequest = preRequestResult.skipRequest || false;
 
       if (skipRequest) {
         sendToWebview('main:run-request-event', {

--- a/src/webview/components/CodeEditor/StyledWrapper.ts
+++ b/src/webview/components/CodeEditor/StyledWrapper.ts
@@ -161,6 +161,32 @@ const StyledWrapper = styled.div<{
     background: ${(props) => props.theme.codemirror.searchLineHighlightCurrent};
   }
 
+  @keyframes cm-error-line-flash {
+    0%, 60% {
+      background-color: ${(props) => rgba(props.theme.colors.text.danger, 0.2)};
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
+
+  .CodeMirror .cm-error-line-flash {
+    background-color: transparent;
+    animation: cm-error-line-flash 3s ease-in-out;
+  }
+
+  .CodeMirror .cm-error-line-flash-gutter .CodeMirror-linenumber {
+    color: ${(props) => props.theme.colors.text.danger} !important;
+    font-weight: 600;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .CodeMirror .cm-error-line-flash {
+      animation: none;
+      background-color: ${(props) => rgba(props.theme.colors.text.danger, 0.2)};
+    }
+  }
+
   .cm-search-match {
     background: rgba(255, 193, 7, 0.25);
   }

--- a/src/webview/components/RequestPane/Script/index.tsx
+++ b/src/webview/components/RequestPane/Script/index.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import get from 'lodash/get';
+import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateRequestScript, updateResponseScript } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
+import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
 import { useTheme } from 'providers/Theme';
+import useFocusErrorLine from 'hooks/useFocusErrorLine';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from 'components/Tabs';
 
 interface ScriptProps {
@@ -18,11 +21,14 @@ const Script = ({
   collection
 }: any) => {
   const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState('pre-request');
   const preRequestEditorRef = useRef(null);
   const postResponseEditorRef = useRef(null);
   const requestScript = item.draft ? get(item, 'draft.request.script.req') : get(item, 'request.script.req');
   const responseScript = item.draft ? get(item, 'draft.request.script.res') : get(item, 'request.script.res');
+
+  const scriptPaneTab = useSelector((state: any) => find(state.tabs.tabs, (t: any) => t.uid === item.uid)?.scriptPaneTab);
+  const activeTab = scriptPaneTab || 'pre-request';
+  const setActiveTab = (tab: string) => dispatch(updateScriptPaneTab({ uid: item.uid, scriptPaneTab: tab }));
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state: any) => state.app.preferences);
@@ -40,6 +46,20 @@ const Script = ({
 
     return () => clearTimeout(timer);
   }, [activeTab]);
+
+  useFocusErrorLine({
+    uid: item.uid,
+    editorRef: preRequestEditorRef,
+    scriptPhase: 'pre-request',
+    isVisible: activeTab === 'pre-request'
+  });
+
+  useFocusErrorLine({
+    uid: item.uid,
+    editorRef: postResponseEditorRef,
+    scriptPhase: 'post-response',
+    isVisible: activeTab === 'post-response'
+  });
 
   const onRequestScriptEdit = (value: string) => {
     dispatch(

--- a/src/webview/components/RequestPane/Tests/index.tsx
+++ b/src/webview/components/RequestPane/Tests/index.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import get from 'lodash/get';
 import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateRequestTests } from 'providers/ReduxStore/slices/collections';
 import { sendRequest, saveRequest } from 'providers/ReduxStore/slices/collections/actions';
 import { useTheme } from 'providers/Theme';
+import useFocusErrorLine from 'hooks/useFocusErrorLine';
 
 interface TestsProps {
   item: unknown;
@@ -17,10 +18,13 @@ const Tests = ({
   collection
 }: any) => {
   const dispatch = useDispatch();
+  const editorRef = useRef(null);
   const tests = item.draft ? get(item, 'draft.request.tests') : get(item, 'request.tests');
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state) => state.app.preferences);
+
+  useFocusErrorLine({ uid: item.uid, editorRef, scriptPhase: 'test' });
 
   const onEdit = (value: any) => {
     dispatch(
@@ -37,6 +41,7 @@ const Tests = ({
 
   return (
     <CodeEditor
+      ref={editorRef}
       collection={collection}
       value={tests || ''}
       theme={displayedTheme}

--- a/src/webview/components/ResponsePane/QueryResult/index.tsx
+++ b/src/webview/components/ResponsePane/QueryResult/index.tsx
@@ -1,6 +1,7 @@
 import { debounce } from 'lodash';
 import { useTheme } from 'providers/Theme/index';
 import React, { useMemo, useState } from 'react';
+import { isScriptSourcedError } from '@bruno-types';
 import { formatResponse, getContentType } from 'utils/common';
 import { getDefaultResponseFormat, detectContentTypeFromBase64 } from 'utils/response';
 import LargeResponseWarning from '../LargeResponseWarning';
@@ -184,7 +185,7 @@ const QueryResult = ({
       {error ? (
         <div>
           {/* The runner reports a script failure through item.error too, where the card already shows it. */}
-          {item?.errorSource === 'script' ? null : (
+          {isScriptSourcedError(item) ? null : (
             <div className="error" style={{ whiteSpace: 'pre-line' }}>{formatErrorMessage(error)}</div>
           )}
 

--- a/src/webview/components/ResponsePane/ScriptError/StyledWrapper.ts
+++ b/src/webview/components/ResponsePane/ScriptError/StyledWrapper.ts
@@ -57,16 +57,33 @@ const StyledWrapper = styled.div`
   }
 
   .script-error-file-path {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
     min-width: 0;
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
     font-family: monospace;
     font-size: ${(props) => props.theme.font.size.xs};
     font-weight: 400;
     text-transform: none;
     letter-spacing: normal;
     opacity: 0.8;
+    transition: opacity 0.15s, text-decoration 0.15s;
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    &.navigable {
+      cursor: pointer;
+
+      &:hover {
+        opacity: 1;
+        text-decoration: underline;
+      }
+    }
   }
 
   .script-error-message {

--- a/src/webview/components/ResponsePane/ScriptError/index.tsx
+++ b/src/webview/components/ResponsePane/ScriptError/index.tsx
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
-import { IconX, IconChevronDown, IconChevronRight } from '@tabler/icons';
-import type { ScriptErrorContext, ScriptErrorPhase } from '@bruno-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { IconX, IconChevronDown, IconChevronRight, IconExternalLink } from '@tabler/icons';
+import type { ScriptErrorContext, ScriptErrorPhase, ScriptType } from '@bruno-types';
 import { SCRIPT_ERROR_PHASES, getScriptError } from '@bruno-types';
 import ErrorBanner from 'ui/ErrorBanner';
 import CodeSnippet from 'ui/CodeSnippet';
 import { getTreePathFromCollectionToItem } from 'utils/collections';
 import { normalizePath } from 'utils/common/path';
+import { updateRequestPaneTab, updateScriptPaneTab, setFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
+import { isTabForItemPresent } from 'selectors/tab';
 import StyledWrapper from './StyledWrapper';
+
+const SCRIPTABLE_REQUEST_TYPES = ['http-request', 'graphql-request'];
 
 interface ScriptErrorProps {
   item?: Record<string, unknown>;
@@ -18,6 +23,7 @@ interface ScriptErrorCardProps {
   title: string;
   message: string;
   errorContext: ScriptErrorContext;
+  scriptPhase: ScriptType;
   item?: Record<string, unknown>;
   collection?: Record<string, unknown>;
   onClose?: () => void;
@@ -31,11 +37,11 @@ const PHASE_TITLES: Record<ScriptErrorPhase, string> = {
 
 /** "echo json.bru" -> Request, "auth/folder.bru" -> "Folder: auth", "collection.bru" -> Collection.
  *  An unmatched folder falls back to a bare "Folder". */
-const getErrorSourceLabel = (
+const getErrorSource = (
   filePath: string,
   item?: Record<string, unknown>,
   collection?: Record<string, unknown>
-): string => {
+): { sourceType: 'request' | 'folder' | 'collection'; label: string } => {
   const normalizedPath = normalizePath(filePath);
 
   // Before the collection case, so folder.yml is not mistaken for a collection file.
@@ -53,24 +59,54 @@ const getErrorSourceLabel = (
         : folderFileName;
 
       if (folderRelPath === normalizedPath) {
-        return `Folder: ${node.name}`;
+        return { sourceType: 'folder', label: `Folder: ${node.name}` };
       }
     }
 
-    return 'Folder';
+    return { sourceType: 'folder', label: 'Folder' };
   }
 
   if (normalizedPath === 'collection.bru' || /^opencollection\.ya?ml$/.test(normalizedPath)) {
-    return 'Collection';
+    return { sourceType: 'collection', label: 'Collection' };
   }
 
-  return 'Request';
+  return { sourceType: 'request', label: 'Request' };
 };
 
-const ScriptErrorCard = ({ title, message, errorContext, item, collection, onClose }: ScriptErrorCardProps) => {
+const ScriptErrorCard = ({ title, message, errorContext, scriptPhase, item, collection, onClose }: ScriptErrorCardProps) => {
+  const dispatch = useDispatch();
   const [showStack, setShowStack] = useState(false);
 
   const filePath = errorContext.filePath ? normalizePath(errorContext.filePath) : null;
+  const source = filePath ? getErrorSource(filePath, item, collection) : null;
+  const errorLine = errorContext.errorLine;
+
+  const hasRequestTab =useSelector(isTabForItemPresent({ itemUid: item?.uid as string }));
+  const canNavigate = source?.sourceType === 'request'
+    && typeof errorLine === 'number'
+    && SCRIPTABLE_REQUEST_TYPES.includes(item?.type as string)
+    && hasRequestTab;
+
+  const navigateToErrorLine = () => {
+    if (!canNavigate) return;
+
+    const uid = item!.uid as string;
+    if (scriptPhase === 'test') {
+      dispatch(updateRequestPaneTab({ uid, requestPaneTab: 'tests' }));
+    } else {
+      dispatch(updateRequestPaneTab({ uid, requestPaneTab: 'script' }));
+      dispatch(updateScriptPaneTab({ uid, scriptPaneTab: scriptPhase }));
+    }
+    dispatch(setFocusErrorLine({ uid, scriptPhase, line: errorLine, requestedAt: Date.now() }));
+  };
+
+  const onFilePathKeyDown = (e: React.KeyboardEvent) => {
+    if (!canNavigate) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      navigateToErrorLine();
+    }
+  };
 
   return (
     <div className="script-error-card" data-testid="script-error-card">
@@ -84,8 +120,19 @@ const ScriptErrorCard = ({ title, message, errorContext, item, collection, onClo
       </div>
       {filePath && (
         <div className="script-error-source-label" data-testid="script-error-source-label">
-          <span>{getErrorSourceLabel(filePath, item, collection)}</span>
-          <span className="script-error-file-path" data-testid="script-error-file-path">{filePath}</span>
+          <span>{source!.label}</span>
+          <span
+            className={`script-error-file-path${canNavigate ? ' navigable' : ''}`}
+            data-testid="script-error-file-path"
+            role={canNavigate ? 'button' : undefined}
+            tabIndex={canNavigate ? 0 : undefined}
+            onClick={navigateToErrorLine}
+            onKeyDown={onFilePathKeyDown}
+            title={canNavigate ? `Go to line ${errorLine} in ${filePath}` : undefined}
+          >
+            <span>{filePath}</span>
+            {canNavigate && <IconExternalLink size={12} className="flex-shrink-0" />}
+          </span>
         </div>
       )}
       <CodeSnippet lines={errorContext.lines} />
@@ -115,7 +162,7 @@ const ScriptErrorCard = ({ title, message, errorContext, item, collection, onClo
 
 const ScriptError = ({ item, collection, onClose }: ScriptErrorProps) => {
   const errors = SCRIPT_ERROR_PHASES
-    .map(({ phase }) => ({ phase, title: PHASE_TITLES[phase], ...getScriptError(item, phase) }))
+    .map(({ phase, scriptType }) => ({ phase, scriptType, title: PHASE_TITLES[phase], ...getScriptError(item, phase) }))
     .filter((e) => e.message);
 
   if (!errors.length) return null;
@@ -126,13 +173,14 @@ const ScriptError = ({ item, collection, onClose }: ScriptErrorProps) => {
 
   return (
     <StyledWrapper className="mt-4 mb-2">
-      {errors.map(({ phase, title, message, context }) => (
+      {errors.map(({ phase, scriptType, title, message, context }) => (
         context
           ? <ScriptErrorCard
               key={phase}
               title={title}
               message={message as string}
               errorContext={context}
+              scriptPhase={scriptType}
               item={item}
               collection={collection}
               onClose={onClose}

--- a/src/webview/components/ResponsePane/index.tsx
+++ b/src/webview/components/ResponsePane/index.tsx
@@ -25,7 +25,7 @@ import HeightBoundContainer from 'ui/HeightBoundContainer';
 import ResponseStopWatch from 'components/ResponsePane/ResponseStopWatch';
 import WSMessagesList from './WsResponsePane/WSMessagesList';
 import ResponsiveTabs from 'ui/ResponsiveTabs';
-import { hasScriptError } from '@bruno-types';
+import { hasScriptError, isScriptSourcedError } from '@bruno-types';
 
 interface RIGHT_CONTENT_EXPANDED_WIDTHProps {
   item?: React.ReactNode;
@@ -80,11 +80,13 @@ const ResponsePane = ({
     dispatch(updateResponseViewTab({ uid: item.uid, responseViewTab: newViewTab }));
   }, [dispatch, item.uid]);
 
+  const requestFailed = Boolean(response.error) && !isScriptSourcedError(item);
+
   // Keyed on the item because this pane instance is reused as the selection changes. A request that
   // failed on its own terms is the actionable error, so the card waits behind its icon.
   useEffect(() => {
-    setShowScriptErrorCard(hasScriptError(item) && !response.error);
-  }, [item?.uid, hasScriptError(item), response.error]);
+    setShowScriptErrorCard(hasScriptError(item) && !requestFailed);
+  }, [item?.uid, hasScriptError(item), requestFailed]);
 
   const selectTab = (tab: any) => {
     dispatch(

--- a/src/webview/components/RunnerResults/ResponsePane/index.tsx
+++ b/src/webview/components/RunnerResults/ResponsePane/index.tsx
@@ -13,7 +13,7 @@ import SkippedRequest from 'components/ResponsePane/SkippedRequest';
 import RunnerTimeline from 'components/ResponsePane/RunnerTimeline';
 import ScriptError from 'components/ResponsePane/ScriptError';
 import ScriptErrorIcon from 'components/ResponsePane/ScriptErrorIcon';
-import { hasScriptError } from '@bruno-types';
+import { hasScriptError, isScriptSourcedError } from '@bruno-types';
 
 interface ResponsePaneProps {
   rightPaneWidth?: number;
@@ -32,19 +32,19 @@ const ResponsePane = ({
 
   const { requestSent, responseReceived, testResults, assertionResults, preRequestTestResults, postResponseTestResults, error } = item;
 
+  // A request that failed on its own terms is the actionable error, so the card stands aside.
+  const requestFailed = Boolean(error) && !isScriptSourcedError(item);
+
   // Keyed on the item because this pane instance is reused as the selection changes.
   useEffect(() => {
-    setShowScriptErrorCard(hasScriptError(item) && !(Boolean(error) && item?.errorSource !== 'script'));
-  }, [item?.uid, hasScriptError(item), error, item?.errorSource]);
+    setShowScriptErrorCard(hasScriptError(item) && !requestFailed);
+  }, [item?.uid, hasScriptError(item), requestFailed]);
 
   const headers = get(item, 'responseReceived.headers', []);
   const status = get(item, 'responseReceived.status', 0);
   const size = get(item, 'responseReceived.size', 0);
   const duration = get(item, 'responseReceived.duration', 0);
 
-  // A request that failed on its own terms is the actionable error, so the card stands aside. A
-  // script failure reported through the same channel is not a request failure.
-  const requestFailed = Boolean(error) && item?.errorSource !== 'script';
   const showScriptError = hasScriptError(item) && !requestFailed;
 
   const selectTab = (tab: any) => setSelectedTab(tab);

--- a/src/webview/hooks/useFocusErrorLine/index.ts
+++ b/src/webview/hooks/useFocusErrorLine/index.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import find from 'lodash/find';
+import { useDispatch, useSelector } from 'react-redux';
+import type { ScriptType } from '@bruno-types';
+import { clearFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
+import { focusErrorLine } from 'utils/codemirror/focusErrorLine';
+
+interface UseFocusErrorLineParams {
+  uid: string;
+  editorRef: RefObject<{ editor?: any } | null>;
+  scriptPhase: ScriptType;
+  isVisible?: boolean;
+}
+
+const useFocusErrorLine =({ uid, editorRef, scriptPhase, isVisible = true }: UseFocusErrorLineParams) => {
+  const dispatch = useDispatch();
+  const focusErrorLineState = useSelector((state: any) => {
+    const tab = find(state.tabs.tabs, (t: any) => t.uid === uid);
+    return tab?.focusErrorLine || null;
+  });
+
+  const disposeRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (!focusErrorLineState || !isVisible) return;
+    if (focusErrorLineState.scriptPhase !== scriptPhase) return;
+
+    const timer = setTimeout(() => {
+      const editor = editorRef.current?.editor;
+      if (editor) {
+        disposeRef.current?.();
+        disposeRef.current = focusErrorLine(editor, focusErrorLineState.line);
+      }
+      dispatch(clearFocusErrorLine({ uid }));
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [focusErrorLineState?.requestedAt, focusErrorLineState?.line, focusErrorLineState?.scriptPhase, isVisible, scriptPhase, uid]);
+
+  useEffect(() => {
+    return () => {
+      disposeRef.current?.();
+      disposeRef.current = null;
+    };
+  }, []);
+};
+
+export default useFocusErrorLine;

--- a/src/webview/providers/ReduxStore/slices/collections/index.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/index.ts
@@ -2035,6 +2035,7 @@ export const collectionsSlice = createSlice({
       }
 
       item.response = response;
+      item.errorSource = (response as { errorSource?: string } | null)?.errorSource || null;
       item.requestState = 'received';
       item.loading = false;
 
@@ -2710,6 +2711,7 @@ export const collectionsSlice = createSlice({
           SCRIPT_ERROR_FIELDS.forEach((field) => {
             (item as any)[field] = null;
           });
+          item.errorSource = null;
 
           (item as any).testResults = [];
           (item as any).assertionResults = [];

--- a/src/webview/providers/ReduxStore/slices/tabs.ts
+++ b/src/webview/providers/ReduxStore/slices/tabs.ts
@@ -10,6 +10,8 @@ interface Tab {
   collectionUid: string;
   requestPaneWidth: number | null;
   requestPaneTab: string;
+  scriptPaneTab?: string;
+  focusErrorLine?: { scriptPhase: string; line: number; requestedAt: number } | null;
   responsePaneTab: string;
   responsePaneScrollPosition: number | null;
   responseFormat: string | null;
@@ -160,6 +162,31 @@ export const tabsSlice = createSlice({
         tab.requestPaneTab = action.payload.requestPaneTab;
       }
     },
+    updateScriptPaneTab: (state, action: PayloadAction<any>) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.scriptPaneTab = action.payload.scriptPaneTab;
+      }
+    },
+    setFocusErrorLine: (state, action: PayloadAction<any>) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.focusErrorLine = {
+          scriptPhase: action.payload.scriptPhase,
+          line: action.payload.line,
+          requestedAt: action.payload.requestedAt
+        };
+      }
+    },
+    clearFocusErrorLine: (state, action: PayloadAction<any>) => {
+      const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
+
+      if (tab) {
+        tab.focusErrorLine = null;
+      }
+    },
     updateResponsePaneTab: (state, action: PayloadAction<any>) => {
       const tab = find(state.tabs, (t) => t.uid === action.payload.uid);
 
@@ -268,6 +295,9 @@ export const {
   updateRequestPaneTabWidth,
   updateRequestPaneTabHeight,
   updateRequestPaneTab,
+  updateScriptPaneTab,
+  setFocusErrorLine,
+  clearFocusErrorLine,
   updateResponsePaneTab,
   updateResponsePaneScrollPosition,
   updateResponseFormat,

--- a/src/webview/utils/codemirror/focusErrorLine.ts
+++ b/src/webview/utils/codemirror/focusErrorLine.ts
@@ -1,0 +1,41 @@
+const LINE_CLASS_TARGET = 'background';
+const LINE_CLASS_NAME = 'cm-error-line-flash';
+const GUTTER_CLASS_TARGET = 'gutter';
+const GUTTER_CLASS_NAME = 'cm-error-line-flash-gutter';
+
+const FLASH_DURATION_MS = 3000;
+
+const noop = () => {};
+
+export const focusErrorLine = (editor: any, line1Based: number): (() => void) => {
+  if (!editor || typeof line1Based !== 'number' || Number.isNaN(line1Based)) {
+    return noop;
+  }
+
+  const line = Math.max(0, Math.min(line1Based - 1, editor.lineCount() - 1));
+
+  try {
+    editor.scrollIntoView({ line, ch: 0 }, 80);
+    editor.addLineClass(line, LINE_CLASS_TARGET, LINE_CLASS_NAME);
+    editor.addLineClass(line, GUTTER_CLASS_TARGET, GUTTER_CLASS_NAME);
+  } catch {
+    return noop;
+  }
+
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    try {
+      editor.removeLineClass(line, LINE_CLASS_TARGET, LINE_CLASS_NAME);
+      editor.removeLineClass(line, GUTTER_CLASS_TARGET, GUTTER_CLASS_NAME);
+    } catch {}
+  };
+
+  const timer = setTimeout(dispose, FLASH_DURATION_MS);
+
+  return () => {
+    clearTimeout(timer);
+    dispose();
+  };
+};

--- a/tests/e2e/specs/script-error.spec.ts
+++ b/tests/e2e/specs/script-error.spec.ts
@@ -17,6 +17,18 @@ const FAILING_REQUEST_BRU = [
   ''
 ].join('\n');
 
+const UNSENT_TOKEN = 'PRE_REQUEST_SHOULD_NOT_SEND';
+
+const FAILING_PRE_REQUEST_BRU = [
+  'meta {', '  name: PreBoom', '  type: http', '  seq: 1', '}', '',
+  'get {', `  url: ${TEST_SERVER}/capture`, '  body: none', '  auth: inherit', '}', '',
+  'headers {', `  x-token: ${UNSENT_TOKEN}`, '}', '',
+  'script:pre-request {',
+  '  bru.setEnvVar("Bad Name", "x");',
+  '}',
+  ''
+].join('\n');
+
 test.describe('Script errors in the response pane', () => {
   test('a failing post-response script renders a card with the source line and stack', async ({ page, tmpDir }) => {
     const sidebar = await openBrunoSidebar(page);
@@ -45,6 +57,53 @@ test.describe('Script errors in the response pane', () => {
 
     await card.locator('[data-testid="script-error-close"]').click();
     await expect(card).toBeHidden();
+  });
+
+  test('a failing pre-request script aborts the send and renders no response', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Pre Request Script Error';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'PreBoom.bru'), FAILING_PRE_REQUEST_BRU, 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'PreBoom');
+    await sendRequest(editor);
+
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
+
+    await expect(editor.locator('[data-testid="response-status-code"]')).toContainText('Error');
+    await expect(editor.locator('[data-testid="response-preview-container"]')).toHaveCount(0);
+
+    const captured = await (await fetch(`${TEST_SERVER}/last-capture`)).json() as { token: string | null };
+    expect(captured.token).not.toBe(UNSENT_TOKEN);
+  });
+
+  test('the file path on the card jumps to the failing line in the script editor', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Script Error Navigation';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'Boom.bru'), FAILING_REQUEST_BRU, 'utf8');
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Boom');
+    await sendRequest(editor, 200);
+
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    const filePath = card.locator('[data-testid="script-error-file-path"]');
+    await expect(filePath).toHaveClass(/navigable/);
+    await filePath.click();
+
+    const postResponseEditor = editor.locator('[data-testid="post-response-script-editor"]');
+    await expect(postResponseEditor).toBeVisible();
+    await expect(postResponseEditor.locator('.cm-error-line-flash')).toHaveCount(1);
   });
 
   test('variables written before a script throws are still applied and persisted', async ({ page, tmpDir }) => {
@@ -126,7 +185,7 @@ test.describe('Script errors in the response pane', () => {
     await expect(editor.locator('.error').first()).toContainText('URL', { timeout: 15_000 });
     await expect(editor.locator('[data-testid="script-error-card"]')).toHaveCount(0);
   });
-  test('a request that fails on its own shows that error, not the script error', async ({ page, tmpDir }) => {
+  test('a failing pre-request script wins over a host that would not resolve', async ({ page, tmpDir }) => {
     const sidebar = await openBrunoSidebar(page);
     const collectionName = 'Bad Host';
 
@@ -143,44 +202,38 @@ test.describe('Script errors in the response pane', () => {
     ].join('\n'), 'utf8');
 
     const editor = await openRequest(page, sidebar, collectionName, 'BadHost');
-    await editor.locator('#send-request').click();
+    await sendRequest(editor);
 
-    await expect(editor.locator('.error').first()).toContainText('does-not-exist-bruno-test.invalid', { timeout: 30_000 });
-    await expect(editor.locator('[data-testid="script-error-card"]')).toHaveCount(0);
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
+    await expect(editor.locator('.error')).toHaveCount(0);
   });
 
-  test('the script error behind a failed request is still reachable from the icon', async ({ page, tmpDir }) => {
+  test('closing the card leaves the script error reachable from the icon', async ({ page, tmpDir }) => {
     const sidebar = await openBrunoSidebar(page);
-    const collectionName = 'Bad Host Reachable';
+    const collectionName = 'Script Error Icon';
 
     await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
 
     const collectionDir = findCollectionDir(tmpDir);
-    fs.writeFileSync(path.join(collectionDir, 'BadHost.bru'), [
-      'meta {', '  name: BadHost', '  type: http', '  seq: 1', '}', '',
-      'get {', '  url: http://does-not-exist-bruno-test.invalid/x', '  body: none', '  auth: inherit', '}', '',
-      'script:pre-request {',
-      "  bru.setEnvVar('Bad Name', 'x');",
-      '}',
-      ''
-    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(collectionDir, 'PreBoom.bru'), FAILING_PRE_REQUEST_BRU, 'utf8');
 
-    const editor = await openRequest(page, sidebar, collectionName, 'BadHost');
-    await editor.locator('#send-request').click();
-
-    await expect(editor.locator('.error').first()).toContainText('does-not-exist-bruno-test.invalid', { timeout: 30_000 });
-
-    const icon = editor.locator('[data-testid="script-error-icon"]').first();
-    await expect(icon).toBeVisible();
-    await icon.click();
+    const editor = await openRequest(page, sidebar, collectionName, 'PreBoom');
+    await sendRequest(editor);
 
     const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    await card.locator('[data-testid="script-error-close"]').click();
+    await expect(editor.locator('[data-testid="script-error-card"]')).toHaveCount(0);
+
+    await editor.locator('[data-testid="script-error-icon"]').first().click();
     await expect(card).toBeVisible();
     await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
-    await expect(card.locator('[data-testid="code-line-error"]')).toContainText("bru.setEnvVar('Bad Name', 'x')");
   });
 
-  test('an empty url wins over a script error raised in the same send', async ({ page, tmpDir }) => {
+  test('a failing pre-request script wins over an empty url', async ({ page, tmpDir }) => {
     const sidebar = await openBrunoSidebar(page);
     const collectionName = 'Empty Url Script';
 
@@ -197,9 +250,11 @@ test.describe('Script errors in the response pane', () => {
     ].join('\n'), 'utf8');
 
     const editor = await openRequest(page, sidebar, collectionName, 'NoUrl');
-    await editor.locator('#send-request').click();
+    await sendRequest(editor);
 
-    await expect(editor.locator('.error').first()).toContainText('URL', { timeout: 15_000 });
-    await expect(editor.locator('[data-testid="script-error-card"]')).toHaveCount(0);
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
+    await expect(editor.locator('.error')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Description

Jira: VSCODE-132
When a script fails the script error panel doesn’t show a link to the line where the error occurred. Also when a pre-request script fails the response is still shown.

## Solution

The file name is now clickable for request-level scripts. Clicking it opens the Script or Tests tab and takes you to the failing line with a short highlight. A failing pre-request script now stops the request so no response is shown.

## Recordings / Screenshots

**Before**
<img width="1152" height="721" alt="Screenshot 2026-08-26 at 4 48 56 PM" src="https://github.com/user-attachments/assets/4df68e9d-e4bd-440e-8a32-ee7139b38f4e" />

**After**

<img width="1464" height="701" alt="Screenshot 2026-08-26 at 4 57 18 PM" src="https://github.com/user-attachments/assets/c857a624-0333-4d49-8fbe-75b2da3634a0" />


