### PR TITLE
fix(prompt-variables): skip prompts that are commented out or unchecked

### DIFF
--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -134,7 +134,7 @@ declare module 'markdown-it' {
 
 declare module '@usebruno/common' {
   export function parseQueryParams(url: string): Array<{ name: string; value?: string }>;
-  export function extractPromptVariables(str: string): string[];
+  export function extractPromptVariables(value: unknown): string[];
   export function parsePathParams(url: string): Record<string, string>;
   export function getSubdirectoriesFromRoot(collection: unknown, item: unknown): string[];
   export function getContentType(headers: unknown[]): string;
@@ -147,7 +147,7 @@ declare module '@usebruno/common' {
 
 declare module '@usebruno/common/utils' {
   export function parseQueryParams(url: string): Array<{ name: string; value?: string }>;
-  export function extractPromptVariables(str: string): string[];
+  export function extractPromptVariables(value: unknown): string[];
   export function parsePathParams(url: string): Record<string, string>;
   export function getSubdirectoriesFromRoot(collection: unknown, item: unknown): string[];
   export function getContentType(headers: unknown[]): string;

--- a/src/webview/providers/ReduxStore/slices/collections/actions.tsx
+++ b/src/webview/providers/ReduxStore/slices/collections/actions.tsx
@@ -204,6 +204,7 @@ import { sanitizeName } from 'utils/common/regex';
 import { buildPersistedEnvVariables, applyScriptVars, getScriptModifiedKeys } from 'utils/environments';
 import { safeParseJSON, safeStringifyJSON } from 'utils/common/index';
 import { resolveInheritedAuth } from 'utils/auth';
+import { getPromptScannableBody, getPromptScannableParams } from 'utils/prompt-variables';
 import { addTab } from 'providers/ReduxStore/slices/tabs';
 import { updateSettingsSelectedTab } from './index';
 import { saveGlobalEnvironment } from 'providers/ReduxStore/slices/global-environments';
@@ -683,11 +684,9 @@ const extractPromptVariablesForRequest = async (item: AppItem, collection: AppCo
 
     // Attempt to extract unique prompt variables from anywhere in the request and environment variables.
     prompts.push(...extractPromptVariables(allVariables));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const bodyContent = (request.body as any)?.[request.body?.mode as string];
-    prompts.push(...extractPromptVariables(bodyContent));
+    prompts.push(...extractPromptVariables(getPromptScannableBody(request.body)));
     prompts.push(...extractPromptVariables(headers as any));
-    prompts.push(...extractPromptVariables((request as any).params));
+    prompts.push(...extractPromptVariables(getPromptScannableParams((request as any).params)));
     prompts.push(...extractPromptVariables(resolvedAuthRequest.auth));
     prompts.push(...extractPromptVariables(request.url));
 

--- a/src/webview/utils/prompt-variables/index.spec.ts
+++ b/src/webview/utils/prompt-variables/index.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { getPromptScannableBody, getPromptScannableParams } from './index';
+import { extractPromptVariables } from '../../shims/bruno-common-utils';
+
+const promptsIn = (body: any) => extractPromptVariables(getPromptScannableBody(body)).sort();
+
+describe('getPromptScannableBody', () => {
+  describe('json body', () => {
+    it('ignores prompts on a commented out line', () => {
+      const json = ['{', '  "title": "{{?Live}}",', '  // "draft": "{{?Commented}}"', '}'].join('\n');
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Live']);
+    });
+
+    it('ignores prompts inside a block comment', () => {
+      const json = ['{', '  /*', '    "draft": "{{?Commented}}"', '  */', '  "title": "{{?Live}}"', '}'].join('\n');
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Live']);
+    });
+
+    it('keeps a prompt in a string that contains //', () => {
+      const json = '{ "url": "https://example.com/{{?Path}}" }';
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Path']);
+    });
+
+    it('keeps a prompt after an escaped quote', () => {
+      const json = '{ "quoted": "say \\"hi\\"", "title": "{{?Live}}" }';
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Live']);
+    });
+
+    it('keeps a prompt in a single quoted string that contains //', () => {
+      const json = "{'url': 'https://example.com/{{?Path}}'}";
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Path']);
+    });
+
+    it('keeps prompts after an unterminated block comment rather than dropping them', () => {
+      const json = ['{', '  "a": "x", /* never closed', '  "title": "{{?Live}}"', '}'].join('\n');
+      expect(promptsIn({ mode: 'json', json })).toEqual(['Live']);
+    });
+  });
+
+  describe('graphql body', () => {
+    it('ignores prompts on a # commented line in the query', () => {
+      const query = ['query {', '  user(id: "{{?Id}}") {', '    # name(alias: "{{?Commented}}")', '  }', '}'].join('\n');
+      expect(promptsIn({ mode: 'graphql', graphql: { query, variables: '{}' } })).toEqual(['Id']);
+    });
+
+    it('ignores prompts commented out in the variables', () => {
+      const variables = ['{', '  "id": "{{?Id}}"', '  // "old": "{{?Commented}}"', '}'].join('\n');
+      expect(promptsIn({ mode: 'graphql', graphql: { query: 'query {}', variables } })).toEqual(['Id']);
+    });
+  });
+
+  describe('disabled rows', () => {
+    it('skips unchecked form url encoded fields', () => {
+      const body = {
+        mode: 'formUrlEncoded',
+        formUrlEncoded: [
+          { uid: '1', name: 'a', value: '{{?Live}}', enabled: true },
+          { uid: '2', name: 'b', value: '{{?Unchecked}}', enabled: false }
+        ]
+      };
+      expect(promptsIn(body)).toEqual(['Live']);
+    });
+
+    it('skips unchecked multipart fields', () => {
+      const body = {
+        mode: 'multipartForm',
+        multipartForm: [
+          { uid: '1', type: 'text', name: 'a', value: '{{?Live}}', enabled: true },
+          { uid: '2', type: 'text', name: 'b', value: '{{?Unchecked}}', enabled: false }
+        ]
+      };
+      expect(promptsIn(body)).toEqual(['Live']);
+    });
+
+    it('only scans the selected file body entry', () => {
+      const body = {
+        mode: 'file',
+        file: [
+          { uid: '1', filePath: '/tmp/{{?Unselected}}.json', selected: false },
+          { uid: '2', filePath: '/tmp/{{?Selected}}.json', selected: true }
+        ]
+      };
+      expect(promptsIn(body)).toEqual(['Selected']);
+    });
+
+    it('falls back to the first file entry when none is marked selected', () => {
+      const body = { mode: 'file', file: [{ uid: '1', filePath: '/tmp/{{?First}}.json' }] };
+      expect(promptsIn(body)).toEqual(['First']);
+    });
+  });
+
+  it('only scans the active body mode', () => {
+    const body = { mode: 'text', text: '{{?Live}}', json: '{ "old": "{{?Inactive}}" }' };
+    expect(promptsIn(body)).toEqual(['Live']);
+  });
+
+  it('returns nothing for a body with no mode', () => {
+    expect(getPromptScannableBody(undefined)).toBeUndefined();
+    expect(getPromptScannableBody({ mode: 'none' } as any)).toBeUndefined();
+  });
+});
+
+describe('getPromptScannableParams', () => {
+  it('skips unchecked query params', () => {
+    const params = [
+      { uid: '1', name: 'a', value: '{{?Live}}', type: 'query', enabled: true },
+      { uid: '2', name: 'b', value: '{{?Unchecked}}', type: 'query', enabled: false }
+    ];
+    expect(extractPromptVariables(getPromptScannableParams(params))).toEqual(['Live']);
+  });
+
+  it('keeps path params, which carry no enabled flag of their own', () => {
+    const params = [{ uid: '1', name: 'id', value: '{{?PathId}}', type: 'path' }];
+    expect(extractPromptVariables(getPromptScannableParams(params))).toEqual(['PathId']);
+  });
+
+  it('tolerates a missing params list', () => {
+    expect(getPromptScannableParams(undefined)).toEqual([]);
+  });
+});

--- a/src/webview/utils/prompt-variables/index.ts
+++ b/src/webview/utils/prompt-variables/index.ts
@@ -1,0 +1,64 @@
+interface ScannableBody {
+  mode?: string | null;
+  json?: string | null;
+  graphql?: { query?: string | null; variables?: string | null } | null;
+  [key: string]: unknown;
+}
+
+interface EnabledRow {
+  enabled?: boolean;
+}
+
+interface FileRow {
+  filePath?: string | null;
+  selected?: boolean;
+}
+
+const STRING_LITERAL = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/.source;
+const JSON_COMMENT = new RegExp(`(${STRING_LITERAL})|//[^\\n]*|/\\*[\\s\\S]*?\\*/`, 'g');
+const GRAPHQL_COMMENT = new RegExp(`(${STRING_LITERAL})|#[^\\n]*`, 'g');
+
+// Unterminated comments and quotes match nothing, so ambiguous text is kept and over-prompts
+// rather than losing a live token.
+const stripComments = (text: string, pattern: RegExp): string =>
+  text.replace(pattern, (_match, stringLiteral) => stringLiteral ?? '');
+
+const enabledRows = (rows: unknown): unknown[] =>
+  Array.isArray(rows) ? rows.filter((row: EnabledRow) => row?.enabled !== false) : [];
+
+// Kept in step with getSelectedFileBodyEntry in the extension host, which the webview cannot import.
+const selectedFile = (files: unknown): unknown[] => {
+  if (!Array.isArray(files)) {
+    return [];
+  }
+  const candidates = files.filter((file: FileRow) => file?.filePath?.trim());
+  const entry = candidates.find((file: FileRow) => file?.selected) ?? candidates[0];
+  return entry ? [entry] : [];
+};
+
+export const getPromptScannableParams = enabledRows;
+
+export const getPromptScannableBody = (body?: unknown): unknown => {
+  const scannable = body as ScannableBody | null | undefined;
+  if (!scannable?.mode) {
+    return undefined;
+  }
+
+  switch (scannable.mode) {
+    case 'json':
+      return stripComments(scannable.json ?? '', JSON_COMMENT);
+    case 'graphql':
+      return {
+        query: stripComments(scannable.graphql?.query ?? '', GRAPHQL_COMMENT),
+        variables: stripComments(scannable.graphql?.variables ?? '', JSON_COMMENT)
+      };
+    case 'formUrlEncoded':
+      return enabledRows(scannable.formUrlEncoded);
+    case 'multipartForm':
+      return enabledRows(scannable.multipartForm);
+    case 'file':
+      return selectedFile(scannable.file);
+    default:
+      return scannable[scannable.mode];
+  }
+};

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -424,6 +424,31 @@ export async function addRequestHeader(
 }
 
 /**
+ * Add a query param row on the Params tab (the first of its two EditableTables).
+ */
+export async function addQueryParam(
+  page: Page,
+  editor: Frame,
+  name: string,
+  value: string,
+  { enabled = true }: { enabled?: boolean } = {}
+): Promise<void> {
+  await openRequestTab(editor, 'params');
+
+  const rows = buildCommonLocators(editor).editableTable.firstTableRows();
+  await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+  const emptyRowIdx = (await rows.count()) - 1;
+  const row = buildCommonLocators(rows.nth(emptyRowIdx)).editableTable;
+
+  await row.columnNameInput().fill(name);
+  await setCodeMirrorValue(page, row.columnValueEditor(), value);
+
+  if (!enabled) {
+    await row.columnCheckbox().uncheck();
+  }
+}
+
+/**
  * Switch the request to Bearer auth and set the token, entirely via the Auth tab.
  */
 export async function setBearerToken(page: Page, editor: Frame, token: string): Promise<void> {

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -86,7 +86,8 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     firstTableRows: () => frame.getByTestId('editable-table').first().locator('tbody tr'),
     columnNameEditor: () => frame.getByTestId('column-name').locator('.CodeMirror'),
     columnNameInput: () => frame.getByTestId('column-name').locator('input'),
-    columnValueEditor: () => frame.getByTestId('column-value').locator('.CodeMirror')
+    columnValueEditor: () => frame.getByTestId('column-value').locator('.CodeMirror'),
+    columnCheckbox: () => frame.getByTestId('column-checkbox')
   },
   auth: {
     modeSelector: () => frame.locator('.auth-mode-selector'),

--- a/tests/e2e/variables/prompt-variable/prompt-variables.spec.ts
+++ b/tests/e2e/variables/prompt-variable/prompt-variables.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../../utils/fixtures';
 import {
   addRequestHeader,
+  addQueryParam,
   setBearerToken,
   fillJsonBody,
   addRequestVar,
@@ -182,6 +183,33 @@ test.describe('Prompt variables — HTTP send', () => {
     await clickSend(editor);
 
     // No modal blocks the send — the response arrives directly.
+    await expectSentWithoutPrompt(page, editor);
+  });
+
+  test('a prompt on a commented out body line does not trigger the modal', async ({ page, tmpDir }) => {
+    const sidebar = await setupCollection(page, tmpDir, 'PV Commented');
+
+    // /raw-body echoes the body as sent, so a commented JSON body does not fail to parse.
+    const editor = await newHttpRequest(
+      page, sidebar, 'PV Commented', 'Commented Prompt', `${SERVER}/raw-body`, 'POST'
+    );
+    await fillJsonBody(page, editor, '{\n"marker":"sent"\n// ,"draft":"{{?Commented}}"\n}');
+
+    await clickSend(editor);
+
+    await expectSentWithoutPrompt(page, editor);
+  });
+
+  test('a prompt in an unchecked query param does not trigger the modal', async ({ page, tmpDir }) => {
+    const sidebar = await setupCollection(page, tmpDir, 'PV Unchecked');
+
+    const editor = await newHttpRequest(
+      page, sidebar, 'PV Unchecked', 'Unchecked Prompt', `${SERVER}/api/echo/query?marker=sent`
+    );
+    await addQueryParam(page, editor, 'token', '{{?Unchecked}}', { enabled: false });
+
+    await clickSend(editor);
+
     await expectSentWithoutPrompt(page, editor);
   });
 


### PR DESCRIPTION
## Description

Jira: VSCODE-148

The prompt variable is still working even after being commented out or disabled in the Variables tab and Params.

It scans the entire request as one block of text when finding prompt variables. It does not account for disabled rows or commented lines.


## Solution

Prompt collection now checks only the parts of the request that are actually sent. Disabled query params and form fields are skipped along with body text inside comments. For unclear cases like unclosed comments or stray quotes the text is still scanned to avoid missing real prompts.

## Recordings / Screenshots

**Before**

https://github.com/user-attachments/assets/6a2d7e75-c509-45ba-8d97-8222add6296b


<!-- attach the recording/screenshot showing the broken behaviour -->

**After**
<img width="1464" height="753" alt="Screenshot 2026-08-31 at 9 01 41 PM" src="https://github.com/user-attachments/assets/3ce0ea4a-2a12-4d3a-94b7-b2360dfdf252" />

<!-- attach the recording/screenshot showing the fixed behaviour -->
