### PR TITLE
fix(timeline): log request timing in timeline network tab

### DIFF
--- a/src/extension/ipc/network/axios-instance.spec.ts
+++ b/src/extension/ipc/network/axios-instance.spec.ts
@@ -61,20 +61,22 @@ describe('axios-instance network log', () => {
       'info',
       'info',
       'request',
-      'info',
       'response',
+      'responseHeader',
       'responseHeader',
       'info'
     ]);
     expect(messagesOfType(timeline, 'request')).toEqual(['GET https://api.example.com/breeds']);
     expect(messagesOfType(timeline, 'response')).toEqual(['HTTP/1.1 200 OK']);
-    expect(messagesOfType(timeline, 'responseHeader')).toEqual(['content-type: application/json']);
+    expect(messagesOfType(timeline, 'responseHeader')).toEqual([
+      'content-type: application/json',
+      expect.stringMatching(/^request-duration: \d+$/)
+    ]);
 
     const infoMessages = messagesOfType(timeline, 'info');
     expect(infoMessages[0]).toBe('Preparing request to https://api.example.com/breeds');
     expect(infoMessages[1]).toMatch(/^Current time is \d{4}-\d{2}-\d{2}T/);
-    expect(infoMessages[2]).toBe('Proxy mode: off');
-    expect(infoMessages[3]).toMatch(/^Request completed in \d+ ms$/);
+    expect(infoMessages[2]).toMatch(/^Request completed in \d+ ms$/);
   });
 
   it('logs the request body', async () => {
@@ -107,19 +109,6 @@ describe('axios-instance network log', () => {
     expect(messagesOfType(timeline, 'requestData')).toEqual(['<request body redacted>']);
   });
 
-  it('names the proxy when one is configured', async () => {
-    const timeline: NetworkLogEntry[] = [];
-    const instance = createAxiosInstance({
-      timeline,
-      proxyMode: 'on',
-      proxyConfig: { protocol: 'http', hostname: 'proxy.local', port: 8080 }
-    });
-
-    await instance.request({ url: 'https://api.example.com/breeds', method: 'get', adapter: createStubAdapter([{}]) });
-
-    expect(messagesOfType(timeline, 'info')).toContain('Proxy mode: on | http://proxy.local:8080');
-  });
-
   it('reports HTTP/2 multiplexing', async () => {
     const timeline: NetworkLogEntry[] = [];
     const instance = createAxiosInstance({ timeline });
@@ -146,7 +135,10 @@ describe('axios-instance network log', () => {
 
     expect(messagesOfType(timeline, 'error')).toEqual(['there was an error executing the request!']);
     expect(messagesOfType(timeline, 'response')).toEqual(['HTTP/1.1 404 Not Found']);
-    expect(messagesOfType(timeline, 'responseHeader')).toEqual(['content-length: 9']);
+    expect(messagesOfType(timeline, 'responseHeader')).toEqual([
+      'content-length: 9',
+      expect.stringMatching(/^request-duration: \d+$/)
+    ]);
   });
 
   it('logs the cause of a request that never got a response', async () => {
@@ -191,6 +183,50 @@ describe('axios-instance network log', () => {
     expect(messagesOfType(timeline, 'info')).toContain(
       'Changed method from POST to GET for 301 redirect and removed request body'
     );
+  });
+
+  it('logs the method change of a redirect that was already a GET', async () => {
+    const timeline: NetworkLogEntry[] = [];
+    const instance = createAxiosInstance({ timeline });
+
+    await instance.request({
+      url: 'https://api.example.com/redirect',
+      method: 'get',
+      adapter: createStubAdapter([
+        { status: 302, statusText: 'Found', headers: { location: '/target' } },
+        { status: 200 }
+      ])
+    });
+
+    expect(messagesOfType(timeline, 'info')).toEqual([
+      'Preparing request to https://api.example.com/redirect',
+      expect.stringMatching(/^Current time is /),
+      expect.stringMatching(/^Request completed in \d+ ms$/),
+      'Resolving relative redirect URL: /target → https://api.example.com/target',
+      'Changed method from GET to GET for 302 redirect and removed request body',
+      'Proxy mode: off',
+      'SSL validation: disabled',
+      'Preparing request to https://api.example.com/target',
+      expect.stringMatching(/^Current time is /),
+      expect.stringMatching(/^Request completed in \d+ ms$/)
+    ]);
+  });
+
+  it('times each hop of a redirect chain separately', async () => {
+    const timeline: NetworkLogEntry[] = [];
+    const instance = createAxiosInstance({ timeline });
+
+    await instance.request({
+      url: 'https://api.example.com/old',
+      method: 'get',
+      adapter: createStubAdapter([
+        { status: 301, statusText: 'Moved Permanently', headers: { location: '/new' } },
+        { status: 200 }
+      ])
+    });
+
+    const durations = messagesOfType(timeline, 'responseHeader').filter((header) => header.startsWith('request-duration: '));
+    expect(durations).toHaveLength(2);
   });
 
   it('does not log when no timeline is passed', async () => {
@@ -337,7 +373,28 @@ describe('axios-instance connection log', () => {
     expect(headers).toContainEqual(expect.stringMatching(/^Accept-Encoding: gzip/));
     expect(headers).toContainEqual(expect.stringMatching(/^Host: 127\.0\.0\.1:\d+$/));
     expect(headers).toContain('Connection: keep-alive');
+    expect(headers).toContainEqual(expect.stringMatching(/^request-start-time: \d+$/));
     expect(headers).not.toContainEqual(expect.stringContaining('x-dropped'));
+  });
+
+  it('names the proxy between the header block and the connection trace', async () => {
+    const timeline: NetworkLogEntry[] = [];
+    const proxyPort = (server.address() as { port: number }).port;
+    const instance = createAxiosInstance({
+      timeline,
+      proxyMode: 'on',
+      proxyConfig: { protocol: 'http', hostname: '127.0.0.1', port: proxyPort }
+    });
+
+    const response = await instance.request({ url: 'http://api.example.com/ping', method: 'get' });
+    (response.data as Readable).resume();
+
+    const messages = timeline.map((entry) => (entry.message as string) ?? '');
+    const proxyLine = messages.indexOf(`Proxy mode: on | http://127.0.0.1:${proxyPort}`);
+    const lastHeader = messages.lastIndexOf(messagesOfType(timeline, 'requestHeader').at(-1) as string);
+
+    expect(proxyLine).toBeGreaterThan(lastHeader);
+    expect(proxyLine).toBeLessThan(messages.findIndex((message) => message.startsWith('Trying ')));
   });
 
   it('keeps the proxy password out of the log', async () => {

--- a/src/extension/ipc/network/axios-instance.spec.ts
+++ b/src/extension/ipc/network/axios-instance.spec.ts
@@ -183,6 +183,7 @@ describe('axios-instance network log', () => {
     expect(messagesOfType(timeline, 'info')).toContain(
       'Changed method from POST to GET for 301 redirect and removed request body'
     );
+    expect(messagesOfType(timeline, 'responseHeader').filter((header) => header.startsWith('request-duration: '))).toHaveLength(2);
   });
 
   it('logs the method change of a redirect that was already a GET', async () => {
@@ -212,7 +213,7 @@ describe('axios-instance network log', () => {
     ]);
   });
 
-  it('times each hop of a redirect chain separately', async () => {
+  it('leaves the SSL line off a redirect to a plaintext target', async () => {
     const timeline: NetworkLogEntry[] = [];
     const instance = createAxiosInstance({ timeline });
 
@@ -220,13 +221,13 @@ describe('axios-instance network log', () => {
       url: 'https://api.example.com/old',
       method: 'get',
       adapter: createStubAdapter([
-        { status: 301, statusText: 'Moved Permanently', headers: { location: '/new' } },
+        { status: 302, statusText: 'Found', headers: { location: 'http://api.example.com/new' } },
         { status: 200 }
       ])
     });
 
-    const durations = messagesOfType(timeline, 'responseHeader').filter((header) => header.startsWith('request-duration: '));
-    expect(durations).toHaveLength(2);
+    expect(messagesOfType(timeline, 'info')).toContain('Proxy mode: off');
+    expect(messagesOfType(timeline, 'info')).not.toContainEqual(expect.stringContaining('SSL validation'));
   });
 
   it('does not log when no timeline is passed', async () => {
@@ -390,10 +391,11 @@ describe('axios-instance connection log', () => {
     (response.data as Readable).resume();
 
     const messages = timeline.map((entry) => (entry.message as string) ?? '');
+    const proxyLines = messages.filter((message) => message.startsWith('Proxy mode:'));
     const proxyLine = messages.indexOf(`Proxy mode: on | http://127.0.0.1:${proxyPort}`);
-    const lastHeader = messages.lastIndexOf(messagesOfType(timeline, 'requestHeader').at(-1) as string);
 
-    expect(proxyLine).toBeGreaterThan(lastHeader);
+    expect(proxyLines).toEqual([`Proxy mode: on | http://127.0.0.1:${proxyPort}`]);
+    expect(proxyLine).toBeGreaterThan(typesOf(timeline).lastIndexOf('requestHeader'));
     expect(proxyLine).toBeLessThan(messages.findIndex((message) => message.startsWith('Trying ')));
   });
 

--- a/src/extension/ipc/network/axios-instance.ts
+++ b/src/extension/ipc/network/axios-instance.ts
@@ -12,7 +12,7 @@ import { getCookieStringForUrl, saveCookies } from '../../utils/cookies';
 import { preferencesUtil } from '../../store/preferences';
 import { safeStringifyJSON } from '../../utils/common';
 import { MultipartField, createFormData, formatMultipartData } from '../../utils/form-data';
-import { createConnectionLoggingTransport } from './connection-log';
+import { createConnectionLoggingTransport, sslValidationMessage } from './connection-log';
 import type { CACertificatesCount } from './cert-utils';
 
 // Import digest auth helper using require due to type declaration issues in @usebruno/requests
@@ -133,7 +133,10 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     proxy: false,
     httpsAgent: new https.Agent(agentOpts),
     headers: {
-      'User-Agent': 'bruno-runtime/1.0'
+      'User-Agent': 'bruno-runtime/1.0',
+      // VS Code's proxy agent drops the keep-alive agent below, so Node would otherwise fall back to
+      // its global agent and send `Connection: close` where the desktop app sends keep-alive.
+      Connection: 'keep-alive'
     }
   };
 
@@ -157,10 +160,12 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     timeline?.push({ timestamp: new Date(), type, message });
   };
 
-  const logResponseHeaders = (headers: Record<string, unknown>): void => {
+  /** `request-duration` is not a header the server sent; the desktop app appends it here and the timeline shows it. */
+  const logResponseHeaders = (headers: Record<string, unknown>, elapsedMs: number): void => {
     Object.entries(headers || {}).forEach(([name, value]) => {
       log('responseHeader', `${name}: ${value}`);
     });
+    log('responseHeader', `request-duration: ${elapsedMs}`);
   };
 
   const proxyModeMessage = proxyMode === 'on' && proxyConfig
@@ -174,11 +179,15 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     log,
     timeout,
     rejectUnauthorized: agentOpts.rejectUnauthorized,
-    caCertificatesCount: caCertificatesCount as Partial<CACertificatesCount> | undefined
+    caCertificatesCount: caCertificatesCount as Partial<CACertificatesCount> | undefined,
+    proxyModeMessage
   });
 
   instance.interceptors.request.use((requestConfig: InternalAxiosRequestConfig) => {
-    (requestConfig as TimedRequestConfig).metadata = { startTime: Date.now() };
+    const startTime = Date.now();
+    (requestConfig as TimedRequestConfig).metadata = { startTime };
+    // Sent on the wire, as the desktop app does, so the hop's start time is visible in the timeline.
+    requestConfig.headers['request-start-time'] = startTime;
 
     if (!timeline) {
       return requestConfig;
@@ -194,9 +203,8 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
       log('requestData', requestBody);
     }
 
-    log('info', proxyModeMessage);
-
-    // Headers are logged from the request the transport creates, where the wire set is complete.
+    // Headers and the proxy line are logged from the request the transport creates, where the wire
+    // set is complete.
     requestConfig.transport = connectionLoggingTransport;
 
     return requestConfig;
@@ -206,13 +214,14 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
 
   instance.interceptors.response.use(
     (response: AxiosResponse) => {
+      const elapsedMs = getElapsedMs(response.config);
       const httpVersion = getHttpVersion(response);
       if (httpVersion?.startsWith('2')) {
         log('info', 'Using HTTP/2, server supports multiplexing');
       }
       log('response', `HTTP/${httpVersion || '1.1'} ${response.status} ${response.statusText}`);
-      logResponseHeaders(response.headers as unknown as Record<string, unknown>);
-      log('info', `Request completed in ${getElapsedMs(response.config)} ms`);
+      logResponseHeaders(response.headers as unknown as Record<string, unknown>, elapsedMs);
+      log('info', `Request completed in ${elapsedMs} ms`);
 
       if (response.config.url && shouldStoreCookies()) {
         saveCookies(response.config.url, response.headers as Record<string, string | string[]>);
@@ -235,12 +244,14 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
         collectionPath?: string;
       };
 
+      const elapsedMs = getElapsedMs(error.config);
+
       log('error', 'there was an error executing the request!');
 
       if (error.response) {
         const httpVersion = getHttpVersion(error.response);
         log('response', `HTTP/${httpVersion || '1.1'} ${error.response.status} ${error.response.statusText}`);
-        logResponseHeaders(error.response.headers as unknown as Record<string, unknown>);
+        logResponseHeaders(error.response.headers as unknown as Record<string, unknown>, elapsedMs);
       } else {
         const cause = describeError(error.cause);
         if (cause) {
@@ -257,7 +268,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
       }
 
       if (error.response && redirectResponseCodes.includes(error.response.status)) {
-        log('info', `Request completed in ${getElapsedMs(error.config)} ms`);
+        log('info', `Request completed in ${elapsedMs} ms`);
 
         if (originalRequest.url && shouldStoreCookies()) {
           saveCookies(originalRequest.url, error.response.headers as Record<string, string | string[]>);
@@ -303,9 +314,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
             delete requestConfig.headers['content-type'];
             delete requestConfig.headers['Content-Type'];
           }
-          if (originalMethod !== 'get') {
-            log('info', `Changed method from ${originalMethod.toUpperCase()} to GET for ${statusCode} redirect and removed request body`);
-          }
+          log('info', `Changed method from ${originalMethod.toUpperCase()} to GET for ${statusCode} redirect and removed request body`);
         } else {
           if (requestConfig.data && typeof requestConfig.data === 'object' &&
               requestConfig.data.constructor && requestConfig.data.constructor.name === 'FormData') {
@@ -333,6 +342,10 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
             requestConfig.headers['cookie'] = cookieString;
           }
         }
+
+        // The hop is re-resolved against the proxy before it is sent, which the desktop app reports here.
+        log('info', proxyModeMessage);
+        log('info', sslValidationMessage(agentOpts.rejectUnauthorized));
 
         return instance(requestConfig);
       }

--- a/src/extension/ipc/network/axios-instance.ts
+++ b/src/extension/ipc/network/axios-instance.ts
@@ -134,8 +134,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     httpsAgent: new https.Agent(agentOpts),
     headers: {
       'User-Agent': 'bruno-runtime/1.0',
-      // VS Code's proxy agent drops the keep-alive agent above, so Node would otherwise fall back to
-      // its global agent and send `Connection: close` where the desktop app sends keep-alive.
+      // VS Code's proxy agent drops the agent above, and Node's global agent sends `Connection: close`.
       Connection: 'keep-alive'
     }
   };
@@ -160,7 +159,6 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     timeline?.push({ timestamp: new Date(), type, message });
   };
 
-  /** `request-duration` is not a header the server sent; the desktop app appends it here. */
   const logResponseHeaders = (headers: Record<string, unknown>, elapsedMs: number): void => {
     Object.entries(headers || {}).forEach(([name, value]) => {
       log('responseHeader', `${name}: ${value}`);
@@ -186,7 +184,6 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
   instance.interceptors.request.use((requestConfig: InternalAxiosRequestConfig) => {
     const startTime = Date.now();
     (requestConfig as TimedRequestConfig).metadata = { startTime };
-    // Sent on the wire, as the desktop app does.
     requestConfig.headers['request-start-time'] = startTime;
 
     if (!timeline) {
@@ -203,8 +200,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
       log('requestData', requestBody);
     }
 
-    // Headers and the proxy line are logged from the request the transport creates, where the wire
-    // set is complete.
+    // Headers and the proxy line are logged from the request the transport creates, where the wire set is complete.
     requestConfig.transport = connectionLoggingTransport;
 
     return requestConfig;
@@ -343,8 +339,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
           }
         }
 
-        // The desktop app re-resolves the proxy for the hop before sending it, so these repeat once
-        // more when the re-issued request reaches the transport.
+        // Repeated once more by the transport, as the desktop app does for every hop.
         log('info', proxyModeMessage);
         if (/^https:/i.test(redirectUrl)) {
           log('info', sslValidationMessage(agentOpts.rejectUnauthorized));

--- a/src/extension/ipc/network/axios-instance.ts
+++ b/src/extension/ipc/network/axios-instance.ts
@@ -134,7 +134,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     httpsAgent: new https.Agent(agentOpts),
     headers: {
       'User-Agent': 'bruno-runtime/1.0',
-      // VS Code's proxy agent drops the keep-alive agent below, so Node would otherwise fall back to
+      // VS Code's proxy agent drops the keep-alive agent above, so Node would otherwise fall back to
       // its global agent and send `Connection: close` where the desktop app sends keep-alive.
       Connection: 'keep-alive'
     }
@@ -160,7 +160,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
     timeline?.push({ timestamp: new Date(), type, message });
   };
 
-  /** `request-duration` is not a header the server sent; the desktop app appends it here and the timeline shows it. */
+  /** `request-duration` is not a header the server sent; the desktop app appends it here. */
   const logResponseHeaders = (headers: Record<string, unknown>, elapsedMs: number): void => {
     Object.entries(headers || {}).forEach(([name, value]) => {
       log('responseHeader', `${name}: ${value}`);
@@ -186,7 +186,7 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
   instance.interceptors.request.use((requestConfig: InternalAxiosRequestConfig) => {
     const startTime = Date.now();
     (requestConfig as TimedRequestConfig).metadata = { startTime };
-    // Sent on the wire, as the desktop app does, so the hop's start time is visible in the timeline.
+    // Sent on the wire, as the desktop app does.
     requestConfig.headers['request-start-time'] = startTime;
 
     if (!timeline) {
@@ -343,9 +343,12 @@ const createAxiosInstance = (options: AxiosInstanceOptions = {}): AxiosInstance 
           }
         }
 
-        // The hop is re-resolved against the proxy before it is sent, which the desktop app reports here.
+        // The desktop app re-resolves the proxy for the hop before sending it, so these repeat once
+        // more when the re-issued request reaches the transport.
         log('info', proxyModeMessage);
-        log('info', sslValidationMessage(agentOpts.rejectUnauthorized));
+        if (/^https:/i.test(redirectUrl)) {
+          log('info', sslValidationMessage(agentOpts.rejectUnauthorized));
+        }
 
         return instance(requestConfig);
       }

--- a/src/extension/ipc/network/connection-log.ts
+++ b/src/extension/ipc/network/connection-log.ts
@@ -14,7 +14,11 @@ export interface ConnectionLogOptions {
   timeout?: number;
   rejectUnauthorized?: boolean;
   caCertificatesCount?: Partial<CACertificatesCount>;
+  proxyModeMessage?: string;
 }
+
+export const sslValidationMessage = (rejectUnauthorized?: boolean): string =>
+  `SSL validation: ${rejectUnauthorized === false ? 'disabled' : 'enabled'}`;
 
 interface ConnectionTarget {
   host: string;
@@ -92,7 +96,7 @@ export const logConnection = (
   { log, rejectUnauthorized, caCertificatesCount }: ConnectionLogOptions
 ): void => {
   if (isHttps) {
-    log('info', `SSL validation: ${rejectUnauthorized === false ? 'disabled' : 'enabled'}`);
+    log('info', sslValidationMessage(rejectUnauthorized));
   }
 
   request.on('socket', (socket: Socket) => {
@@ -165,6 +169,12 @@ export const createConnectionLoggingTransport = (options: ConnectionLogOptions) 
     }
 
     logRequestHeaders(request, options.log);
+
+    // The desktop app resolves the proxy once the headers are written, so the line sits between the
+    // header block and the connection trace.
+    if (options.proxyModeMessage) {
+      options.log('info', options.proxyModeMessage);
+    }
 
     const host = requestOptions.hostname || requestOptions.host;
     if (host && !requestOptions.socketPath) {

--- a/src/extension/ipc/network/connection-log.ts
+++ b/src/extension/ipc/network/connection-log.ts
@@ -170,8 +170,7 @@ export const createConnectionLoggingTransport = (options: ConnectionLogOptions) 
 
     logRequestHeaders(request, options.log);
 
-    // The desktop app resolves the proxy once the headers are written, so the line sits between the
-    // header block and the connection trace.
+    // Sits between the header block and the connection trace, where the desktop app puts it.
     options.log('info', options.proxyModeMessage);
 
     const host = requestOptions.hostname || requestOptions.host;

--- a/src/extension/ipc/network/connection-log.ts
+++ b/src/extension/ipc/network/connection-log.ts
@@ -14,7 +14,7 @@ export interface ConnectionLogOptions {
   timeout?: number;
   rejectUnauthorized?: boolean;
   caCertificatesCount?: Partial<CACertificatesCount>;
-  proxyModeMessage?: string;
+  proxyModeMessage: string;
 }
 
 export const sslValidationMessage = (rejectUnauthorized?: boolean): string =>
@@ -172,9 +172,7 @@ export const createConnectionLoggingTransport = (options: ConnectionLogOptions) 
 
     // The desktop app resolves the proxy once the headers are written, so the line sits between the
     // header block and the connection trace.
-    if (options.proxyModeMessage) {
-      options.log('info', options.proxyModeMessage);
-    }
+    options.log('info', options.proxyModeMessage);
 
     const host = requestOptions.hostname || requestOptions.host;
     if (host && !requestOptions.socketPath) {

--- a/src/webview/components/Documentation/StyledWrapper.ts
+++ b/src/webview/components/Documentation/StyledWrapper.ts
@@ -4,6 +4,10 @@ const StyledWrapper = styled.div`
   .editing-mode {
     cursor: pointer;
   }
+
+  div.CodeMirror {
+    height: inherit;
+  }
 `;
 
 export default StyledWrapper;

--- a/src/webview/components/Documentation/index.tsx
+++ b/src/webview/components/Documentation/index.tsx
@@ -47,24 +47,26 @@ const Documentation = ({
 
   return (
     <StyledWrapper className="flex flex-col gap-y-1 h-full w-full relative">
-      <div className="editing-mode" role="tab" onClick={toggleViewMode}>
+      <div className="editing-mode flex-shrink-0" role="tab" onClick={toggleViewMode}>
         {isEditing ? 'Preview' : 'Edit'}
       </div>
 
-      {isEditing ? (
-        <CodeEditor
-          collection={collection}
-          theme={displayedTheme}
-          font={get(preferences, 'font.codeFont', 'default')}
-          fontSize={get(preferences, 'font.codeFontSize')}
-          value={docs || ''}
-          onEdit={onEdit}
-          onSave={onSave}
-          mode="application/text"
-        />
-      ) : (
-        <Markdown collectionPath={collection.pathname} onDoubleClick={toggleViewMode} content={docs} />
-      )}
+      <div className="flex-1 min-h-0">
+        {isEditing ? (
+          <CodeEditor
+            collection={collection}
+            theme={displayedTheme}
+            font={get(preferences, 'font.codeFont', 'default')}
+            fontSize={get(preferences, 'font.codeFontSize')}
+            value={docs || ''}
+            onEdit={onEdit}
+            onSave={onSave}
+            mode="application/text"
+          />
+        ) : (
+          <Markdown collectionPath={collection.pathname} onDoubleClick={toggleViewMode} content={docs} />
+        )}
+      </div>
     </StyledWrapper>
   );
 };


### PR DESCRIPTION
## Description

VSCODE-136

The Docs tab editor was stuck at a fixed height instead of using the full panel. The network timeline also differed from Desktop, with missing start time and duration per hop, closed connections instead of reuse, and incomplete redirect traces.

## Solution

The Docs editor now uses the available space below the Edit and Preview toggle. The timeline now records the start time and duration for each hop, keeps connections open, and matches the Desktop app’s proxy output. Redirects also show the method change, proxy details, and certificate check before the next hop.


## Recordings / Screenshots

**Before**

<img width="1860" height="851" alt="image-20260826-113153" src="https://github.com/user-attachments/assets/5d3876cf-27e9-4bfb-bc38-36626ffda91b" />

**After**

<img width="1427" height="752" alt="Screenshot 2026-08-28 at 1 23 15 PM" src="https://github.com/user-attachments/assets/28be8c62-820b-4ce7-acea-865317e43b8a" />
