### PR TITLE
fix: set quickjs as default sandbox

### DIFF
--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -43,9 +43,8 @@ const getJsSandboxRuntime = (collection: Record<string, unknown>): string => {
     return 'nodevm';
   }
 
-  /** QuickJS's wasm sandbox can't be esbuild-bundled (its ESM loader needs `import.meta.url`), so it
-   *  fails to init and every script silently throws; node-vm bundles cleanly. */
-  return 'nodevm';
+  // default runtime is `quickjs`
+  return 'quickjs';
 };
 
 const promisifyStream = async (stream: Readable): Promise<Buffer> => {

--- a/src/webview/utils/codemirror/autocomplete.ts
+++ b/src/webview/utils/codemirror/autocomplete.ts
@@ -91,6 +91,7 @@ const STATIC_API_HINTS = {
     'bru.getTestResults()',
     'bru.sleep(ms)',
     'bru.getCollectionName()',
+    'bru.isSafeMode()',
     'bru.getGlobalEnvVar(key)',
     'bru.setGlobalEnvVar(key, value)',
     'bru.runner',


### PR DESCRIPTION
### Description
Jira: VSCODE-129
### Problem
`bru.isSafeMode()` is not working.
### Fix
`nodevm` was returned as sandbox even for Safe Mode. Now `quickjs` is returned as sandbox for Safe Mode. `nodevm` sandbox is returned for Developer Mode only.