### PR TITLE
Fix(windows-test):display folder/request name properly and disable secondary sidebar

### DIFF
--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -102,6 +102,8 @@ function writeVSCodeSettings(userDataDir: string): void {
       'security.workspace.trust.enabled': false,
       'extensions.ignoreRecommendations': true,
       'github.copilot.enable': false,
+      'chat.disableAIFeatures': true,
+      'workbench.secondarySideBar.defaultVisibility': 'hidden',
       'workbench.welcomePage.walkthroughs.openOnInstall': false,
       'workbench.accounts.experimental.showEntitlements': false,
       'accessibility.signUpPlaceholder': false,
@@ -138,6 +140,28 @@ function launchVSCode(
   return proc;
 }
 
+function makeTempDir(prefix: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    if (process.platform !== 'win32') {
+      return dir;
+    }
+    const longPath = fs.realpathSync.native(dir);
+    return longPath.replace(/^([A-Za-z]):/, (_match, drive: string) => `${drive.toLowerCase()}:`);
+  }
+
+async function ensureSecondarySidebarClosed(page: Page): Promise<void> {
+  const auxiliaryBar = page.locator('.part.auxiliarybar');
+  const isVisible = await auxiliaryBar.isVisible().catch(() => false);
+  if (!isVisible) return;
+
+  await page.keyboard.press('F1');
+  await page.waitForSelector('.quick-input-widget').catch(() => {});
+  await page.keyboard.type('View: Close Secondary Side Bar');
+  await page.keyboard.press('Enter');
+
+  await auxiliaryBar.waitFor({ state: 'hidden'}).catch(() => {});
+}
+
 /** Wait for the VS Code workbench UI to be ready */
 async function waitForWorkbench(page: Page): Promise<void> {
   // Wait for the monaco workbench shell to exist
@@ -156,6 +180,7 @@ async function waitForWorkbench(page: Page): Promise<void> {
   } catch {
     // Dialog didn't appear — that's fine
   }
+  await ensureSecondarySidebarClosed(page);
 
   // Small extra buffer for extension activation
   await new Promise(r => setTimeout(r, 2_000));
@@ -164,10 +189,10 @@ async function waitForWorkbench(page: Page): Promise<void> {
 export const test = base.extend<VSCodeFixture>({
   page: async ({}, use) => {
     const debugPort = await getFreePort();
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-vscode-test-'));
+    const userDataDir = makeTempDir('bruno-vscode-test-');
 
     // Create a temp workspace folder so the extension host has a workspace to run against
-    const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-workspace-'));
+    const workspacePath = makeTempDir('bruno-workspace-');
 
     writeVSCodeSettings(userDataDir);
 
@@ -225,7 +250,7 @@ export const test = base.extend<VSCodeFixture>({
   },
 
   tmpDir: async ({}, use) => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bruno-test-collections-'));
+    const dir = makeTempDir('bruno-test-collections-');
     await use(dir);
     fs.rmSync(dir, { recursive: true, force: true });
   },


### PR DESCRIPTION
**Description**

JIRA: VSCODE-158

This fix address the folder/request name displayed in the Windows and disables the secondary sidebar while an automation script is being executed in the VS Code extension.

**Problem**
Folder/request names were incorrectly displayed as (..) instead of showing the actual name.
The secondary sidebar remained visible while executing automation scripts.

**Fix**
Updated the folder/request name handling to display the correct name instead of (..).
Disabled the secondary sidebar during automation script execution in the VS Code extension.