### PR TITLE
feat(params): implement description column in query pane

### DIFF
--- a/src/webview/components/RequestPane/QueryParams/index.tsx
+++ b/src/webview/components/RequestPane/QueryParams/index.tsx
@@ -101,6 +101,28 @@ const QueryParams = ({
           placeholder={isLastEmptyRow ? 'Value' : ''}
         />
       )
+    },
+    {
+      key: 'description',
+      name: 'Description',
+      placeholder: 'Description',
+      render: ({
+        row,
+        value,
+        onChange,
+        isLastEmptyRow
+      }: any) => (
+        <MultiLineEditor
+          value={value || ''}
+          theme={storedTheme}
+          onSave={onSave}
+          onChange={onChange}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+          placeholder={isLastEmptyRow ? 'Description' : ''}
+        />
+      )
     }
   ];
 

--- a/src/webview/components/RequestPane/QueryParams/index.tsx
+++ b/src/webview/components/RequestPane/QueryParams/index.tsx
@@ -153,7 +153,27 @@ const QueryParams = ({
           item={item}
         />
       )
-    }
+    },
+    {
+      key: "description",
+      name: "Description",
+      placeholder: "Description",
+      render: ({ 
+        row, 
+        value, 
+        onChange 
+      }: any) => (
+        <MultiLineEditor
+          value={value || ""}
+          theme={storedTheme}
+          onSave={onSave}
+          onChange={(newValue: any) => handlePathParamChange(row.uid, "description", newValue)}
+          onRun={handleRun}
+          collection={collection}
+          item={item}
+        />
+      ),
+    },
   ];
 
   const defaultQueryRow = {


### PR DESCRIPTION
## feat(query params): implement description column in query params pane

### Description
Adds a **Description** column to the query params table in the request pane, mirroring how the existing **Value** column works.

This brings the VS Code extension in line with the Bruno desktop app, which already supports descriptions for query params, so users get a consistent experience across both.

### Changes
- Added a new `description` column to the `QueryParams` component's column config
- Reused the `MultiLineEditor` component (theme, `onSave`, `onChange`, `onRun`, `collection`, `item`) to keep the editing experience consistent with the other columns
- Shows a `"Description"` placeholder on the last empty row, matching the Value column's behavior