### PR TITLE
fix(request-url): Send button is visible on entering lengthy URL

### DIFF
--- a/src/webview/components/RequestPane/GrpcQueryUrl/index.tsx
+++ b/src/webview/components/RequestPane/GrpcQueryUrl/index.tsx
@@ -315,7 +315,7 @@ const GrpcQueryUrl = ({
           <span className="text-xs font-medium" style={{ color: theme.request.grpc }}>gRPC</span>
         </div>
       </div>
-      <div className="flex items-center w-full input-container h-full relative">
+      <div className="flex items-center w-full min-w-0 input-container h-full relative">
         <SingleLineEditor
           ref={editorRef}
           value={url}

--- a/src/webview/components/RequestPane/QueryUrl/index.tsx
+++ b/src/webview/components/RequestPane/QueryUrl/index.tsx
@@ -361,7 +361,7 @@ const QueryUrl = ({
       </div>
       <div
         id="request-url"
-        className="h-full w-full flex flex-row input-container"
+        className="h-full w-full min-w-0 flex flex-row input-container"
       >
         <SingleLineEditor
           ref={editorRef}

--- a/src/webview/components/RequestPane/WsQueryUrl/index.tsx
+++ b/src/webview/components/RequestPane/WsQueryUrl/index.tsx
@@ -133,7 +133,7 @@ const WsQueryUrl = ({
   return (
     <StyledWrapper>
       <div className="flex items-center h-full">
-        <div className="flex items-center input-container flex-1 w-full input-container pr-2 h-full relative">
+        <div className="flex items-center input-container flex-1 w-full min-w-0 pr-2 h-full relative">
           <div className="flex items-center justify-center px-[10px]">
             <span className="text-xs font-medium method-ws">WS</span>
           </div>


### PR DESCRIPTION
### Description
Jira: VSCODE-167
### Problem
Send button is not visible when too lengthy URL is entered in request URL bar.
### Fix
When lengthy URL is entered in request URL, the editor shrinks to the available space and URL scrolls inside the input.
### Screenshot
**Before**
<img width="678" height="495" alt="Screenshot 2026-09-08 at 1 28 33 PM" src="https://github.com/user-attachments/assets/4b15ccdc-22c5-4b39-a77a-332deedee2bf" />

**After**
<img width="677" height="507" alt="Screenshot 2026-09-08 at 1 26 20 PM" src="https://github.com/user-attachments/assets/346ee4c9-d725-4e60-a35e-85515d73cc4b" />
