### PR TITLE
fix(script-errors): report folder and collection errors from unsaved scripts

### DIFF
--- a/src/extension/editors/bruno-editor-provider.ts
+++ b/src/extension/editors/bruno-editor-provider.ts
@@ -9,7 +9,8 @@ import {
   setCurrentWebview,
   clearCurrentWebview,
   handleInvoke,
-  hasHandler
+  hasHandler,
+  registerHandler
 } from '../ipc/handlers';
 import {
   openCollection,
@@ -43,10 +44,17 @@ interface CollectionLoadParams {
   webviewPanel: vscode.WebviewPanel;
 }
 
+interface ScriptErrorFocus {
+  scriptPhase: string;
+  line?: number;
+}
+
 const pendingVariablesModeRequests = new Map<string, { collectionRoot: string }>();
 const pendingNotLoadedRequests = new Map<string, { parentCollectionRoot: string }>();
+const pendingScriptErrorFocus = new Map<string, ScriptErrorFocus>();
 // Stores view data per webview so renderer:ready can re-send as fallback
 const viewDataByWebview = new Map<vscode.Webview, Record<string, unknown>>();
+const webviewByFilePath = new Map<string, vscode.Webview>();
 
 export function setPendingVariablesMode(filePath: string, collectionRoot: string): void {
   pendingVariablesModeRequests.set(filePath, { collectionRoot });
@@ -54,6 +62,35 @@ export function setPendingVariablesMode(filePath: string, collectionRoot: string
 
 export function setPendingNotLoadedRequest(filePath: string, parentCollectionRoot: string): void {
   pendingNotLoadedRequests.set(filePath, { parentCollectionRoot });
+}
+
+export function registerScriptErrorSourceHandler(): void {
+  registerHandler('renderer:reveal-script-error-source', async (args: unknown[]) => {
+    const [payload] = args as [{ filePath?: string; scriptPhase?: string; line?: number }];
+
+    if (!payload?.filePath || !payload.scriptPhase || !fs.existsSync(payload.filePath)) {
+      return { success: false };
+    }
+
+    const focus: ScriptErrorFocus = { scriptPhase: payload.scriptPhase, line: payload.line };
+    const key = path.normalize(payload.filePath);
+    pendingScriptErrorFocus.set(key, focus);
+
+    await ensureBrunoEditorIntent(payload.filePath, 'default');
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      vscode.Uri.file(payload.filePath),
+      BrunoEditorProvider.viewType
+    );
+
+    const webview = webviewByFilePath.get(key);
+    const viewData = webview && viewDataByWebview.get(webview);
+    if (webview && viewData && pendingScriptErrorFocus.delete(key)) {
+      stateManager.sendTo(webview, 'main:set-view', { ...viewData, focusScriptError: focus });
+    }
+
+    return { success: true };
+  });
 }
 
 const currentIntentByFilePath = new Map<string, string>();
@@ -108,6 +145,7 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
     stateManager.addWebview(webviewPanel.webview);
 
     registerDocument(document);
+    webviewByFilePath.set(path.normalize(filePath), webviewPanel.webview);
 
     const collectionRoot = findCollectionRoot(filePath);
 
@@ -141,6 +179,7 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
       stateManager.removeWebview(webviewPanel.webview);
       unregisterDocument(document.uri.fsPath);
       viewDataByWebview.delete(webviewPanel.webview);
+      webviewByFilePath.delete(path.normalize(document.uri.fsPath));
       currentIntentByFilePath.delete(document.uri.fsPath);
     });
 
@@ -293,7 +332,16 @@ export class BrunoEditorProvider implements vscode.CustomTextEditorProvider {
         }
 
         viewDataByWebview.set(webviewPanel.webview, viewData);
-        stateManager.sendTo(webviewPanel.webview, 'main:set-view', viewData);
+
+        const focusKey = path.normalize(filePath);
+        const focusScriptError = pendingScriptErrorFocus.get(focusKey);
+        pendingScriptErrorFocus.delete(focusKey);
+
+        stateManager.sendTo(
+          webviewPanel.webview,
+          'main:set-view',
+          focusScriptError ? { ...viewData, focusScriptError } : viewData
+        );
 
         // Collection/folder settings dashboards need the full request tree (e.g.
         // the Overview shows request counts). The single-request open above only

--- a/src/extension/editors/dirty-state-manager.ts
+++ b/src/extension/editors/dirty-state-manager.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { registerHandler } from '../ipc/handlers';
+import { setUnsavedRoot, clearUnsavedRootForFile } from '../store/unsaved-roots';
 import { DIRTY_MARKER, dirtyMarkerOffsets, stripDirtyMarker } from '../utils/dirty-marker';
 import { hasRequestExtension } from '../utils/filesystem';
