### PR TITLE
fix: allow single file selection in client certificate file picker

### DIFF
--- a/src/extension/ipc/filesystem.ts
+++ b/src/extension/ipc/filesystem.ts
@@ -27,9 +27,9 @@ const registerFilesystemIpc = (): void => {
   });
 
   registerHandler('renderer:browse-files', async (args) => {
-    const [filters] = args as [FileFilter[]?];
+    const [filters, properties] = args as [FileFilter[]?, string[]?];
     try {
-      const result = await browseFiles(filters);
+      const result = await browseFiles(filters, properties);
       return result;
     } catch (error) {
       throw error;

--- a/src/extension/utils/filesystem.ts
+++ b/src/extension/utils/filesystem.ts
@@ -172,7 +172,10 @@ export const browseDirectory = async (): Promise<string | false> => {
   return isDirectory(resolvedPath) ? resolvedPath : false;
 };
 
-export const browseFiles = async (filters?: { name: string; extensions: string[] }[]): Promise<string[]> => {
+export const browseFiles = async (
+  filters?: { name: string; extensions: string[] }[],
+  properties?: string[]
+): Promise<string[]> => {
   const vscodeFilters: { [key: string]: string[] } = {};
   if (filters) {
     for (const filter of filters) {
@@ -183,7 +186,7 @@ export const browseFiles = async (filters?: { name: string; extensions: string[]
   const uris = await vscode.window.showOpenDialog({
     canSelectFiles: true,
     canSelectFolders: false,
-    canSelectMany: true,
+    canSelectMany: properties?.includes('multiSelections') ?? false,
     filters: vscodeFilters
   });
 

--- a/src/webview/components/CollectionSettings/ClientCertSettings/index.tsx
+++ b/src/webview/components/CollectionSettings/ClientCertSettings/index.tsx
@@ -110,7 +110,7 @@ const ClientCertSettings = ({
 
     const fieldName = e.currentTarget.name;
 
-    const filePaths = (await (dispatch as any)(browseFiles(CERT_FILE_FILTERS, ['']))) as string[];
+    const filePaths = (await (dispatch as any)(browseFiles(CERT_FILE_FILTERS, []))) as string[];
     const filePath = filePaths?.[0];
     if (!filePath) return;
 

--- a/src/webview/components/FilePickerEditor/index.tsx
+++ b/src/webview/components/FilePickerEditor/index.tsx
@@ -59,7 +59,7 @@ const FilePickerEditor = ({
   const browse = () => {
     if (readOnly) return;
 
-    (dispatch(browseFiles([], [!isSingleFilePicker ? 'multiSelections' : ''])) as unknown as Promise<string[]>)
+    (dispatch(browseFiles([], isSingleFilePicker ? [] : ['multiSelections'])) as unknown as Promise<string[]>)
       .then((filePaths: any) => {
         // If file is in the collection's directory, then we use relative path
         // Otherwise, we use the absolute path

--- a/src/webview/components/RequestPane/MultipartFormParams/index.tsx
+++ b/src/webview/components/RequestPane/MultipartFormParams/index.tsx
@@ -52,7 +52,7 @@ const MultipartFormParams = ({
   }, [dispatch, collection.uid, item.uid]);
 
   const handleBrowseFiles = useCallback((row: any, onChange: any) => {
-    (dispatch(browseFiles([], [])) as unknown as Promise<string[]>)
+    (dispatch(browseFiles([], ['multiSelections'])) as unknown as Promise<string[]>)
       .then((filePaths: string[]) => {
         const processedPaths = filePaths.map((filePath: any) => {
           const collectionDir = collection.pathname;

--- a/src/webview/hooks/useProtoFileManagement/index.ts
+++ b/src/webview/hooks/useProtoFileManagement/index.ts
@@ -339,7 +339,7 @@ export default function useProtoFileManagement(collection: AppCollection): UsePr
     const filters = [{ name: 'Proto Files', extensions: ['proto'] }];
 
     try {
-      const filePaths = await dispatch(browseFiles(filters, [''])) as string[];
+      const filePaths = await dispatch(browseFiles(filters, [])) as string[];
       if (filePaths && filePaths.length > 0) {
         return { success: true, filePath: filePaths[0] };
       }


### PR DESCRIPTION
### Problem
When selecting client certificate through file picker, it was allowing to select multiple files. 
### Fix
Updated the browseFiles to allow select single file at a time.