### PR TITLE
fix(file/binary body): Send empty body if empty row is selected.

### DIFF
--- a/src/extension/ipc/network/index.ts
+++ b/src/extension/ipc/network/index.ts
@@ -740,11 +740,13 @@ const prepareItemRequest = (item: unknown, collection: unknown): BrunoRequest =>
         break;
       case 'file': {
         const selectedFile = getSelectedFileBodyEntry(body.file);
-        headers.push({
-          name: 'content-type',
-          value: (selectedFile?.contentType || '').trim() || DEFAULT_FILE_BODY_CONTENT_TYPE,
-          enabled: true
-        });
+        if(selectedFile){
+          headers.push({
+            name: 'content-type',
+            value: (selectedFile?.contentType || '').trim() || DEFAULT_FILE_BODY_CONTENT_TYPE,
+            enabled: true
+          });
+        }
         break;
       }
       case 'graphql':

--- a/src/extension/utils/file-body.ts
+++ b/src/extension/utils/file-body.ts
@@ -19,7 +19,7 @@ export const getSelectedFileBodyEntry = (files: FileBodyEntry[] | null | undefin
   if (!candidates.length) {
     return undefined;
   }
-  return candidates.find((file) => file.selected) || candidates[0];
+  return candidates.find((file) => file.selected);
 };
 
 /**


### PR DESCRIPTION
### Description
Jira: VSCODE-64
### Problem
In file/binary body mode, when empty row is selected, it is sending first row's file as request body.
### Fix
Sending empty body when empty row is selected. Send the file/binary body data only when row with file is selected.