### PR TITLE
fix(script-editor): keep autocomplete dropdown themed in graphql requests

### DIFF
--- a/src/webview/globalStyles.ts
+++ b/src/webview/globalStyles.ts
@@ -283,7 +283,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   // Autocomplete hints dropdown container
-  .CodeMirror-hints {
+  ul.CodeMirror-hints {
     position: absolute;
     overflow-y: auto;
     max-height: 20em;
@@ -303,9 +303,16 @@ const GlobalStyle = createGlobalStyle`
     padding: 0.25rem;
     font-size: ${(props) => props.theme.font.size.sm};
     font-family: inherit;
+    color: ${(props) => props.theme.dropdown.color};
   }
 
-  .CodeMirror-hint {
+  // graphiql colours this sidebar from a palette globals.css pins to black in every theme.
+  ul.CodeMirror-hints .CodeMirror-hint-information,
+  ul.CodeMirror-hints .CodeMirror-hint-information * {
+    color: ${(props) => props.theme.dropdown.color};
+  }
+
+  li.CodeMirror-hint {
     color: ${(props) => props.theme.dropdown.color};
     border-radius: ${(props) => props.theme.border.radius.base};
     line-height: 1.5rem;


### PR DESCRIPTION
## Description

Jira: VSCODE-156

bru API script dialogue highlighted with white background on Windows

## Root cause

GraphQL requests load the GraphiQL editor and its stylesheet is fetched only the first time. Its styles override Bruno’s autocomplete list styles and change the background, text colour and font.

## Solution

Bruno’s autocomplete styles now take priority over GraphiQL styles regardless of load order. GraphiQL styles are still loaded only when a GraphQL request is opened. Other request types remain unchanged.

## Recordings / Screenshots

**Before**

<!-- attach the recording/screenshot showing the broken behaviour -->

**After**

<!-- attach the recording/screenshot showing the fixed behaviour -->
