### PR TITLE
fix(tests): set VSCODE version and update locator

### DIFF
--- a/tests/e2e/utils/fixtures/index.ts
+++ b/tests/e2e/utils/fixtures/index.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 
 // This file lives at tests/e2e/utils/fixtures/, so climb four levels to the repo root.
 const EXTENSION_ROOT = path.resolve(__dirname, '../../../..');
+const VSCODE_VERSION = '1.136.2';
 
 export interface VSCodeFixture {
   /** The VS Code workbench page — use this to interact with the UI */
@@ -76,8 +77,8 @@ async function resolveExecutable(): Promise<string> {
     console.log(`[e2e] Using custom VS Code: ${process.env.VSCODE_PATH}`);
     return process.env.VSCODE_PATH;
   }
-  console.log('[e2e] Downloading stable VS Code…');
-  const exe = await downloadAndUnzipVSCode('stable');
+  console.log(`[e2e] Downloading VS Code ${VSCODE_VERSION}…`);
+  const exe = await downloadAndUnzipVSCode(VSCODE_VERSION);
   const resolved = fs.existsSync(exe) ? exe : resolveRenamedBinary(exe);
   if (!fs.existsSync(resolved)) {
     throw new Error(`VS Code executable not found (tried ${exe} and ${resolved})`);

--- a/tests/e2e/utils/page/actions.ts
+++ b/tests/e2e/utils/page/actions.ts
@@ -490,7 +490,7 @@ export async function addRequestVar(
 ): Promise<void> {
   await openRequestTab(editor, 'vars', 'Vars');
 
-  const rows = buildCommonLocators(editor).editableTable.firstTableRows();
+  const rows = buildCommonLocators(editor).varsTable.rows('request', 'req');
   await expect(rows.first()).toBeVisible({ timeout: 10_000 });
   const emptyRowIdx = (await rows.count()) - 1;
   const row = buildCommonLocators(rows.nth(emptyRowIdx)).editableTable;

--- a/tests/e2e/utils/page/locators.ts
+++ b/tests/e2e/utils/page/locators.ts
@@ -62,7 +62,7 @@ export const buildCommonLocators = (frame: FrameLike) => ({
   workbench: {
     editorTab: (title: string) => frame.locator('.tabs-container .tab').filter({ hasText: title }),
     editorTabClose: (title: string) =>
-      frame.locator('.tabs-container .tab').filter({ hasText: title }).locator('.action-label.codicon-close')
+      frame.locator('.tabs-container .tab').filter({ hasText: title }).locator('.tab-actions .action-label')
   },
   // New Request panel form.
   newRequest: {
@@ -88,6 +88,10 @@ export const buildCommonLocators = (frame: FrameLike) => ({
     columnNameInput: () => frame.getByTestId('column-name').locator('input'),
     columnValueEditor: () => frame.getByTestId('column-value').locator('.CodeMirror'),
     columnCheckbox: () => frame.getByTestId('column-checkbox')
+  },
+  varsTable: {
+    rows: (scope: 'request' | 'collection' | 'folder', kind: 'req' | 'res' = 'req') =>
+      frame.getByTestId(`${scope}-vars-${kind}`).locator('tbody tr')
   },
   auth: {
     modeSelector: () => frame.locator('.auth-mode-selector'),


### PR DESCRIPTION
### Description
Ensure all the test cases are passing
### Problem
Some of the test cases are failing
### Fix
1. Added VS Code version. Every test case uses the same VS Code version instead of using latest version whenever new version is released. This ensures the VSCODE specific locators used in tests doesn't get outdated.
2. Updated locator for vars Table 