+import type { FolderRoot } from '@bruno-types';
 
 interface DirtyDocument {
   filePath: string;
@@ -41,6 +43,7 @@ export function unregisterDocument(filePath: string): void {
   const normalizedPath = normalizePath(filePath);
   registeredDocuments.delete(normalizedPath);
   dirtyDocuments.delete(normalizedPath);
+  clearUnsavedRootForFile(filePath);
 }
 
 export function getRegisteredDocument(filePath: string): vscode.TextDocument | undefined {
@@ -283,6 +286,7 @@ export function registerDirtyStateHandlers(): void {
       collectionUid: string;
       itemType: 'request' | 'folder' | 'collection';
       isDirty: boolean;
+      root?: FolderRoot;
     }];
 
     if (!payload) {
@@ -291,6 +295,9 @@ export function registerDirtyStateHandlers(): void {
     }
 
     if (payload.isDirty) {
+      if (payload.root && payload.itemType !== 'request') {
+        setUnsavedRoot(payload.itemType, payload.filePath, payload.root);
+      }
       await markDocumentDirty(
         payload.filePath,
         payload.itemUid,
@@ -298,6 +305,7 @@ export function registerDirtyStateHandlers(): void {
         payload.itemType
       );
     } else {
+      clearUnsavedRootForFile(payload.filePath);
       await markDocumentClean(payload.filePath);
     }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -31,7 +31,7 @@ import collectionWatcher, { setMessageSender as setWatcherMessageSender } from '
 import { setMessageSender as setCollectionsMessageSender, setEventEmitter as setCollectionsEventEmitter } from './app/collections';
 
 import { stateManager } from './webview/state-manager';
-import { BrunoEditorProvider } from './editors/bruno-editor-provider';
+import { BrunoEditorProvider, registerScriptErrorSourceHandler } from './editors/bruno-editor-provider';
 import { SidebarViewProvider } from './views/SidebarViewProvider';
 import { WorkspaceCollectionsProvider } from './views/WorkspaceCollectionsProvider';
 import { LogsViewProvider } from './views/LogsViewProvider';
@@ -65,6 +65,7 @@ function registerIpcHandlers(): void {
   registerGlobalEnvironmentsIpc();
   registerNetworkIpc();
   registerDirtyStateHandlers();
+  registerScriptErrorSourceHandler();
 
   registerWorkspaceIpc({
     addWatcher: (_workspacePath: string) => {},

--- a/src/extension/store/unsaved-roots.ts
+++ b/src/extension/store/unsaved-roots.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import type { FolderRoot } from '@bruno-types';
+
+type RootScope = 'collection' | 'folder';
+
+interface ParkedRoot {
+  sourceFile: string;
+  root: FolderRoot;
+}
+
+const unsavedRoots = new Map<string, ParkedRoot>();
+
+const keyFor = (scope: RootScope, dirPath: string): string => `${scope}:${path.normalize(dirPath)}`;
+
+export const setUnsavedRoot = (scope: RootScope, filePath: string, root: FolderRoot): void => {
+  unsavedRoots.set(keyFor(scope, path.dirname(filePath)), { sourceFile: path.normalize(filePath), root });
+};
+
+export const clearUnsavedRootForFile = (filePath: string): void => {
+  const sourceFile = path.normalize(filePath);
+  for (const [key, parked] of unsavedRoots) {
+    if (parked.sourceFile === sourceFile) {
+      unsavedRoots.delete(key);
+    }
+  }
+};
+
+export const getUnsavedRoot = (scope: RootScope, dirPath?: string): FolderRoot | undefined =>
+  dirPath ? unsavedRoots.get(keyFor(scope, dirPath))?.root : undefined;

--- a/src/extension/utils/collection.ts
+++ b/src/extension/utils/collection.ts
@@ -11,6 +11,7 @@ import { posixifyPath, getCollectionFormat } from './filesystem';
 import { getRequestUid, getExampleUid } from '../cache/requestUids';
 import { uuid } from './common';
 import { preferencesUtil } from '../store/preferences';
+import { getUnsavedRoot } from '../store/unsaved-roots';
 
 const FORMAT_CONFIG = {
   yml: { collectionFile: 'opencollection.yml', folderFile: 'folder.yml' },
@@ -214,12 +215,21 @@ interface Request {
   tags?: string[];
 }
 
+const effectiveCollectionRoot = (collection: Collection): CollectionRoot =>
+  collection?.draft?.root
+    || (getUnsavedRoot('collection', collection?.pathname) as CollectionRoot | undefined)
+    || collection?.root
+    || {};
+
+const effectiveFolderRoot = (folder: Item): CollectionRoot | undefined =>
+  folder?.draft?.root
+    || (getUnsavedRoot('folder', folder?.pathname) as CollectionRoot | undefined)
+    || folder?.root;
+
 const mergeHeaders = (collection: Collection, request: Request, requestTreePath: Item[]): void => {
   const headers = new Map<string, string>();
 
-  const collectionHeaders: Header[] = collection?.draft?.root
-    ? get(collection, 'draft.root.request.headers', [])
-    : get(collection, 'root.request.headers', []);
+  const collectionHeaders: Header[] = get(effectiveCollectionRoot(collection), 'request.headers', []);
 
   collectionHeaders.forEach((header) => {
     if (header.enabled) {
@@ -233,8 +243,7 @@ const mergeHeaders = (collection: Collection, request: Request, requestTreePath:
 
   for (const i of requestTreePath) {
     if (i.type === 'folder') {
-      const folderRoot = i?.draft || i?.root;
-      const _headers: Header[] = get(folderRoot, 'request.headers', []);
+      const _headers: Header[] = get(effectiveFolderRoot(i), 'request.headers', []);
       _headers.forEach((header) => {
         if (header.enabled) {
           if (header.name.toLowerCase() === 'content-type') {
@@ -268,7 +277,7 @@ const rawValue = (_var: Variable): VariableValue => _var.value;
 
 const getItemVars = (item: Item, phase: 'req' | 'res'): Variable[] =>
   item.type === 'folder'
-    ? get(item?.draft || item?.root, `request.vars.${phase}`, [])
+    ? get(effectiveFolderRoot(item), `request.vars.${phase}`, [])
     : get(item, item?.draft ? `draft.request.vars.${phase}` : `request.vars.${phase}`, []);
 
 const collectVars = (
@@ -289,7 +298,7 @@ const collectVars = (
 };
 
 const mergeVars = (collection: Collection, request: Request, requestTreePath: Item[] = []): void => {
-  const collectionRoot = collection?.draft?.root || collection?.root || {};
+  const collectionRoot = effectiveCollectionRoot(collection);
   const collectionVariables: Record<string, VariableValue> = {};
   const folderVariables: Record<string, VariableValue> = {};
   const requestVariables: Record<string, VariableValue> = {};
@@ -409,7 +418,7 @@ const mergeScripts = (
   requestTreePath: Item[],
   scriptFlow: string
 ): void => {
-  const collectionRoot = collection?.draft?.root || collection?.root || {};
+  const collectionRoot = effectiveCollectionRoot(collection);
   const collectionPreReqScript = get(collectionRoot, 'request.script.req', '');
   const collectionPostResScript = get(collectionRoot, 'request.script.res', '');
   const collectionTests = get(collectionRoot, 'request.tests', '');
@@ -441,7 +450,7 @@ const mergeScripts = (
 
   for (const i of requestTreePath) {
     if (i.type === 'folder') {
-      const folderRoot = i?.draft || i?.root;
+      const folderRoot = effectiveFolderRoot(i);
       const folderFilePath = path.join(i.pathname || '', config.folderFile);
       const folderSource: SegmentSource = {
         type: 'folder',
@@ -934,14 +943,14 @@ const getEnvVars = (environment: Environment | null | undefined = {}): Record<st
 };
 
 const mergeAuth = (collection: Collection, request: Request, requestTreePath: Item[]): void => {
-  const collectionRoot = collection?.draft?.root || collection?.root || {};
+  const collectionRoot = effectiveCollectionRoot(collection);
   const collectionAuth = get(collectionRoot, 'request.auth', { mode: 'none' });
   let effectiveAuth = collectionAuth;
   let lastFolderWithAuth: Item | null = null;
 
   for (const i of requestTreePath) {
     if (i.type === 'folder') {
-      const folderRoot = i?.draft || i?.root;
+      const folderRoot = effectiveFolderRoot(i);
       const folderAuth = get(folderRoot, 'request.auth');
       if (folderAuth && folderAuth.mode && folderAuth.mode !== 'none' && folderAuth.mode !== 'inherit') {
         effectiveAuth = folderAuth;

--- a/src/extension/utils/script-error-context.spec.ts
+++ b/src/extension/utils/script-error-context.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, test, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -6,6 +6,7 @@ import path from 'path';
 vi.mock('vscode', () => ({}));
 
 const { mergeScripts } = await import('./collection');
+const { setUnsavedRoot, clearUnsavedRootForFile } = await import('../store/unsaved-roots');
 const { ScriptRuntime, formatErrorWithContextV2 } = await import('@usebruno/js');
 
 const COLLECTION_SCRIPT = 'const fromCollection = true;';
@@ -196,5 +197,55 @@ describe('an inherited script maps back to the file it was written in', () => {
 
     expect(context?.filePath).toBe('sub/folder.bru');
     expect(context?.errorLine).toBe(2);
+  });
+});
+
+describe('a root left unsaved in another editor is what gets merged', () => {
+  const collectionPath = path.join(os.tmpdir(), 'bruno-unsaved-root');
+  const folderPath = path.join(collectionPath, 'sub');
+  const folderFile = path.join(folderPath, 'folder.bru');
+  const collectionFile = path.join(collectionPath, 'collection.bru');
+  const DRAFT = "throw new Error('from the draft');";
+
+  const collection = { pathname: collectionPath, root: {} };
+  const tree = [
+    { type: 'folder', uid: 'f1', name: 'sub', pathname: folderPath, root: {} },
+    { type: 'http-request', uid: 'r1', name: 'Boom' }
+  ];
+
+  const merge = () => {
+    const request: any = { script: { req: '', res: '' }, tests: '' };
+    mergeScripts(collection as never, request, tree as never, 'sequential');
+    return request;
+  };
+
+  afterEach(() => {
+    clearUnsavedRootForFile(folderFile);
+    clearUnsavedRootForFile(collectionFile);
+  });
+
+  test('runs an unsaved folder script and attributes it to the folder file', () => {
+    setUnsavedRoot('folder', folderFile, { request: { script: { res: DRAFT } } });
+
+    const request = merge();
+
+    expect(request.script.res).toContain(DRAFT);
+    expect(request.script.resMetadata.segments).toMatchObject([{ type: 'folder', displayPath: 'sub/folder.bru' }]);
+  });
+
+  test('runs an unsaved collection script and attributes it to the collection file', () => {
+    setUnsavedRoot('collection', collectionFile, { request: { script: { res: DRAFT } } });
+
+    const request = merge();
+
+    expect(request.script.res).toContain(DRAFT);
+    expect(request.script.resMetadata.segments).toMatchObject([{ type: 'collection', displayPath: 'collection.bru' }]);
+  });
+
+  test('goes back to the saved script once the draft is gone', () => {
+    setUnsavedRoot('folder', folderFile, { request: { script: { res: DRAFT } } });
+    clearUnsavedRootForFile(folderFile);
+
+    expect(merge().script.res).toBe('');
   });
 });

--- a/src/webview/components/CollectionSettings/Script/index.tsx
+++ b/src/webview/components/CollectionSettings/Script/index.tsx
@@ -1,9 +1,12 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import get from 'lodash/get';
+import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateCollectionRequestScript, updateCollectionResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveCollectionSettings } from 'providers/ReduxStore/slices/collections/actions';
+import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
+import useFocusErrorLine from 'hooks/useFocusErrorLine';
 import { useTheme } from 'providers/Theme';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from 'components/Tabs';
 import StyledWrapper from './StyledWrapper';
@@ -18,11 +21,15 @@ const Script = ({
   collection
 }: any) => {
   const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState('pre-request');
   const preRequestEditorRef = useRef(null);
   const postResponseEditorRef = useRef(null);
   const requestScript = collection.draft?.root ? get(collection, 'draft.root.request.script.req', '') : get(collection, 'root.request.script.req', '');
   const responseScript = collection.draft?.root ? get(collection, 'draft.root.request.script.res', '') : get(collection, 'root.request.script.res', '');
+
+  const tabUid = `settings-${collection.uid}`;
+  const scriptPaneTab = useSelector((state: any) => find(state.tabs.tabs, (t: any) => t.uid === tabUid)?.scriptPaneTab);
+  const activeTab = scriptPaneTab || 'pre-request';
+  const setActiveTab = (tab: string) => dispatch(updateScriptPaneTab({ uid: tabUid, scriptPaneTab: tab }));
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state: any) => state.app.preferences);
@@ -39,6 +46,20 @@ const Script = ({
 
     return () => clearTimeout(timer);
   }, [activeTab]);
+
+  useFocusErrorLine({
+    uid: tabUid,
+    editorRef: preRequestEditorRef,
+    scriptPhase: 'pre-request',
+    isVisible: activeTab === 'pre-request'
+  });
+
+  useFocusErrorLine({
+    uid: tabUid,
+    editorRef: postResponseEditorRef,
+    scriptPhase: 'post-response',
+    isVisible: activeTab === 'post-response'
+  });
 
   const onRequestScriptEdit = (value: any) => {
     dispatch(

--- a/src/webview/components/FolderSettings/Script/index.tsx
+++ b/src/webview/components/FolderSettings/Script/index.tsx
@@ -1,9 +1,12 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import get from 'lodash/get';
+import find from 'lodash/find';
 import { useDispatch, useSelector } from 'react-redux';
 import CodeEditor from 'components/CodeEditor';
 import { updateFolderRequestScript, updateFolderResponseScript } from 'providers/ReduxStore/slices/collections';
 import { saveFolderRoot } from 'providers/ReduxStore/slices/collections/actions';
+import { updateScriptPaneTab } from 'providers/ReduxStore/slices/tabs';
+import useFocusErrorLine from 'hooks/useFocusErrorLine';
 import { useTheme } from 'providers/Theme';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from 'components/Tabs';
 import StyledWrapper from './StyledWrapper';
@@ -20,11 +23,14 @@ const Script = ({
   folder
 }: any) => {
   const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState('pre-request');
   const preRequestEditorRef = useRef(null);
   const postResponseEditorRef = useRef(null);
   const requestScript = folder.draft ? get(folder, 'draft.root.request.script.req', '') : get(folder, 'root.request.script.req', '');
   const responseScript = folder.draft ? get(folder, 'draft.root.request.script.res', '') : get(folder, 'root.request.script.res', '');
+
+  const scriptPaneTab = useSelector((state: any) => find(state.tabs.tabs, (t: any) => t.uid === folder.uid)?.scriptPaneTab);
+  const activeTab = scriptPaneTab || 'pre-request';
+  const setActiveTab = (tab: string) => dispatch(updateScriptPaneTab({ uid: folder.uid, scriptPaneTab: tab }));
 
   const { displayedTheme } = useTheme();
   const preferences = useSelector((state: any) => state.app.preferences);
@@ -41,6 +47,20 @@ const Script = ({
 
     return () => clearTimeout(timer);
   }, [activeTab]);
+
+  useFocusErrorLine({
+    uid: folder.uid,
+    editorRef: preRequestEditorRef,
+    scriptPhase: 'pre-request',
+    isVisible: activeTab === 'pre-request'
+  });
+
+  useFocusErrorLine({
+    uid: folder.uid,
+    editorRef: postResponseEditorRef,
+    scriptPhase: 'post-response',
+    isVisible: activeTab === 'post-response'
+  });
 
   const onRequestScriptEdit = (value: any) => {
     dispatch(
@@ -78,7 +98,7 @@ const Script = ({
           <TabsTrigger value="post-response">Post Response</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="pre-request" className="mt-2">
+        <TabsContent value="pre-request" className="mt-2" dataTestId="folder-pre-request-script-editor">
           <CodeEditor
             ref={preRequestEditorRef}
             collection={collection}
@@ -93,7 +113,7 @@ const Script = ({
           />
         </TabsContent>
 
-        <TabsContent value="post-response" className="mt-2">
+        <TabsContent value="post-response" className="mt-2" dataTestId="folder-post-response-script-editor">
           <CodeEditor
             ref={postResponseEditorRef}
             collection={collection}

--- a/src/webview/components/ResponsePane/ScriptError/index.tsx
+++ b/src/webview/components/ResponsePane/ScriptError/index.tsx
@@ -6,7 +6,8 @@ import { SCRIPT_ERROR_PHASES, getScriptError } from '@bruno-types';
 import ErrorBanner from 'ui/ErrorBanner';
 import CodeSnippet from 'ui/CodeSnippet';
 import { getTreePathFromCollectionToItem } from 'utils/collections';
-import { normalizePath } from 'utils/common/path';
+import { normalizePath, getAbsoluteFilePath } from 'utils/common/path';
+import { ipcRenderer } from 'utils/ipc';
 import { updateRequestPaneTab, updateScriptPaneTab, setFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
 import { isTabForItemPresent } from 'selectors/tab';
 import StyledWrapper from './StyledWrapper';
@@ -82,13 +83,30 @@ const ScriptErrorCard = ({ title, message, errorContext, scriptPhase, item, coll
   const errorLine = errorContext.errorLine;
 
   const hasRequestTab =useSelector(isTabForItemPresent({ itemUid: item?.uid as string }));
-  const canNavigate = source?.sourceType === 'request'
-    && typeof errorLine === 'number'
-    && SCRIPTABLE_REQUEST_TYPES.includes(item?.type as string)
-    && hasRequestTab;
+  const collectionPathname = normalizePath(collection?.pathname as string);
+  const isInheritedSource = source?.sourceType === 'folder' || source?.sourceType === 'collection';
+  const canNavigate = isInheritedSource
+    ? !!collectionPathname
+    : source?.sourceType === 'request'
+      && typeof errorLine === 'number'
+      && SCRIPTABLE_REQUEST_TYPES.includes(item?.type as string)
+      && hasRequestTab;
+
+  const revealInheritedSource = () => {
+    ipcRenderer.invoke('renderer:reveal-script-error-source', {
+      filePath: getAbsoluteFilePath(collectionPathname, filePath!),
+      scriptPhase,
+      line: typeof errorLine === 'number' ? errorLine : undefined
+    });
+  };
 
   const navigateToErrorLine = () => {
     if (!canNavigate) return;
+
+    if (isInheritedSource) {
+      revealInheritedSource();
+      return;
+    }
 
     const uid = item!.uid as string;
     if (scriptPhase === 'test') {
@@ -128,7 +146,9 @@ const ScriptErrorCard = ({ title, message, errorContext, scriptPhase, item, coll
             tabIndex={canNavigate ? 0 : undefined}
             onClick={navigateToErrorLine}
             onKeyDown={onFilePathKeyDown}
-            title={canNavigate ? `Go to line ${errorLine} in ${filePath}` : undefined}
+            title={canNavigate
+              ? (isInheritedSource ? `Open ${filePath}` : `Go to line ${errorLine} in ${filePath}`)
+              : undefined}
           >
             <span>{filePath}</span>
             {canNavigate && <IconExternalLink size={12} className="flex-shrink-0" />}

--- a/src/webview/pages/Bruno/index.tsx
+++ b/src/webview/pages/Bruno/index.tsx
@@ -10,7 +10,8 @@ import useWsEventListeners from 'utils/network/ws-event-listeners';
 
 import { ViewContainer, ViewData } from 'views';
 
-import { addTab } from 'providers/ReduxStore/slices/tabs';
+import { addTab, updateScriptPaneTab, setFocusErrorLine } from 'providers/ReduxStore/slices/tabs';
+import { updateSettingsSelectedTab, updatedFolderSettingsSelectedTab } from 'providers/ReduxStore/slices/collections';
 import {
   saveRequest,
   saveFolderRoot,
@@ -67,8 +68,9 @@ export default function Main(): React.ReactElement {
       }));
     } else if (viewData.viewType === 'collection-settings' && viewData.collectionUid) {
       // Collection settings uses a unique ID to allow opening alongside runner
+      const tabUid = `settings-${viewData.collectionUid}`;
       dispatch(addTab({
-        uid: `settings-${viewData.collectionUid}`,
+        uid: tabUid,
         collectionUid: viewData.collectionUid,
         type: 'collection-settings',
         preview: false
@@ -103,6 +105,36 @@ export default function Main(): React.ReactElement {
       }));
     }
   }, [viewData, dispatch, collections]);
+
+  useEffect(() => {
+    const focus = viewData.focusScriptError;
+    if (!focus) return;
+
+    const { scriptPhase, line } = focus;
+    const focusTab = (uid: string) => {
+      if (scriptPhase !== 'test') {
+        dispatch(updateScriptPaneTab({ uid, scriptPaneTab: scriptPhase }));
+      }
+      if (typeof line === 'number') {
+        dispatch(setFocusErrorLine({ uid, scriptPhase, line, requestedAt: Date.now() }));
+      }
+    };
+
+    if (viewData.viewType === 'collection-settings' && viewData.collectionUid) {
+      dispatch(updateSettingsSelectedTab({
+        collectionUid: viewData.collectionUid,
+        tab: scriptPhase === 'test' ? 'tests' : 'script'
+      }));
+      focusTab(`settings-${viewData.collectionUid}`);
+    } else if (viewData.viewType === 'folder-settings' && viewData.folderUid) {
+      dispatch(updatedFolderSettingsSelectedTab({
+        collectionUid: viewData.collectionUid,
+        folderUid: viewData.folderUid,
+        tab: scriptPhase === 'test' ? 'test' : 'script'
+      }));
+      focusTab(viewData.folderUid);
+    }
+  }, [viewData, dispatch]);
 
   useEffect(() => {
     if (mainSectionRef.current) {

--- a/src/webview/providers/ReduxStore/middlewares/vscode-dirty-state/middleware.ts
+++ b/src/webview/providers/ReduxStore/middlewares/vscode-dirty-state/middleware.ts
@@ -104,7 +104,8 @@ const notifyDirtyState = async (
   itemUid: string,
   collectionUid: string,
   itemType: 'request' | 'folder' | 'collection',
-  isDirty: boolean
+  isDirty: boolean,
+  root?: unknown
 ) => {
   console.log('[VSCodeDirtyState] Notifying dirty state:', {
     filePath,
@@ -117,7 +118,8 @@ const notifyDirtyState = async (
       itemUid,
       collectionUid,
       itemType,
-      isDirty
+      isDirty,
+      root
     });
     console.log('[VSCodeDirtyState] Notification result:', result);
   } catch (error) {
@@ -192,7 +194,7 @@ export const vscodeDirtyStateMiddleware = ({
         if (folder) {
           const filePath = getFolderFilePath(folder, collection);
           if (filePath) {
-            notifyDirtyState(filePath, folderUid, collectionUid, 'folder', true);
+            notifyDirtyState(filePath, folderUid, collectionUid, 'folder', true, folder.draft?.root);
           }
         }
       }
@@ -201,7 +203,7 @@ export const vscodeDirtyStateMiddleware = ({
       if (collection) {
         const filePath = getCollectionFilePath(collection);
         if (filePath) {
-          notifyDirtyState(filePath, collectionUid, collectionUid, 'collection', true);
+          notifyDirtyState(filePath, collectionUid, collectionUid, 'collection', true, collection.draft?.root);
         }
       }
     } else {

--- a/src/webview/utils/codemirror/focusErrorLine.ts
+++ b/src/webview/utils/codemirror/focusErrorLine.ts
@@ -23,19 +23,21 @@ export const focusErrorLine = (editor: any, line1Based: number): (() => void) =>
   }
 
   let disposed = false;
+  let timer: ReturnType<typeof setTimeout>;
+
   const dispose = () => {
     if (disposed) return;
     disposed = true;
+    clearTimeout(timer);
     try {
+      editor.off('change', dispose);
       editor.removeLineClass(line, LINE_CLASS_TARGET, LINE_CLASS_NAME);
       editor.removeLineClass(line, GUTTER_CLASS_TARGET, GUTTER_CLASS_NAME);
     } catch {}
   };
 
-  const timer = setTimeout(dispose, FLASH_DURATION_MS);
+  timer = setTimeout(dispose, FLASH_DURATION_MS);
+  editor.on('change', dispose);
 
-  return () => {
-    clearTimeout(timer);
-    dispose();
-  };
+  return dispose;
 };

--- a/src/webview/views/types.ts
+++ b/src/webview/views/types.ts
@@ -44,6 +44,7 @@ export interface ViewData {
   folderUid?: string;
   collectionPath?: string;
   itemPath?: string;
+  focusScriptError?: { scriptPhase: string; line?: number };
 }
 
 /**

--- a/tests/e2e/specs/script-error.spec.ts
+++ b/tests/e2e/specs/script-error.spec.ts
@@ -1,9 +1,32 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import type { Page, Frame } from '@playwright/test';
 import { test, expect } from '../utils/fixtures';
-import { openBrunoSidebar, createCollection, openRequest, sendRequest, findCollectionDir } from '../utils/page/actions';
+import {
+  openBrunoSidebar,
+  createCollection,
+  createFolder,
+  openRequest,
+  sendRequest,
+  findCollectionDir,
+  setCodeMirrorValue
+} from '../utils/page/actions';
 
 const TEST_SERVER = 'http://127.0.0.1:8081';
+
+async function frameWith(page: Page, marker: string, timeout = 15_000): Promise<Frame> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      if (frame === page.mainFrame()) continue;
+      try {
+        if ((await frame.locator(marker).count()) > 0) return frame;
+      } catch {}
+    }
+    await page.waitForTimeout(400);
+  }
+  throw new Error(`No webview frame with ${marker} within ${timeout}ms`);
+}
 
 // `bru.setEnvVar` rejects names with spaces, so the failure comes from the sandbox itself.
 const FAILING_REQUEST_BRU = [
@@ -231,6 +254,95 @@ test.describe('Script errors in the response pane', () => {
     await editor.locator('[data-testid="script-error-icon"]').first().click();
     await expect(card).toBeVisible();
     await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
+  });
+
+  test('a folder script that was never saved reports its error and opens on click', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Unsaved Folder Script';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+    await createFolder(sidebar, collectionName, 'sub');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'sub', 'Boom.bru'), [
+      'meta {', '  name: Boom', '  type: http', '  seq: 1', '}', '',
+      'get {', `  url: ${TEST_SERVER}/capture`, '  body: none', '  auth: inherit', '}', ''
+    ].join('\n'), 'utf8');
+
+    await sidebar.locator('[data-testid="sidebar-collection-item-row"]').filter({ hasText: 'sub' }).click();
+
+    const settings = await frameWith(page, '[data-testid="folder-settings"]');
+    await settings.locator('[role="tab"]').filter({ hasText: 'Script' }).first().click();
+    await settings.locator('.tab-trigger').filter({ hasText: 'Post Response' }).first().click();
+
+    const folderScript = settings.locator('[data-testid="folder-post-response-script-editor"]');
+    await expect(folderScript.locator('.CodeMirror')).toBeVisible({ timeout: 15_000 });
+    await setCodeMirrorValue(page, folderScript.locator('.CodeMirror'), "throw new Error('boom from the folder draft');");
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Boom');
+    await sendRequest(editor, 200);
+
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Post-Response Script Error');
+    await expect(card.locator('[data-testid="script-error-source-label"]')).toContainText('Folder');
+    await expect(card.locator('[data-testid="script-error-file-path"]')).toHaveText('sub/folder.bru');
+    await expect(card.locator('[data-testid="code-line-error"]')).toContainText('boom from the folder draft');
+
+    await card.locator('[data-testid="script-error-file-path"]').click();
+    await expect(folderScript).toBeVisible({ timeout: 15_000 });
+    await expect(folderScript.locator('.cm-error-line-flash')).toHaveCount(1);
+  });
+
+  test('following a folder error does not lock the editor to the errored script', async ({ page, tmpDir }) => {
+    const sidebar = await openBrunoSidebar(page);
+    const collectionName = 'Folder Error Editing';
+
+    await createCollection(page, sidebar, collectionName, tmpDir, 'bru');
+    await createFolder(sidebar, collectionName, 'sub');
+
+    const collectionDir = findCollectionDir(tmpDir);
+    fs.writeFileSync(path.join(collectionDir, 'sub', 'folder.bru'), [
+      'meta {', '  name: sub', '}', '',
+      'script:pre-request {',
+      "  throw new Error('boom before the request');",
+      '}',
+      ''
+    ].join('\n'), 'utf8');
+    fs.writeFileSync(path.join(collectionDir, 'sub', 'Boom.bru'), [
+      'meta {', '  name: Boom', '  type: http', '  seq: 1', '}', '',
+      'get {', `  url: ${TEST_SERVER}/capture`, '  body: none', '  auth: inherit', '}', ''
+    ].join('\n'), 'utf8');
+
+    await sidebar.locator('[data-testid="sidebar-collection-item-row"]').filter({ hasText: 'sub' })
+      .locator('[data-testid="folder-chevron"]').click();
+
+    const editor = await openRequest(page, sidebar, collectionName, 'Boom');
+    await sendRequest(editor);
+
+    const card = editor.locator('[data-testid="script-error-card"]').first();
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-testid="script-error-title"]')).toHaveText('Pre-Request Script Error');
+    await card.locator('[data-testid="script-error-file-path"]').click();
+
+    const settings = await frameWith(page, '[data-testid="folder-settings"]');
+    const preRequest = settings.locator('[data-testid="folder-pre-request-script-editor"]');
+    await expect(preRequest).toBeVisible({ timeout: 15_000 });
+    await expect(preRequest.locator('.cm-error-line-flash')).toHaveCount(1);
+
+    await setCodeMirrorValue(page, preRequest.locator('.CodeMirror'), "throw new Error('edited');");
+    await expect(preRequest.locator('.cm-error-line-flash')).toHaveCount(0);
+
+    await settings.locator('.tab-trigger').filter({ hasText: 'Post Response' }).first().click();
+    const postResponse = settings.locator('[data-testid="folder-post-response-script-editor"]');
+    await expect(postResponse).toBeVisible();
+
+    await setCodeMirrorValue(page, postResponse.locator('.CodeMirror'), 'const edited = 1;');
+
+    await expect(postResponse).toBeVisible();
+    await expect(preRequest).toBeHidden();
+    await expect(postResponse).toContainText('const edited = 1;');
+    await expect(postResponse.locator('.cm-error-line-flash')).toHaveCount(0);
   });
 
   test('a failing pre-request script wins over an empty url', async ({ page, tmpDir }) => {


### PR DESCRIPTION
## Description

Jira: VSCODE-132

When the script error occurs on the response and upon clicking on the error, it should navigate to the error where the script is being failed.

## Root cause

Folder and collection settings open in their own editor tab and unsaved edits never left it, so a request sent from another tab only ever saw what was on disk. The card had no way to reach another tab either.

## Solution

Unsaved folder and collection settings are now shared with the part of the extension that runs a request so an unsaved script is the one that runs and the one that gets reported. Clicking the file name opens that folder or collection settings tab, on the Script or Tests section, and highlights the failing line.
