### PR TITLE
fix(environment-variables): omit __name__ from persisted environment variables

### DIFF
--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -182,7 +182,7 @@ import {
   scriptUpdateCollectionVars
 } from './index';
 
-import { each } from 'lodash';
+import { each, omit } from 'lodash';
 import { closeAllCollectionTabs, closeTabs, updateResponsePaneScrollPosition } from 'providers/ReduxStore/slices/tabs';
 import { removeCollectionFromWorkspace, addCollectionToWorkspace } from 'providers/ReduxStore/slices/workspaces';
 import { resolveRequestFilename } from 'utils/common/platform';
@@ -2304,10 +2304,9 @@ export const mergeAndPersistEnvironment
           return dataType === 'string' ? {} : { dataType };
         };
 
-        // Environment vars are merge-only (set/update), unlike the collection and global scopes which
-        // drop vars a script deleted: deleteEnvVar is not among the persisting scripting APIs, so a
-        // script never removes an environment variable from disk.
-        let normalizedNewVars = Object.entries(persistentEnvVariables).map(([name, value]) => ({
+        const scriptEnvVariables = omit(persistentEnvVariables, ['__name__']);
+
+        let normalizedNewVars = Object.entries(scriptEnvVariables).map(([name, value]) => ({
           uid: uuid(),
           name,
           value,
@@ -2331,7 +2330,7 @@ export const mergeAndPersistEnvironment
           }
         });
 
-        const persistedNames = new Set(Object.keys(persistentEnvVariables));
+        const persistedNames = new Set(Object.keys(scriptEnvVariables));
 
         existingVars.forEach((v: any) => {
           if (!v.ephemeral) {

--- a/src/webview/providers/ReduxStore/slices/collections/env-vars-persist.spec.ts
+++ b/src/webview/providers/ReduxStore/slices/collections/env-vars-persist.spec.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('vscode', () => ({}));
+
+const { mergeAndPersistEnvironment } = await import('./actions');
+const { uuid } = await import('../../../../utils/common/index');
+
+const invoke = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  invoke.mockClear();
+  (globalThis as any).window = { ipcRenderer: { invoke } };
+});
+
+const envVar = (name: string, value: unknown, extra: Record<string, unknown> = {}) => ({
+  uid: uuid(),
+  name,
+  value,
+  type: 'text',
+  enabled: true,
+  secret: false,
+  ...extra
+});
+
+// environmentSchema validates the uid length, so use real uids.
+const COLLECTION_UID = uuid();
+const ENVIRONMENT_UID = uuid();
+
+function makeState(variables: any[]): any {
+  return {
+    collections: {
+      collections: [{
+        uid: COLLECTION_UID,
+        name: 'My Collection',
+        pathname: '/collections/my-collection',
+        items: [],
+        activeEnvironmentUid: ENVIRONMENT_UID,
+        environments: [{ uid: ENVIRONMENT_UID, name: 'Local', variables }],
+        brunoConfig: {}
+      }]
+    }
+  };
+}
+
+async function persist(variables: any[], persistentEnvVariables: Record<string, unknown>) {
+  const getState = () => makeState(variables);
+  await mergeAndPersistEnvironment({ persistentEnvVariables, collectionUid: COLLECTION_UID } as any)(vi.fn(), getState);
+
+  const call = invoke.mock.calls.find(([channel]) => channel === 'renderer:save-environment');
+  expect(call, 'expected the environment to be saved').toBeDefined();
+  return call![2].variables as any[];
+}
+
+describe('script-written env vars are persisted without the __name__ metadata key', () => {
+  test('a script that sets a var does not materialize __name__', async () => {
+    const saved = await persist(
+      [envVar('seed', 'SEED')],
+      { seed: 'SEED', envTok: 'ENVVAL', __name__: 'Local' }
+    );
+
+    expect(saved.map((v) => v.name).sort()).toEqual(['envTok', 'seed']);
+    expect(saved.find((v) => v.name === 'envTok')?.value).toBe('ENVVAL');
+  });
+
+  test('a script that deletes every env var leaves the file empty, not holding __name__', async () => {
+    const saved = await persist([], { __name__: 'Local' });
+    expect(saved).toEqual([]);
+  });
+
+  test('deletions still reach disk while other vars are written', async () => {
+    const saved = await persist([], { envTok: 'ENVVAL', __name__: 'Local' });
+    expect(saved.map((v) => v.name)).toEqual(['envTok']);
+  });
+
+  test('data types of script-written values still round-trip', async () => {
+    const saved = await persist([], { timeout: 30, flag: true, __name__: 'Local' });
+
+    expect(saved.find((v) => v.name === 'timeout')).toMatchObject({ value: 30, dataType: 'number' });
+    expect(saved.find((v) => v.name === 'flag')).toMatchObject({ value: true, dataType: 'boolean' });
+    expect(saved.find((v) => v.name === '__name__')).toBeUndefined();
+  });
+});

--- a/tests/e2e/specs/script-set-vars.spec.ts
+++ b/tests/e2e/specs/script-set-vars.spec.ts
@@ -103,5 +103,7 @@ test.describe('Scripting: variable APIs', () => {
     const envFile = path.join(collectionDir, 'environments', 'Local.bru');
     await expect.poll(() => fs.readFileSync(envFile, 'utf8'), { timeout: 15_000 }).toContain('envTok: ENVVAL');
     expect(fs.readFileSync(envFile, 'utf8')).not.toContain('seed: SEED');
+
+    expect(fs.readFileSync(envFile, 'utf8')).not.toContain('__name__');
   });
 });


### PR DESCRIPTION
### Description
Jira: VSCODE-131
### Problem
`__name__` is shown on UI when environment variables are created/deleted through script(`bru.setEnvVar`/`bru.deleteEnvVar`)
### Fix
Ommitted `__name__ ` from persisted environment variables so it's not visible on UI.

### Screenshot
**Before**

https://github.com/user-attachments/assets/07f9df95-fb56-48e4-bdc5-148c8347c651


**After**

https://github.com/user-attachments/assets/f51ee244-081d-4571-95da-d30dd1d0bddb

